### PR TITLE
Skip analysis of already analyzed items when normalizing.

### DIFF
--- a/Breeder/BR_Loudness.cpp
+++ b/Breeder/BR_Loudness.cpp
@@ -219,7 +219,7 @@ BR_LoudnessObject::~BR_LoudnessObject ()
 		DestroyAudioAccessor(this->GetAudioData().audio);
 }
 
-bool BR_LoudnessObject::Analyze (bool integratedOnly /*=false*/, bool doTruePeak /*=true*/)
+bool BR_LoudnessObject::Analyze (bool integratedOnly, bool doTruePeak)
 {
 	this->AbortAnalyze();
 	this->SetIntegratedOnly(integratedOnly);
@@ -1768,7 +1768,7 @@ static WDL_DLGRET NormalizeProgressProc (HWND hwnd, UINT uMsg, WPARAM wParam, LP
 				if (s_currentItem = s_normalizeData->items->Get(s_currentItemId))
 				{
 					s_currentItemLen = s_currentItem->GetAudioLength();
-					s_currentItem->Analyze(s_normalizeData->quickMode);
+					s_currentItem->Analyze(s_normalizeData->quickMode, false);
 					s_analyzeInProgress = true;
 				}
 				else

--- a/Breeder/BR_Loudness.h
+++ b/Breeder/BR_Loudness.h
@@ -39,7 +39,7 @@ public:
 	~BR_LoudnessObject ();
 
 	/* Analyze */
-	bool Analyze (bool integratedOnly = false, bool doTruePeak = true);
+	bool Analyze (bool integratedOnly, bool doTruePeak);
 	void AbortAnalyze ();
 	bool IsRunning ();
 	double GetProgress ();


### PR DESCRIPTION
Skip analysis of already analyzed items when normalizing from loudness dialog (broke it in d6c63aeaec1a552911af19dbadd19710770859ee)
