### PR TITLE
Fix TCP handle lookup from the master track (#837)

### DIFF
--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -2859,7 +2859,6 @@ HWND GetTcpWnd ()
 		int masterVis = 0;
 		if (!track && !IsMasterVisible)
 		{
-			PreventUIRefresh(1);
 			masterVis = SetMasterTrackVisibility(GetMasterTrackVisibility() | 1);
 		}
 
@@ -2889,7 +2888,6 @@ HWND GetTcpWnd ()
 		// Restore TCP master to previous state
 		if (!track && !IsMasterVisible)
 		{
-			PreventUIRefresh(-1);
 			SetMasterTrackVisibility(masterVis);
 		}
 	}


### PR DESCRIPTION
This got broken since REAPER v5.15. Assuming the new REAPER behavior is right, this PR removes the use of PreventUIRefresh before enabling the master track in the TCP.

A new `GetTCPHwnd` API function would probably be better than this hack to find the TCP.

http://forum.cockos.com/showthread.php?t=187580