### PR TITLE
Feature/implement #514 toggle triplet and dotted grid in midi editor

### DIFF
--- a/Misc/Analysis.cpp
+++ b/Misc/Analysis.cpp
@@ -240,20 +240,11 @@ double GetMediaItemMaxPeak(MediaItem* mi)
 	double curPeak = -150.0;
 	double maxPeak = -150.0;
 	
-	/*
-	I'd like to avoid unnecessary scanning of MIDI items 
-	(maybe good idea for DoAnalyzeItem() also ?), 
-	found schwa's post below, but doesn't work, hm, why ?
-	http://forum.cockos.com/showpost.php?p=702992&postcount=4
-	*/
-	/*
-	PCM_source* src = (PCM_source*)mi;
-	bool isMIDI = (src && !strncmp(src->GetType(), "MIDI", 4));
-	if (isMIDI) return -150.0;
-	*/
+	// if MIDI item, don't scan
+	int sampleRate = ((PCM_source*)mi)->GetSampleRate(); // will rtn. 0 for MIDI items
+	if (sampleRate == 0) return -150.0;
 
 	int iChannels = ((PCM_source*)mi)->GetNumChannels();
-
 	if (iChannels)
 	{
 		ANALYZE_PCM a;
@@ -282,13 +273,10 @@ double GetMediaItemAverageRMS(MediaItem* mi)
 	double curAvrgRMS = -150.0;
 	double maxAvrgRMS = -150.0;
 
-	// see comment in GetMediaItemMaxPeak()
-	/*
-	PCM_source* src = (PCM_source*)mi;
-	bool isMIDI = (src && !strncmp(src->GetType(), "MIDI", 4));
-	if (isMIDI) return -150.0;
-	*/
-
+	// if MIDI item, don't scan
+	int sampleRate = ((PCM_source*)mi)->GetSampleRate(); // will rtn. 0 for MIDI items
+	if (sampleRate == 0) return -150.0;
+	
 	int iChannels = ((PCM_source*)mi)->GetNumChannels();
 	if (iChannels)
 	{

--- a/nofish/nofish.cpp
+++ b/nofish/nofish.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-/ nofish.h
+/ nofish.cpp
 /
 / Copyright (c) 2016 nofish
 / http://forum.cockos.com/member.php?u=6870
@@ -31,24 +31,16 @@
 #include "nofish.h"
 
 
-void BypassFXexceptVSTiForSelTracks(COMMAND_T* ct);
+//////////////////////////////////////////////////////////////////
+// Bypass FX (except VSTi) for selected tracks					//
+// conversion of spk77's EEL script								//
+// http://forum.cockos.com/showpost.php?p=1475585&postcount=6	//
+//////////////////////////////////////////////////////////////////
 
-static COMMAND_T g_commandTable[] =
-{
-	//!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
-
-	//////////////////////////////////////////////////////////////////
-	// Bypass FX (except VSTi) for selected tracks					//
-	// conversion of spk77's EEL script								//
-	// http://forum.cockos.com/showpost.php?p=1475585&postcount=6	//
-	//////////////////////////////////////////////////////////////////
-	{ { DEFACCEL, "SWS/NF: Bypass FX (except VSTi) for selected tracks" }, "NF_BYPASS_FX_EXCEPT_VSTI_FOR_SEL_TRACKS", BypassFXexceptVSTiForSelTracks, NULL },
-
-	//!WANT_LOCALIZE_1ST_STRING_END
-
-	{ {}, LAST_COMMAND, },
-};
-
+/*
+remark for SWS: I've just seen now the comment to not use these O(n) actions in loops, sorry
+won't do again
+*/
 void BypassFXexceptVSTiForSelTracks(COMMAND_T* ct)
 {
 	Undo_BeginBlock();
@@ -63,8 +55,162 @@ void BypassFXexceptVSTiForSelTracks(COMMAND_T* ct)
 			}
 		}
 	}
+	// a1cab2f6: also check master track
+	MediaTrack* mtrack = GetMasterTrack(0);
+	if (mtrack) 
+	{
+		if (GetMediaTrackInfo_Value(mtrack, "I_SELECTED") != 0) {
+			int vsti_index = TrackFX_GetInstrument(mtrack); // Get position of first VSTi on current track
+			for (int j = 0; j < TrackFX_GetCount(mtrack); j++) { // loop through FX on current track
+				if (j != vsti_index) { // if current FX is not a VSTi...
+					TrackFX_SetEnabled(mtrack, j, 0); // ...bypass current FX
+				}
+			}
+		}
+	}
+	
+
 	Undo_EndBlock(SWS_CMD_SHORTNAME(ct), 0);
 }
+
+
+//////////////////////////////////////////////////////////////////
+// 																//
+// 	#514 Toggle triplet and dotted grid in MIDI editor			//
+// 																//
+//////////////////////////////////////////////////////////////////
+
+const int ME_SECTION = 32060;
+
+int Main_IsMIDIGridTriplet(COMMAND_T* = NULL)
+{
+	int toggleState = GetToggleCommandStateEx(ME_SECTION, 41004); // action 41004 = Grid: Set grid type to triplet;
+	return toggleState;
+}
+
+
+int Main_IsMIDIGridDotted(COMMAND_T* = NULL)
+{
+	int toggleState = GetToggleCommandStateEx(ME_SECTION, 41005); // action 41005 = Grid: Set grid type to dotted;
+	return toggleState;
+}
+
+
+// fwd. decl.
+void Main_NFToggleDottedMIDI(COMMAND_T* = NULL);
+
+
+void Main_NFToggleTripletMIDI(COMMAND_T* = NULL)
+{
+
+	if (Main_IsMIDIGridDotted())
+		Main_NFToggleDottedMIDI();
+
+	if (Main_IsMIDIGridTriplet()) {
+		// set to straight
+		HWND midiEditor;
+		midiEditor = MIDIEditor_GetActive();
+		MIDIEditor_OnCommand(midiEditor, 41003); // null ptr. check is handled by REAPER
+	}
+		
+	else {
+		// set to triplet
+		HWND midiEditor;
+		midiEditor = MIDIEditor_GetActive();
+		MIDIEditor_OnCommand(midiEditor, 41004);
+	}
+		
+	UpdateMIDIGridToolbar();
+}
+	
+
+
+void Main_NFToggleDottedMIDI(COMMAND_T*)
+{
+	if (Main_IsMIDIGridTriplet())
+		Main_NFToggleTripletMIDI();
+
+	if (Main_IsMIDIGridDotted()) {
+		// set to straight
+		HWND midiEditor;
+		midiEditor = MIDIEditor_GetActive();
+		MIDIEditor_OnCommand(midiEditor, 41003);
+	}
+	else {
+		// set to dotted
+		HWND midiEditor;
+		midiEditor = MIDIEditor_GetActive();
+		MIDIEditor_OnCommand(midiEditor, 41005);
+	}
+	
+	UpdateMIDIGridToolbar();
+}
+
+void UpdateMIDIGridToolbar()
+{
+	static int cmds[2] =
+	{
+		NamedCommandLookup("_NF_ME_TOGGLETRIPLET_"),
+		NamedCommandLookup("_NF_ME_TOGGLEDOTTED_"),
+	};
+	for (int i = 0; i < 2; ++i) {
+		// RefreshToolbar(cmds[i]); 
+		RefreshToolbar2(ME_SECTION, cmds[i]); // when registered in ME
+	}
+}
+
+// pass through from ME to Main
+void ME_NFToggleTripletMIDI(COMMAND_T* _ct, int _val, int _valhw, int _relmode, HWND _hwnd) {
+	Main_NFToggleTripletMIDI(_ct);
+}
+
+void ME_NFToggleDottedMIDI(COMMAND_T* _ct, int _val, int _valhw, int _relmode, HWND _hwnd) {
+	Main_NFToggleDottedMIDI(_ct);
+}
+// /514
+
+
+//////////////////////////////////////////////////////////////////
+// 																//
+// Register commands											//
+// 																//
+//////////////////////////////////////////////////////////////////
+
+
+// COMMAND SIGNATURES
+
+/*
+void BypassFXexceptVSTiForSelTracks(COMMAND_T* ct);
+
+#514
+void Main_NFToggleTripletMIDI(COMMAND_T* = NULL)
+void Main_NFToggleDottedMIDI(COMMAND_T*)
+void ME_NFToggleTripletMIDI(COMMAND_T* _ct, int _val, int _valhw, int _relmode, HWND _hwnd)
+ME_NFToggleDottedMIDI(COMMAND_T* _ct, int _val, int _valhw, int _relmode, HWND _hwnd)
+*/
+
+
+static COMMAND_T g_commandTable[] =
+{
+	//!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
+
+	// Bypass FX(except VSTi) for selected tracks
+	{ { DEFACCEL, "SWS/NF: Bypass FX (except VSTi) for selected tracks" }, "NF_BYPASS_FX_EXCEPT_VSTI_FOR_SEL_TRACKS", BypassFXexceptVSTiForSelTracks, NULL },
+
+
+	// #514
+	// don't register in Main
+	// { { DEFACCEL, "SWS/NF: Toggle triplet grid" },	"NF_MAIN_TOGGLETRIPLET_MIDI",   Main_NFToggleTripletMIDI, NULL, 0, Main_IsMIDIGridTriplet },
+	// { { DEFACCEL, "SWS/NF: Toggle dotted grid" },   "NF_MAIN_TOGGLEDOTTED_MIDI",    Main_NFToggleDottedMIDI, NULL, 0, Main_IsMIDIGridDotted },
+
+	{ { DEFACCEL, "SWS/NF: Toggle triplet grid" }, "NF_ME_TOGGLETRIPLET" , NULL, NULL, 0, Main_IsMIDIGridTriplet, ME_SECTION, ME_NFToggleTripletMIDI },
+	{ { DEFACCEL, "SWS/NF: Toggle dotted grid" }, "NF_ME_TOGGLEDOTTED" , NULL, NULL, 0, Main_IsMIDIGridDotted, ME_SECTION, ME_NFToggleDottedMIDI  },
+	
+	//!WANT_LOCALIZE_1ST_STRING_END
+
+	{ {}, LAST_COMMAND, },
+};
+
 
 int nofish_Init()
 {

--- a/nofish/nofish.h
+++ b/nofish/nofish.h
@@ -29,3 +29,6 @@
 #pragma once
 
 int nofish_Init();
+
+// #514
+void UpdateMIDIGridToolbar();

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,9 @@
+Actions
++New actions (MIDI editor) (Issue 514):
+ - SWS/NF: Toggle dotted grid
+ - SWS/NF: Toggle triplet grid
+ (reflect toggle state when used as ME toolbar buttons)
+
 New ReaScript functions (Issue 781)
 +reaper.NF_GetMediaItemMaxPeak()
 +reaper.NF_GetMediaItemAverageRMS()


### PR DESCRIPTION
registers two actions in ME:
- SWS/NF: Toggle dotted grid
- SWS/NF: Toggle triplet grid
(similar to AW's toggle actions for Main)

demo: http://i.imgur.com/TCaKba2.gif

