### PR TITLE
implement #647, #785 global notes - init commit

### DIFF
--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -355,6 +355,8 @@ static COMMAND_T s_cmdTable[] =
 	{ { DEFACCEL, "SWS/S&M: Open/close Notes window" }, "S&M_SHOW_NOTES_VIEW", OpenNotes, NULL, -1, IsNotesDisplayed},
 	{ { DEFACCEL, "SWS/S&M: Open/close Notes window (project notes)" }, "S&M_SHOWNOTESHELP", OpenNotes, NULL, SNM_NOTES_PROJECT, IsNotesDisplayed},
 	{ { DEFACCEL, "SWS/S&M: Open/close Notes window (extra project notes)" }, "S&M_EXTRAPROJECTNOTES", OpenNotes, NULL, SNM_NOTES_PROJECT_EXTRA, IsNotesDisplayed},
+	// #647
+	{ { DEFACCEL, "SWS/S&M: Open/close Notes window (global notes)" }, "S&M_GLOBALNOTES", OpenNotes, NULL, SNM_NOTES_GLOBAL, IsNotesDisplayed },
 	{ { DEFACCEL, "SWS/S&M: Open/close Notes window (item notes)" }, "S&M_ITEMNOTES", OpenNotes, NULL, SNM_NOTES_ITEM, IsNotesDisplayed},
 	{ { DEFACCEL, "SWS/S&M: Open/close Notes window (track notes)" }, "S&M_TRACKNOTES", OpenNotes, NULL, SNM_NOTES_TRACK, IsNotesDisplayed},
 	{ { DEFACCEL, "SWS/S&M: Open/close Notes window (marker names)" }, "S&M_MKR_NAMES", OpenNotes, NULL, SNM_NOTES_MKR_NAME, IsNotesDisplayed},

--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -1500,11 +1500,11 @@ static void SaveExtensionConfig(ProjectStateContext *ctx, bool isUndo, struct pr
 			StringToExtensionConfig(&formatedNotes, ctx);
 	}
 
-	// #647, write to "Global notes.txt" in ResourcePath instead of .rpp
+	// #647, write to "SWS_Global notes.txt" in ResourcePath instead of .rpp
 	if (g_glbNotes.Get()->GetLength())
 	{
 		WDL_FastString filePath; 
-		filePath.SetFormatted(SNM_MAX_PATH, "%s/Global notes.txt", GetResourcePath());
+		filePath.SetFormatted(SNM_MAX_PATH, "%s/SWS_Global notes.txt", GetResourcePath());
 
 		WDL_FileWrite outfile(filePath.Get()); 
 		if (outfile.IsOpen() == true) {
@@ -1610,10 +1610,10 @@ int NotesInit()
 		*defaultHelpFn = '\0';
 	GetPrivateProfileString(NOTES_INI_SEC, "Action_help_file", defaultHelpFn, g_actionHelpFn, sizeof(g_actionHelpFn), g_SNM_IniFn.Get());
 
-	// #647 read global notes from "Global notes.txt" (stored in ResourcePath)
+	// #647 read global notes from "SWS_Global notes.txt" (stored in ResourcePath)
 	if (g_glbNotes.Get()->GetLength() <= 0) {
 		WDL_FastString filePath;
-		filePath.SetFormatted(SNM_MAX_PATH, "%s/Global notes.txt", GetResourcePath());
+		filePath.SetFormatted(SNM_MAX_PATH, "%s/SWS_Global notes.txt", GetResourcePath());
 		WDL_FileRead infile(filePath.Get());
 		
 		if (infile.IsOpen() == true) {

--- a/SnM/SnM_Notes.h
+++ b/SnM/SnM_Notes.h
@@ -41,6 +41,8 @@ enum {
   SNM_NOTES_ITEM,
   SNM_NOTES_PROJECT,
   SNM_NOTES_PROJECT_EXTRA,
+  // #647
+  SNM_NOTES_GLOBAL,
   SNM_NOTES_MKR_NAME,      // these should remain consecutive ---->
   SNM_NOTES_RGN_NAME,
   SNM_NOTES_MKRRGN_NAME,
@@ -119,6 +121,8 @@ public:
 	void SaveCurrentText(int _type, bool _wantUndo = true);
 	void SaveCurrentProjectNotes(bool _wantUndo = true);
 	void SaveCurrentExtraProjectNotes(bool _wantUndo = true);
+	// #647
+	void SaveCurrentGlobalNotes(bool _wantUndo = true);
 	void SaveCurrentItemNotes(bool _wantUndo = true);
 	void SaveCurrentTrackNotes(bool _wantUndo = true);
 	void SaveCurrentMkrRgnNameOrSub(int _type, bool _wantUndo = true);

--- a/stdafx.h
+++ b/stdafx.h
@@ -93,6 +93,7 @@
 #include "WDL/lineparse.h"
 #include "WDL/MersenneTwister.h"
 #include "WDL/fileread.h"
+#include "WDL/filewrite.h" // #647
 
 #ifndef __GNUC__
 #pragma warning(default : 4996)


### PR DESCRIPTION
closes #647, closes #785

Adds a "Global notes" section to the S&M notes window.

http://i.imgur.com/7RySuaB.jpg

Implements #647 (I'm aware this is closed. Maybe there's a good reasons for it. It's a feature I'd find useful myself too though, e.g. when working on an album, so I wanted to have a go at it).

It's somewhat experimental in that I'm not sure it's 100% save what I'm doing there (e.g. using WDL's filewrite). I intentionally store the global notes in a .txt file (rather than .ini) to make it distinct it's not related to a particular project and for easy editing in a text editor.
This approach could of course be changed though.

(I did some initial tests to make sure it doesn't mess with existing notes being done with SWS versions prior to this and it seems fine so far I think).

Tim, would like to hear your thoughts about this.
(I'm not sad if this feature doesn't make it for whatever reason.)

Todo (in case it gets in):
- error handling (make robust)
- clean up comments (remove //#647, I left them in for now to quickly spot my changes)
- update whatsnew

