### PR TITLE
Fix possible overflow in GetClipboard and add GetClipboardBig

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -239,10 +239,13 @@ APIdef g_apidefs[] =
 	{ APIFUNC(NF_AnalyzeTakeLoudness_IntegratedOnly), "bool", "MediaItem_Take*,double*", "take,lufsIntegratedOut", "Does LUFS integrated analysis only. Faster than full loudness analysis (<a href=\"#NF_AnalyzeTakeLoudness\">NF_AnalyzeTakeLoudness</a>) . Use this if only LUFS integrated is required." }, 
 	{ APIFUNC(NF_AnalyzeTakeLoudness), "bool", "MediaItem_Take*,bool,double*,double*,double*,double*,double*,double*", "take,analyzeTruePeak,lufsIntegratedOut,rangeOut, truePeakOut,truePeakPosOut,shortTermMaxOut,momentaryMaxOut", "Full loudness analysis. retval: returns true on successful analysis, false on MIDI take or when analysis failed for some reason. analyzeTruePeak=true: Also do true peak analysis. Returns true peak value and true peak position which can be jumped to with SetEditCurPos(). Considerably slower than without true peak analysis (since it uses oversampling). Note: Short term uses a time window of 3 sec. for calculation. So for items shorter than this shortTermMaxOut can't be calculated. Momentary uses a time window of 0.4 sec. " }, 
 	{ APIFUNC(NF_AnalyzeTakeLoudness2), "bool", "MediaItem_Take*,bool,double*,double*,double*,double*,double*,double*,double*,double*", "take,analyzeTruePeak,lufsIntegratedOut,rangeOut, truePeakOut,truePeakPosOut,shortTermMaxOut,momentaryMaxOut,shortTermMaxPosOut,momentaryMaxPosOut", "Same as <a href=\"#NF_AnalyzeTakeLoudness\">NF_AnalyzeTakeLoudness</a> but additionally returns shortTermMaxPos and momentaryMaxPos which can be jumped to with SetEditCurPos(). Note: shortTermMaxPos and momentaryMaxPos actaully indicate the beginning of time  <i>intervalls</i>, (3 sec. and 0.4 sec. resp.). " },
-	
+
 	{ APIFUNC(SN_FocusMIDIEditor), "void", "", "", "Focuses the active/open MIDI editor.", },
+
 	{ APIFUNC(CF_SetClipboard), "void", "const char*", "str", "Write the given string into the system clipboard.", },
-	{ APIFUNC(CF_GetClipboard), "void", "char*,int", "buf,buf_sz", "Read the contents of the system clipboard.", },
+	{ APIFUNC(CF_GetClipboard), "void", "char*,int", "buf,buf_sz", "Read the contents of the system clipboard (limited to 1023 characters in Lua).", },
+	{ APIFUNC(CF_GetClipboardBig), "const char*", "WDL_FastString*", "output", "Read the contents of the system clipboard. See <a href=\"#SNM_CreateFastString\">SNM_CreateFastString</a> and <a href=\"#SNM_DeleteFastString\">SNM_DeleteFastString</a>.", },
+
 	{ NULL, } // denote end of table
 };
 

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -34,6 +34,8 @@ static const unsigned int FORMAT = CF_UNICODETEXT;
 static const unsigned int FORMAT = CF_TEXT;
 #endif
 
+extern WDL_PtrList_DOD<WDL_FastString> g_script_strs;
+
 void CF_SetClipboard(const char *buf)
 {
 #ifdef _WIN32
@@ -78,4 +80,32 @@ void CF_GetClipboard(char *buf, int bufSize)
   }
 
   CloseClipboard();
+}
+
+const char *CF_GetClipboardBig(WDL_FastString *output)
+{
+  if(g_script_strs.Find(output) == -1)
+    return nullptr;
+
+  OpenClipboard(GetMainHwnd());
+  HANDLE mem = GetClipboardData(FORMAT);
+
+  if(void *data = GlobalLock(mem)) {
+#ifdef _WIN32
+    const int size = WideCharToMultiByte(CP_UTF8, 0,
+      (const wchar_t *)data, -1, nullptr, 0, nullptr, nullptr) - 1;
+
+    output->SetLen(size);
+
+    WideCharToMultiByte(CP_UTF8, 0, (const wchar_t *)data, -1,
+      const_cast<char *>(output->Get()), size, nullptr, nullptr);
+#else
+    output->Set((const char *)data);
+#endif
+    GlobalUnlock(mem);
+  }
+
+  CloseClipboard();
+
+  return output->Get();
 }

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -65,7 +65,12 @@ void CF_GetClipboard(char *buf, int bufSize)
   if(void *data = GlobalLock(mem)) {
 #ifdef _WIN32
     WideCharToMultiByte(CP_UTF8, 0, (const wchar_t *)data, -1,
-      buf, bufSize, nullptr, nullptr);
+      buf, bufSize - 1, nullptr, nullptr);
+
+    // Insert a null terminator if the buffer is too small to hold the entire
+    // clipboard data. WideCharToMultiByte inserts it at the end of the string
+    // by itself when the buffer is big enough.
+    buf[bufSize - 1] = 0;
 #else
     snprintf(buf, bufSize, "%s", (const char *)data);
 #endif

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -29,3 +29,4 @@
 
 void CF_SetClipboard(const char *);
 void CF_GetClipboard(char *buf, int bufSize);
+const char *CF_GetClipboardBig(WDL_FastString *);

--- a/reascript_vararg.h
+++ b/reascript_vararg.h
@@ -584,5 +584,10 @@ static void* __vararg_CF_GetClipboard(void** arglist, int numparms)
   return NULL;
 }
 
+static void* __vararg_CF_GetClipboardBig(void** arglist, int numparms)
+{
+  return (void*)(INT_PTR)CF_GetClipboardBig((WDL_FastString*)arglist[0]);
+}
+
 
 #endif


### PR DESCRIPTION
I kept the original (but limited in length) GetClipboard for compatibility and convenience, but I'm unsure if it would be best to instead just replace it with the new GetClipboardBig one that uses FastString.