### PR TITLE
Fix potential crashes in RMS analysis/normalize

### DIFF
--- a/Misc/Analysis.cpp
+++ b/Misc/Analysis.cpp
@@ -34,9 +34,6 @@ static void GetRMSOptions(double *target, double *windowSize);
 
 static bool AnalyzePCMSource(ANALYZE_PCM* a)
 {
-	if (!a->pcm)
-		return false;
-
 	// Init local transfer block "t" and sum of squares
 	PCM_source_transfer_t t={0,};
 	t.samplerate = a->pcm->GetSampleRate();

--- a/Misc/Analysis.cpp
+++ b/Misc/Analysis.cpp
@@ -177,6 +177,10 @@ bool AnalyzeItem(MediaItem* mi, ANALYZE_PCM* a)
 	if (take)
 		cName = (const char*)GetSetMediaItemTakeInfo(take, "P_NAME", NULL);
 
+	const double oldWinSize = a->dWindowSize;
+	if (a->dWindowSize > a->pcm->GetLength())
+		a->dWindowSize = 0;
+
 	HANDLE hThread = (HANDLE)_beginthreadex(NULL, 0, AnalyzePCMThread, a, 0, NULL);
 
 	WDL_String title;
@@ -184,11 +188,13 @@ bool AnalyzeItem(MediaItem* mi, ANALYZE_PCM* a)
 	SWS_WaitDlg wait(title.Get(), &a->dProgress);
 
 	CloseHandle(hThread);
+
+	// restore original window if it was larger than the item's length
+	a->dWindowSize = oldWinSize;
+
 	delete a->pcm;
 	return true;
 }
-
-
 
 void DoAnalyzeItem(COMMAND_T*)
 {

--- a/Misc/Analysis.h
+++ b/Misc/Analysis.h
@@ -44,6 +44,7 @@ typedef struct ANALYZE_PCM
 	double dProgress;		// out Analysis progress, 0.0-1.0 for 0-100%
 	INT64 sampleCount;		// out # of samples analyzed
 	double dWindowSize;		// RMS window in seconds.  If this is != 0.0, then RMS is calculated/returned as max within window
+	bool success;
 } ANALYZE_PCM;
 
 int AnalysisInit();


### PR DESCRIPTION
This PR prevents crashes on RMS analysis/normalize when a negative window or impossibly large window sizes are specified or when there is just not enough RAM left.

1. sanitize RMS analysis/normalize options before use (reject negative values)
2. disable windowing if window is larger than the item length
3. don't crash if there is not enough free RAM to hold the audio buffer