### PR TITLE
Basic support for UTF-8 resource paths on Windows

### DIFF
--- a/Utility/win32-utf8.cpp
+++ b/Utility/win32-utf8.cpp
@@ -28,13 +28,14 @@
 #include "stdafx.h"
 #include "SnM\SnM.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
+#  define widen_cstr(cstr) widen(cstr).c_str()
+#else
 #  error This file should not be built on non-Windows systems.
 #endif
 
-#ifdef _WIN32
-#  define widen_cstr(cstr) widen(cstr).c_str()
-#endif
+static_assert(GetPrivateProfileString == GetPrivateProfileStringUTF8,
+  "The current version of WDL does not override GetPrivateProfileString to GetPrivateProfileStringUTF8. Update WDL.");
 
 using namespace std;
 

--- a/Utility/win32-utf8.cpp
+++ b/Utility/win32-utf8.cpp
@@ -1,0 +1,82 @@
+/******************************************************************************
+/ cfillion.cpp
+/
+/ Copyright (c) 2017 Christian Fillion
+/ https://cfillion.ca
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#include "stdafx.h"
+#include "SnM\SnM.h"
+
+#ifndef _WIN32
+#  error This file should not be built on non-Windows systems.
+#endif
+
+#ifdef _WIN32
+#  define widen_cstr(cstr) widen(cstr).c_str()
+#endif
+
+using namespace std;
+
+static wstring widen(const char *input, const UINT codepage = CP_UTF8, const int size = -1)
+{
+  const int wsize = MultiByteToWideChar(codepage, 0, input, size, nullptr, 0) - 1;
+
+  wstring output(wsize, 0);
+  MultiByteToWideChar(codepage, 0, input, size, &output[0], wsize);
+
+  return output;
+}
+
+static string narrow(const wchar_t *input)
+{
+  const int size = WideCharToMultiByte(CP_UTF8, 0,
+    input, -1, nullptr, 0, nullptr, nullptr) - 1;
+
+  string output(size, 0);
+  WideCharToMultiByte(CP_UTF8, 0, input, -1, &output[0], size, nullptr, nullptr);
+
+  return output;
+}
+
+DWORD GetPrivateProfileSectionUTF8(LPCTSTR appStr, LPTSTR retStr, DWORD nSize, LPCTSTR fnStr)
+{
+  wchar_t ret[SNM_MAX_INI_SECTION];
+  const int size = GetPrivateProfileSectionW(widen_cstr(appStr), ret,
+    SNM_MAX_INI_SECTION, widen_cstr(fnStr));
+
+  return WideCharToMultiByte(CP_UTF8, 0, ret, size, retStr, nSize, nullptr, nullptr);
+}
+
+BOOL WritePrivateProfileSectionUTF8(LPCTSTR appStr, LPCTSTR str, LPCTSTR fnStr)
+{
+  int size = 1;
+  const char *p = str;
+  while(*p) {
+    const int segmentLen = strlen(p) + 1;
+    p += segmentLen;
+    size += segmentLen;
+  }
+
+  return WritePrivateProfileSectionW(widen_cstr(appStr), widen(str, CP_UTF8, size).c_str(), widen_cstr(fnStr));
+}

--- a/Utility/win32-utf8.h
+++ b/Utility/win32-utf8.h
@@ -1,12 +1,18 @@
 #pragma once
 
+#include <windows.h>
+
+const char *GetResourcePathUTF8();
+#define GetResourcePath() GetResourcePathUTF8()
+
 DWORD GetPrivateProfileSectionUTF8(LPCTSTR appStr, LPTSTR retStr, DWORD nSize, LPCTSTR fnStr);
-BOOL WritePrivateProfileSectionUTF8(LPCTSTR appStr, LPCTSTR str, LPCTSTR fnStr);
 
 #ifdef GetPrivateProfileSection
 #  undef GetPrivateProfileSection
 #endif
 #define GetPrivateProfileSection GetPrivateProfileSectionUTF8
+
+BOOL WritePrivateProfileSectionUTF8(LPCTSTR appStr, LPCTSTR str, LPCTSTR fnStr);
 
 #ifdef WritePrivateProfileSection
 #  undef WritePrivateProfileSection

--- a/Utility/win32-utf8.h
+++ b/Utility/win32-utf8.h
@@ -5,15 +5,13 @@
 const char *GetResourcePathUTF8();
 #define GetResourcePath() GetResourcePathUTF8()
 
-DWORD GetPrivateProfileSectionUTF8(LPCTSTR appStr, LPTSTR retStr, DWORD nSize, LPCTSTR fnStr);
-
+DWORD GetPrivateProfileSectionUTF8(LPCTSTR appName, LPTSTR retStr, DWORD nSize, LPCTSTR fileName);
 #ifdef GetPrivateProfileSection
 #  undef GetPrivateProfileSection
 #endif
 #define GetPrivateProfileSection GetPrivateProfileSectionUTF8
 
-BOOL WritePrivateProfileSectionUTF8(LPCTSTR appStr, LPCTSTR str, LPCTSTR fnStr);
-
+BOOL WritePrivateProfileSectionUTF8(LPCTSTR appName, LPCTSTR str, LPCTSTR fileName);
 #ifdef WritePrivateProfileSection
 #  undef WritePrivateProfileSection
 #endif

--- a/Utility/win32-utf8.h
+++ b/Utility/win32-utf8.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <windows.h>
+
+DWORD GetPrivateProfileSectionUTF8(LPCTSTR appStr, LPTSTR retStr, DWORD nSize, LPCTSTR fnStr);
+BOOL WritePrivateProfileSectionUTF8(LPCTSTR appStr, LPCTSTR str, LPCTSTR fnStr);
+
+#ifdef GetPrivateProfileSection
+#undef GetPrivateProfileSection
+#endif
+#define GetPrivateProfileSection GetPrivateProfileSectionUTF8
+
+#ifdef WritePrivateProfileSection
+#undef WritePrivateProfileSection
+#endif
+#define WritePrivateProfileSection WritePrivateProfileSectionUTF8

--- a/Utility/win32-utf8.h
+++ b/Utility/win32-utf8.h
@@ -1,16 +1,14 @@
 #pragma once
 
-#include <windows.h>
-
 DWORD GetPrivateProfileSectionUTF8(LPCTSTR appStr, LPTSTR retStr, DWORD nSize, LPCTSTR fnStr);
 BOOL WritePrivateProfileSectionUTF8(LPCTSTR appStr, LPCTSTR str, LPCTSTR fnStr);
 
 #ifdef GetPrivateProfileSection
-#undef GetPrivateProfileSection
+#  undef GetPrivateProfileSection
 #endif
 #define GetPrivateProfileSection GetPrivateProfileSectionUTF8
 
 #ifdef WritePrivateProfileSection
-#undef WritePrivateProfileSection
+#  undef WritePrivateProfileSection
 #endif
 #define WritePrivateProfileSection WritePrivateProfileSectionUTF8

--- a/stdafx.h
+++ b/stdafx.h
@@ -94,10 +94,6 @@
 #include "WDL/MersenneTwister.h"
 #include "WDL/fileread.h"
 
-#ifdef _WIN32
-#include "Utility/win32-utf8.h"
-#endif
-
 #ifndef __GNUC__
 #pragma warning(default : 4996)
 #pragma warning(default : 4267)
@@ -124,4 +120,8 @@
 #include "Padre/padreUtils.h"
 #include "Padre/padreMidi.h"
 #include "Padre/padreMidiItemProcBase.h"
-#include "Breeder/BR_Timer.h" 
+#include "Breeder/BR_Timer.h"
+
+#ifdef _WIN32
+#  include "Utility/win32-utf8.h"
+#endif

--- a/stdafx.h
+++ b/stdafx.h
@@ -94,6 +94,10 @@
 #include "WDL/MersenneTwister.h"
 #include "WDL/fileread.h"
 
+#ifdef _WIN32
+#include "Utility/win32-utf8.h"
+#endif
+
 #ifndef __GNUC__
 #pragma warning(default : 4996)
 #pragma warning(default : 4267)

--- a/sws_extension.vcxproj
+++ b/sws_extension.vcxproj
@@ -375,6 +375,7 @@ echo Warning: sws_python.py generation failed (Perl installed?)
     <ClInclude Include="resource.h" />
     <ClInclude Include="snooks\snooks.h" />
     <ClInclude Include="snooks\SN_ReaScript.h" />
+    <ClInclude Include="Utility\win32-utf8.h" />
     <ClInclude Include="Wol\wol_Util.h" />
     <ClInclude Include="Wol\wol_Zoom.h" />
     <ClInclude Include="Xenakios\Parameters.h" />
@@ -553,6 +554,7 @@ echo Warning: sws_python.py generation failed (Perl installed?)
     <ClCompile Include="nofish\nofish.cpp" />
     <ClCompile Include="snooks\snooks.cpp" />
     <ClCompile Include="snooks\SN_ReaScript.cpp" />
+    <ClCompile Include="Utility\win32-utf8.cpp" />
     <ClCompile Include="Wol\wol_Util.cpp" />
     <ClCompile Include="Wol\wol_Zoom.cpp" />
     <ClCompile Include="Xenakios\AutoRename.cpp" />

--- a/sws_extension.vcxproj.filters
+++ b/sws_extension.vcxproj.filters
@@ -631,6 +631,9 @@
     <ClInclude Include="cfillion\cfillion.hpp">
       <Filter>cfillion</Filter>
     </ClInclude>
+    <ClInclude Include="Utility\win32-utf8.h">
+      <Filter>Core\Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="sws_extension.rc">
@@ -1262,6 +1265,9 @@
     </ClCompile>
     <ClCompile Include="cfillion\cfillion.cpp">
       <Filter>cfillion</Filter>
+    </ClCompile>
+    <ClCompile Include="Utility\win32-utf8.cpp">
+      <Filter>Core\Utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes SWS not reading or saving any settings when loaded in REAPER 5.70+ and the resource path contains any non-latin characters (or 5.60+ if the resource path contains characters outside of the ANSI codepage).

None of the changes affect macOS or Linux. Up to date WDL is required for full UTF-8 support.

While waiting for an official release I have made builds available at <https://cfillion.ca/files/sws/utf8-resource-path/>.

**Caveat:** UTF-8 characters cannot be stored in ini files anymore if the resource path contain any non-latin character. They get replaced by '?'s. REAPER 5.70 exhibits the same behavior. See #934, #935 and <https://forum.cockos.com/showthread.php?p=1927329> for more details (no answer from Justin yet).