### PR TITLE
Snapshots: also store receive envelopes, fixes #537

### DIFF
--- a/ObjectState/TrackSends.h
+++ b/ObjectState/TrackSends.h
@@ -39,11 +39,13 @@ public:
 class TrackSend
 {
 public:
-	TrackSend(GUID* guid, const char* str);
+	// NF: #537, also store the AUXVOL, AUXPAN, AUXMUTE chunks of the receiving tracks in the TrackSend object
+	TrackSend(GUID* guid, const char* str, const char* auxvol, const char* auxpan, const char* auxmute);
 	TrackSend(GUID* guid, int iMode, double dVol, double dPan, int iMute, int iMono, int iPhase, int iSrc, int iDest, int iMidi, int iAuto);
-	TrackSend(const char* str);
+	TrackSend(const char* str, const char* auxvol, const char* auxpan, const char* auxmute);
 	TrackSend(TrackSend& ts);
 	WDL_FastString* AuxRecvString(MediaTrack* srcTr, WDL_FastString* str);
+	WDL_FastString GetAuxvolstr(); WDL_FastString GetAuxpanstr(); WDL_FastString GetAuxmutestr();
 	void GetChunk(WDL_FastString* chunk);
 	const GUID* GetGuid() { return &m_destGuid; }
 	void SetGuid(const GUID* guid) { m_destGuid = *guid; }
@@ -51,6 +53,7 @@ public:
 private:
 	GUID m_destGuid;
 	WDL_FastString m_str;
+	WDL_FastString m_auxvolstr, m_auxpanstr, m_auxmutestr;
 };
 
 class TrackSends

--- a/Snapshots/SnapshotClass.cpp
+++ b/Snapshots/SnapshotClass.cpp
@@ -697,6 +697,8 @@ Snapshot::Snapshot(const char* chunk)
 	m_cName = NULL;
 	m_cNotes = NULL;
 
+	int auxEnvsOccurence = -1;
+
 	while(GetChunkLine(chunk, line, 4096, &pos, false))
 	{
 		if (lp.parse(line))
@@ -754,9 +756,23 @@ Snapshot::Snapshot(const char* chunk)
 				ts->m_sends.m_sends.Add(new TrackSend(&guid, lp.gettoken_int(5), lp.gettoken_float(2), lp.gettoken_float(3),
 					lp.gettoken_int(4), 0, 0, lp.gettoken_int(6), lp.gettoken_int(7), lp.gettoken_int(8), -1));
 			}
-			else if (strcmp("AUXSEND", lp.gettoken_str(0)) == 0)
-			// Same format as AUXRECV but on the send track, with second param as recv GUID
-				ts->m_sends.m_sends.Add(new TrackSend(line));
+			else if (strcmp("AUXSEND", lp.gettoken_str(0)) == 0) {
+				// Same format as AUXRECV but on the send track, with second param as recv GUID
+
+				// NF: also get the AUXVOLENV etc. subchunks
+				auxEnvsOccurence += 1;
+				WDL_FastString chunkStr;
+				chunkStr.Set(chunk);
+				SNM_ChunkParserPatcher p(&chunkStr);
+				WDL_FastString AUXVOL, AUXPAN, AUXMUTE;
+
+				p.GetSubChunk("AUXVOLENV", 3, auxEnvsOccurence, &AUXVOL, "FXCHAIN");
+				p.GetSubChunk("AUXPANENV", 3, auxEnvsOccurence, &AUXPAN, "FXCHAIN");
+				p.GetSubChunk("AUXMUTEENV", 3, auxEnvsOccurence, &AUXMUTE, "FXCHAIN");
+
+				ts->m_sends.m_sends.Add(new TrackSend(line, AUXVOL.Get(), AUXPAN.Get(), AUXMUTE.Get()));
+			}
+
 			else if (strcmp("HWOUT", lp.gettoken_str(0)) == 0)
 				ts->m_sends.m_hwSends.Add(new WDL_FastString(line));
 			else if (strcmp("FX", lp.gettoken_str(0)) == 0) // "One liner"

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -788,6 +788,7 @@ error:
 		IMPAPI(GetEnvelopePoint); // v5pre4
 		IMPAPI(GetEnvelopePointByTime) // v5pre4
 		IMPAPI(GetEnvelopeScalingMode); // v5pre13+
+		IMPAPI(GetEnvelopeStateChunk);
 		IMPAPI(GetExePath);
 		IMPAPI(GetFocusedFX);
 		IMPAPI(GetFXEnvelope); // v5pre5+
@@ -999,6 +1000,7 @@ error:
 		IMPAPI(SetEditCurPos);
 		IMPAPI(SetEditCurPos2);
 		IMPAPI(SetEnvelopePoint); // v5pre4+
+		IMPAPI(SetEnvelopeStateChunk);
 		IMPAPI(SetGlobalAutomationOverride);
 		IMPAPI(SetMasterTrackVisibility);
 		IMPAPI(SetMediaItemInfo_Value);

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,7 @@
+Fixes:
++Issue 537: Snapshots: (Attempt to) Fix longstanding issue with send envelopes not restored when recalling snapshots (thanks ovnis for testing!).
+ - Note: Since snapshots are based on state chunks, changes within AI envelopes are not recalled currently (https://forum.cockos.com/showthread.php?t=205406|FR|), though AI properties (e.g. position) should be recalled correctly. Also note that when deleting an AI and trying to recall a previously stored snapshot which contains this AI it won't be recalled correctly.
+
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!
 


### PR DESCRIPTION
fixes #537

ovnis from the REAPER forum helped me testing this time and we both couldn't find any issues so far with recalling send envelopes (apart from snapshots not working correctly with automation items in general, as noted in the whatsnew), so it's hopefully better than my last fix attempt. 

Build for testing:
https://www.dropbox.com/s/fzhobty77njvvf8/reaper_sws64.dll?dl=1

@swstim 
I don't know why you appear as commit author and not me and I don't know how to change it, sorry.
(Tried to do an amend commit with me as author but didn't work.)
