### PR TITLE
Create CF_GetSWSVersion API function

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -262,6 +262,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetClipboardBig), "const char*", "WDL_FastString*", "output", "Read the contents of the system clipboard. See <a href=\"#SNM_CreateFastString\">SNM_CreateFastString</a> and <a href=\"#SNM_DeleteFastString\">SNM_DeleteFastString</a>.", },
 	{ APIFUNC(CF_ShellExecute), "bool", "const char*", "file", "Open the given file or URL in the default application. See also <a href=\"#CF_LocateInExplorer\">CF_LocateInExplorer</a>.", },
 	{ APIFUNC(CF_LocateInExplorer), "bool", "const char*", "file", "Select the given file in explorer/finder.", },
+	{ APIFUNC(CF_GetSWSVersion), "void", "char*,int", "buf,buf_sz", "Return the current SWS version number.", },
 
 	{ NULL, } // denote end of table
 };

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -27,6 +27,7 @@
 
 #include "stdafx.h"
 #include "cfillion.hpp"
+#include "version.h"
 
 #ifdef _WIN32
 static const unsigned int FORMAT = CF_UNICODETEXT;
@@ -132,4 +133,9 @@ bool CF_LocateInExplorer(const char *file)
   arg.SetFormatted(strlen(file) + 10, "(/select,\"%s\")", file);
 
   return CF_ShellExecute("explorer.exe", arg.Get());
+}
+
+void CF_GetSWSVersion(char *buf, const int bufSize)
+{
+  snprintf(buf, bufSize, "%d.%d.%d.%d", SWS_VERSION);
 }

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -32,3 +32,4 @@ void CF_GetClipboard(char *buf, int bufSize);
 const char *CF_GetClipboardBig(WDL_FastString *);
 bool CF_ShellExecute(const char *file, const char *args = NULL);
 bool CF_LocateInExplorer(const char *file);
+void CF_GetSWSVersion(char *buf, int bufSize);


### PR DESCRIPTION
Using snprintf instead of _snprintfSafe because Visual Studio 2015+'s implementation of snprintf is now correct and it's overridden to WDL_snprintf anyway.