### PR TITLE
Auto group tweaks

### DIFF
--- a/Misc/Adam.h
+++ b/Misc/Adam.h
@@ -36,4 +36,13 @@ void UpdateTimebaseToolbar();
 void AWDoAutoGroup(bool rec);
 
 // #587
-void NFDoAutoGroupTakesMode();
+void NFDoAutoGroupTakesMode(WDL_TypedBuf<MediaItem*> selItems);
+
+// AutoGroupTakesMode helper functions
+MediaItem* GetSelectedItemOnTrack_byIndex(WDL_TypedBuf<MediaItem*> origSelItems,  vector<int> selItemsPerTrackCount, 
+	int selTrackIdx, int column);
+void SelectRecArmedTracksOfSelItems(WDL_TypedBuf<MediaItem*> selItems);
+int GetMaxSelItemsPerTrackCount(vector<int> selItemsPerTrackCount);
+void UnselectAllTracks();  void UnselectAllItems();
+void RestoreOrigTracksAndItemsSelection(WDL_TypedBuf<MediaTrack*> origSelTracks, WDL_TypedBuf<MediaItem*> origSelItems);
+bool isMoreThanOneTrackRecArmed();

--- a/Misc/Adam.h
+++ b/Misc/Adam.h
@@ -38,11 +38,11 @@ void AWDoAutoGroup(bool rec);
 // #587
 void NFDoAutoGroupTakesMode(WDL_TypedBuf<MediaItem*> selItems);
 
-// AutoGroupTakesMode helper functions
+// Auto group in takes mode helper functions
 MediaItem* GetSelectedItemOnTrack_byIndex(WDL_TypedBuf<MediaItem*> origSelItems,  vector<int> selItemsPerTrackCount, 
 	int selTrackIdx, int column);
 void SelectRecArmedTracksOfSelItems(WDL_TypedBuf<MediaItem*> selItems);
 int GetMaxSelItemsPerTrackCount(vector<int> selItemsPerTrackCount);
 void UnselectAllTracks();  void UnselectAllItems();
 void RestoreOrigTracksAndItemsSelection(WDL_TypedBuf<MediaTrack*> origSelTracks, WDL_TypedBuf<MediaItem*> origSelItems);
-bool isMoreThanOneTrackRecArmed();
+bool IsMoreThanOneTrackRecArmed();

--- a/nofish/nofish.h
+++ b/nofish/nofish.h
@@ -30,61 +30,16 @@
 
 // Eraser tool
 void NF_RegisterContinuousActions();
-
 void EraserToolInit();
-
-
-
-
-// register SWS actions
-int nofish_Init();
 
 // #514
 void UpdateMIDIGridToolbar();
 
-// #587 utility functions
-class NFTrackItemUtilities
-{
-public:
-	// NFTrackItemUtilities();
-	// ~NFTrackItemUtilities();
+// register SWS actions
+int nofish_Init();
 
-	void NFSaveSelectedTracks();
-	void NFRestoreSelectedTracks();
 
-	void NFSaveSelectedItems();
-	void NFRestoreSelectedItems();
 
-	void NFUnselectAllTracks();
-	void NFSelectTracksOfSelectedItems();
-
-	int NFCountSelectedItems_OnTrack(MediaTrack* track);
-	MediaItem* NFGetSelectedItems_OnTrack(int track_sel_id, int idx);
-
-	// const vector<int>& NFGetIntVector() const;
-	vector <int> count_sel_items_on_track; // should probably be private for good coding practice
-	
-	int GetMaxValfromIntVector(vector <int>);
-
-	bool isMoreThanOneTrackRecArmed();
-
-private:
-	// vector <int> count_sel_items_on_track;
-
-	// save/restore tracks/items
-	vector <MediaItem*> selItems;
-	vector <MediaTrack*> selTracks;
-};
-
-/*
-NFTrackItemUtilities::NFTrackItemUtilities()
-{
-}
-
-NFTrackItemUtilities::~NFTrackItemUtilities()
-{
-}
-*/
 
 
 

--- a/nofish/nofish.h
+++ b/nofish/nofish.h
@@ -28,18 +28,12 @@
 
 #pragma once
 
-// Eraser tool
-void NF_RegisterContinuousActions();
+// continuous actions
 void EraserToolInit();
+void NF_RegisterContinuousActions();
 
 // #514
 void UpdateMIDIGridToolbar();
 
-// register SWS actions
+// register actions
 int nofish_Init();
-
-
-
-
-
-

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -706,6 +706,7 @@ error:
 /* unused
 		IMPAPI(Audio_RegHardwareHook);
 */
+		IMPAPI(ColorToNative)
 		IMPAPI(CoolSB_GetScrollInfo);
 		IMPAPI(CoolSB_SetScrollInfo);
 		IMPAPI(CountActionShortcuts);

--- a/sws_util.cpp
+++ b/sws_util.cpp
@@ -420,6 +420,18 @@ void dprintf(const char* format, ...)
 }
 #endif
 
+void SWS_GetAllTracks(WDL_TypedBuf<MediaTrack*>* buf, bool bMaster)
+{
+	buf->Resize(0);
+	for (int i = (bMaster ? 0 : 1); i <= GetNumTracks(); i++)
+	{
+		MediaTrack* tr = CSurf_TrackFromID(i, false);
+		int pos = buf->GetSize();
+		buf->Resize(pos + 1);
+		buf->Get()[pos] = tr;
+	}
+}
+
 void SWS_GetSelectedTracks(WDL_TypedBuf<MediaTrack*>* buf, bool bMaster)
 {
 	buf->Resize(0);

--- a/sws_util.h
+++ b/sws_util.h
@@ -251,6 +251,7 @@ void UpdateStretchMarkersAfterSetTakeStartOffset(MediaItem_Take* take, double ta
   #endif
 #endif
 
+void SWS_GetAllTracks(WDL_TypedBuf<MediaTrack*>* buf, bool bMaster = false);
 void SWS_GetSelectedTracks(WDL_TypedBuf<MediaTrack*>* buf, bool bMaster = false);
 void SWS_GetSelectedMediaItems(WDL_TypedBuf<MediaItem*>* buf);
 void SWS_GetSelectedMediaItemsOnTrack(WDL_TypedBuf<MediaItem*>* buf, MediaTrack* tr);

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,9 @@
+Actions:
++"SWS/NF: Eraser tool...":
+ - added 'ignoring snap' variant
+ - changed functionality (now cuts item sections on shortcut release rather than continuous erasing because it didn't work well with Ripple editing), changed action description to reflect this change
+
+
 Fixes:
 +Auto group:
  - Revert creating explicit undo point (match behaviour prior 2.95)

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,8 @@
+Fixes:
++Auto group:
+ - Revert creating explicit undo point (match behaviour prior 2.95)
+ - Prevent grouping of selected items on not record armed tracks
+
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!
 

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,4 +1,10 @@
 Actions:
++New actions (Main section):
+ - SWS/NF: Disable multichannel metering (all tracks)
+ - SWS/NF: Disable multichannel metering (selected tracks)
+ - SWS/NF: Enable multichannel metering (all tracks)
+ - SWS/NF: Enable multichannel metering (selected tracks)
+
 +"SWS/NF: Eraser tool...":
  - added 'ignoring snap' variant
  - changed functionality (now cuts item sections on shortcut release rather than continuous erasing because it didn't work well with Ripple editing), changed action description to reflect this change


### PR DESCRIPTION
Auto group:
- Revert creating explicit undo point (match behaviour prior 2.95)
 - Prevent grouping of selected items on not record armed tracks
- Internal tweaks / clean up

nofish.h/.cpp:
- clean up

Eraser tool tweaks: 
~~temp. disable Pref: "If no items are selected..."~~ (reverted, not necessary with changed functionality below)
- Add 'ignoring snap' variant, cut on shortcut release (rather than continuous erasing)

Added actions:
 - SWS/NF: Disable multichannel metering (all tracks)
 - SWS/NF: Disable multichannel metering (selected tracks)
 - SWS/NF: Enable multichannel metering (all tracks)
 - SWS/NF: Enable multichannel metering (selected tracks)
