### PR TITLE
Add API functions for enumerating selected effects in a given chain

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -262,6 +262,8 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetClipboardBig), "const char*", "WDL_FastString*", "output", "Read the contents of the system clipboard. See <a href=\"#SNM_CreateFastString\">SNM_CreateFastString</a> and <a href=\"#SNM_DeleteFastString\">SNM_DeleteFastString</a>.", },
 	{ APIFUNC(CF_ShellExecute), "bool", "const char*", "file", "Open the given file or URL in the default application. See also <a href=\"#CF_LocateInExplorer\">CF_LocateInExplorer</a>.", },
 	{ APIFUNC(CF_LocateInExplorer), "bool", "const char*", "file", "Select the given file in explorer/finder.", },
+	{ APIFUNC(CF_GetFocusedFXChain), "FxChain*", "", "", "Return a handle to the currently focused FX chain window. The window is found by title so accuracy is limited for take FX chains.", },
+	{ APIFUNC(CF_EnumSelectedFX), "int", "FxChain*,int", "hwnd,index", "Return the index of the next selected effect in the given FX chain. Start index should be -1. Returns -1 if there are no more selected effects.", },
 
 	{ NULL, } // denote end of table
 };

--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -263,8 +263,8 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_ShellExecute), "bool", "const char*", "file", "Open the given file or URL in the default application. See also <a href=\"#CF_LocateInExplorer\">CF_LocateInExplorer</a>.", },
 	{ APIFUNC(CF_LocateInExplorer), "bool", "const char*", "file", "Select the given file in explorer/finder.", },
 	{ APIFUNC(CF_GetTrackFXChain), "FxChain*", "MediaTrack*", "track", "Return a handle to the given track FX chain window.", },
-	{ APIFUNC(CF_GetTakeFXChain), "FxChain*", "MediaItem_Take*", "take", "Return a handle to the given take FX chain window.", },
-	{ APIFUNC(CF_GetFocusedFXChain), "FxChain*", "", "", "Return a handle to the currently focused FX chain window. The window is found by title so accuracy is limited for take FX chains.", },
+	{ APIFUNC(CF_GetTakeFXChain), "FxChain*", "MediaItem_Take*", "take", "Return a handle to the given take FX chain window. HACK: This temporarily renames the take in order to disambiguate the take FX chain window from similarily named takes.", },
+	{ APIFUNC(CF_GetFocusedFXChain), "FxChain*", "", "", "Return a handle to the currently focused FX chain window.", },
 	{ APIFUNC(CF_EnumSelectedFX), "int", "FxChain*,int", "hwnd,index", "Return the index of the next selected effect in the given FX chain. Start index should be -1. Returns -1 if there are no more selected effects.", },
 
 	{ NULL, } // denote end of table

--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -262,6 +262,8 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetClipboardBig), "const char*", "WDL_FastString*", "output", "Read the contents of the system clipboard. See <a href=\"#SNM_CreateFastString\">SNM_CreateFastString</a> and <a href=\"#SNM_DeleteFastString\">SNM_DeleteFastString</a>.", },
 	{ APIFUNC(CF_ShellExecute), "bool", "const char*", "file", "Open the given file or URL in the default application. See also <a href=\"#CF_LocateInExplorer\">CF_LocateInExplorer</a>.", },
 	{ APIFUNC(CF_LocateInExplorer), "bool", "const char*", "file", "Select the given file in explorer/finder.", },
+	{ APIFUNC(CF_GetTrackFXChain), "FxChain*", "MediaTrack*", "track", "Return a handle to the given track FX chain window.", },
+	{ APIFUNC(CF_GetTakeFXChain), "FxChain*", "MediaItem_Take*", "take", "Return a handle to the given take FX chain window.", },
 	{ APIFUNC(CF_GetFocusedFXChain), "FxChain*", "", "", "Return a handle to the currently focused FX chain window. The window is found by title so accuracy is limited for take FX chains.", },
 	{ APIFUNC(CF_EnumSelectedFX), "int", "FxChain*,int", "hwnd,index", "Return the index of the next selected effect in the given FX chain. Start index should be -1. Returns -1 if there are no more selected effects.", },
 

--- a/Utility/win32-utf8.cpp
+++ b/Utility/win32-utf8.cpp
@@ -130,3 +130,9 @@ BOOL WritePrivateProfileSectionUTF8(LPCTSTR appName, LPCTSTR string, LPCTSTR fil
   return WritePrivateProfileSectionW(widen(appName).c_str(),
     wideString.c_str(), widen(fileName).c_str());
 }
+
+HWND FindWindowExUTF8(HWND parent, HWND after, const char *className, const char *title)
+{
+  return FindWindowExW(parent, after,
+    className ? widen(className).c_str() : nullptr, title ? widen(title).c_str() : nullptr);
+}

--- a/Utility/win32-utf8.h
+++ b/Utility/win32-utf8.h
@@ -16,3 +16,9 @@ BOOL WritePrivateProfileSectionUTF8(LPCTSTR appName, LPCTSTR str, LPCTSTR fileNa
 #  undef WritePrivateProfileSection
 #endif
 #define WritePrivateProfileSection WritePrivateProfileSectionUTF8
+
+HWND FindWindowExUTF8(HWND parent, HWND after, const char *className, const char *title);
+#ifdef FindWindowEx
+#  undef FindWindowEx
+#endif
+#define FindWindowEx FindWindowExUTF8

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -133,3 +133,42 @@ bool CF_LocateInExplorer(const char *file)
 
   return CF_ShellExecute("explorer.exe", arg.Get());
 }
+
+HWND CF_GetFocusedFXChain()
+{
+  // TODO: Localization support
+
+  int trackIndex, itemIndex, fxIndex;
+  const int focusType = GetFocusedFX(&trackIndex, &itemIndex, &fxIndex);
+
+  char chainTitle[64];
+
+  switch(focusType) {
+  case 1: // track FX
+    if(trackIndex > 0)
+      snprintf(chainTitle, sizeof(chainTitle), "FX: Track %d", trackIndex);
+    else
+      snprintf(chainTitle, sizeof(chainTitle), "FX: Master Track");
+    break;
+  case 2: { // item FX
+    MediaTrack *track = GetTrack(0, trackIndex - 1);
+    MediaItem *item = GetTrackMediaItem(track, itemIndex);
+    const int takeIndex = (fxIndex >> 16) & 0xff;
+    MediaItem_Take *take = GetMediaItemTake(item, takeIndex);
+    snprintf(chainTitle, sizeof(chainTitle), "FX: Item \"%s\"", GetTakeName(take));
+    break;
+  }
+  default:
+    return nullptr;
+  }
+
+  return FindWindowEx(nullptr, nullptr, nullptr, chainTitle);
+}
+
+int CF_EnumSelectedFX(HWND fxChain, int index)
+{
+  const HWND list = GetDlgItem(fxChain, 1076);
+  index = ListView_GetNextItem(list, index, LVNI_SELECTED);
+
+  return index;
+}

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -27,6 +27,7 @@
 
 #include "stdafx.h"
 #include "cfillion.hpp"
+#include "reaper/localize.h"
 
 #ifdef _WIN32
 static const unsigned int FORMAT = CF_UNICODETEXT;
@@ -139,9 +140,11 @@ static HWND CF_GetTrackFXChain(const int trackIndex)
   char chainTitle[64];
 
   if(trackIndex < 1) // Master track
-    snprintf(chainTitle, sizeof(chainTitle), "FX: Master Track");
+    snprintf(chainTitle, sizeof(chainTitle), "%s%s",
+      __LOCALIZE("FX: ", "fx"), __LOCALIZE("Master Track", "fx"));
   else
-    snprintf(chainTitle, sizeof(chainTitle), "FX: Track %d", trackIndex);
+    snprintf(chainTitle, sizeof(chainTitle), "%s%s %d",
+      __LOCALIZE("FX: ", "fx"), __LOCALIZE("Track", "fx"), trackIndex);
 
   return FindWindowEx(nullptr, nullptr, nullptr, chainTitle);
 }
@@ -173,7 +176,8 @@ HWND CF_GetTakeFXChain(MediaItem_Take *take)
   GetSetMediaItemTakeInfo_String(take, "P_NAME", guidStr, true);
 
   char chainTitle[64];
-  snprintf(chainTitle, sizeof(chainTitle), "FX: Item \"%s\"", guidStr);
+  snprintf(chainTitle, sizeof(chainTitle), "%s%s \"%s\"",
+    __LOCALIZE("FX: ", "fx"), __LOCALIZE("Item", "fx"), guidStr);
 
   HWND window = FindWindowEx(nullptr, nullptr, nullptr, chainTitle);
 

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -146,14 +146,14 @@ static HWND CF_GetTrackFXChain(const int trackIndex)
     snprintf(chainTitle, sizeof(chainTitle), "%s%s %d",
       __LOCALIZE("FX: ", "fx"), __LOCALIZE("Track", "fx"), trackIndex);
 
-  return FindWindowEx(nullptr, nullptr, nullptr, chainTitle);
+  return FindWindowEx(NULL, NULL, NULL, chainTitle);
 }
 
 HWND CF_GetTrackFXChain(MediaTrack *track)
 {
   int trackNumber = 0;
 
-  if(track != GetMasterTrack(nullptr))
+  if(track != GetMasterTrack(NULL))
     trackNumber = static_cast<int>(GetMediaTrackInfo_Value(track, "IP_TRACKNUMBER"));
 
   return CF_GetTrackFXChain(trackNumber);
@@ -165,7 +165,7 @@ HWND CF_GetTakeFXChain(MediaItem_Take *take)
   // attached to it (pointer to an internal FxChain object?) but it does not
   // seem to hint back to the take in any obvious way.
 
-  GUID *guid = static_cast<GUID *>(GetSetMediaItemTakeInfo(take, "GUID", nullptr));
+  GUID *guid = static_cast<GUID *>(GetSetMediaItemTakeInfo(take, "GUID", NULL));
 
   char guidStr[64];
   guidToString(guid, guidStr);
@@ -177,7 +177,7 @@ HWND CF_GetTakeFXChain(MediaItem_Take *take)
   snprintf(chainTitle, sizeof(chainTitle), "%s%s \"%s\"",
     __LOCALIZE("FX: ", "fx"), __LOCALIZE("Item", "fx"), guidStr);
 
-  HWND window = FindWindowEx(nullptr, nullptr, nullptr, chainTitle);
+  HWND window = FindWindowEx(NULL, NULL, NULL, chainTitle);
 
   GetSetMediaItemTakeInfo_String(take, "P_NAME",
     const_cast<char *>(originalName.c_str()), true);
@@ -195,13 +195,13 @@ HWND CF_GetFocusedFXChain()
   case 1:
     return CF_GetTrackFXChain(trackIndex);
   case 2: {
-    MediaTrack *track = GetTrack(nullptr, trackIndex - 1);
+    MediaTrack *track = GetTrack(NULL, trackIndex - 1);
     MediaItem *item = GetTrackMediaItem(track, itemIndex);
     MediaItem_Take *take = GetMediaItemTake(item, HIWORD(fxIndex));
     return CF_GetTakeFXChain(take);
   }
   default:
-    return nullptr;
+    return NULL;
   }
 }
 

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -137,9 +137,9 @@ bool CF_LocateInExplorer(const char *file)
 
 static HWND CF_GetTrackFXChain(const int trackIndex)
 {
-  char chainTitle[64];
+  char chainTitle[128];
 
-  if(trackIndex < 1) // Master track
+  if(trackIndex < 1)
     snprintf(chainTitle, sizeof(chainTitle), "%s%s",
       __LOCALIZE("FX: ", "fx"), __LOCALIZE("Master Track", "fx"));
   else
@@ -151,20 +151,19 @@ static HWND CF_GetTrackFXChain(const int trackIndex)
 
 HWND CF_GetTrackFXChain(MediaTrack *track)
 {
-  if(track == GetMasterTrack(nullptr))
-    return CF_GetTrackFXChain(0);
-  else {
-    const int trackNumber = static_cast<int>(
-      GetMediaTrackInfo_Value(track, "IP_TRACKNUMBER"));
-    return CF_GetTrackFXChain(trackNumber);
-  }
+  int trackNumber = 0;
+
+  if(track != GetMasterTrack(nullptr))
+    trackNumber = static_cast<int>(GetMediaTrackInfo_Value(track, "IP_TRACKNUMBER"));
+
+  return CF_GetTrackFXChain(trackNumber);
 }
 
 HWND CF_GetTakeFXChain(MediaItem_Take *take)
 {
   // Shameful hack follows. The FX chain window does have some user data
   // attached to it (pointer to an internal FxChain object?) but it does not
-  // seem to point back to the take in any obvious way.
+  // seem to hint back to the take in any obvious way.
 
   GUID guid;
   genGuid(&guid);
@@ -175,7 +174,7 @@ HWND CF_GetTakeFXChain(MediaItem_Take *take)
   string originalName = GetTakeName(take);
   GetSetMediaItemTakeInfo_String(take, "P_NAME", guidStr, true);
 
-  char chainTitle[64];
+  char chainTitle[128];
   snprintf(chainTitle, sizeof(chainTitle), "%s%s \"%s\"",
     __LOCALIZE("FX: ", "fx"), __LOCALIZE("Item", "fx"), guidStr);
 

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -165,11 +165,10 @@ HWND CF_GetTakeFXChain(MediaItem_Take *take)
   // attached to it (pointer to an internal FxChain object?) but it does not
   // seem to hint back to the take in any obvious way.
 
-  GUID guid;
-  genGuid(&guid);
+  GUID *guid = static_cast<GUID *>(GetSetMediaItemTakeInfo(take, "GUID", nullptr));
 
   char guidStr[64];
-  guidToString(&guid, guidStr);
+  guidToString(guid, guidStr);
 
   string originalName = GetTakeName(take);
   GetSetMediaItemTakeInfo_String(take, "P_NAME", guidStr, true);

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -35,4 +35,6 @@ const char *CF_GetClipboardBig(WDL_FastString *);
 bool CF_ShellExecute(const char *file, const char *args = NULL);
 bool CF_LocateInExplorer(const char *file);
 HWND CF_GetFocusedFXChain();
+HWND CF_GetTrackFXChain(MediaTrack *);
+HWND CF_GetTakeFXChain(MediaItem_Take *);
 int CF_EnumSelectedFX(HWND chain, int index);

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -27,8 +27,12 @@
 
 #pragma once
 
+typedef HWND__ FxChain;
+
 void CF_SetClipboard(const char *);
 void CF_GetClipboard(char *buf, int bufSize);
 const char *CF_GetClipboardBig(WDL_FastString *);
 bool CF_ShellExecute(const char *file, const char *args = NULL);
 bool CF_LocateInExplorer(const char *file);
+HWND CF_GetFocusedFXChain();
+int CF_EnumSelectedFX(HWND chain, int index);

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -37,4 +37,4 @@ bool CF_LocateInExplorer(const char *file);
 HWND CF_GetFocusedFXChain();
 HWND CF_GetTrackFXChain(MediaTrack *);
 HWND CF_GetTakeFXChain(MediaItem_Take *);
-int CF_EnumSelectedFX(HWND chain, int index);
+int CF_EnumSelectedFX(HWND chain, int index = -1);

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -769,6 +769,7 @@ error:
 		IMPAPI(format_timestr_pos);
 		IMPAPI(format_timestr_len);
 		IMPAPI(FreeHeapPtr);
+		IMPAPI(genGuid);
 		IMPAPI(GetActionShortcutDesc);
 		IMPAPI(GetActiveTake);
 		IMPAPI(GetAllProjectPlayStates); // v5.111+
@@ -845,6 +846,7 @@ error:
 		IMPAPI(GetSetEnvelopeState);
 		IMPAPI(GetSetMediaItemInfo);
 		IMPAPI(GetSetMediaItemTakeInfo);
+		IMPAPI(GetSetMediaItemTakeInfo_String);
 		IMPAPI(GetMediaSourceLength); // v5.0pre3+
 		IMPAPI(GetSetMediaTrackInfo);
 		IMPAPI(GetSetObjectState);
@@ -854,6 +856,7 @@ error:
 		IMPAPI(GetSetTrackGroupMembership); // v5.21pre5+
 		IMPAPI(GetTempoTimeSigMarker);
 		IMPAPI(GetTakeEnvelopeByName);
+		IMPAPI(GetTakeName);
 		IMPAPI(GetTakeStretchMarker);
 		IMPAPI(GetSetTrackSendInfo);
 		IMPAPI(GetSetTrackState);

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -769,7 +769,6 @@ error:
 		IMPAPI(format_timestr_pos);
 		IMPAPI(format_timestr_len);
 		IMPAPI(FreeHeapPtr);
-		IMPAPI(genGuid);
 		IMPAPI(GetActionShortcutDesc);
 		IMPAPI(GetActiveTake);
 		IMPAPI(GetAllProjectPlayStates); // v5.111+


### PR DESCRIPTION
Credits to @amagalma for the original idea.

SWELL must be patched for implementing global window lookup in FindWindowEx to make this work on Linux: <https://github.com/cfillion/WDL/commit/cdb3c730b1223ec79227cc4dc48249a1340cc4b5.patch>.

EDIT 2018-07-24: Justin pushed a similar patch to upstream WDL.