### PR TITLE
Repair CF_LocateInExplorer

### DIFF
--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -129,7 +129,7 @@ bool CF_LocateInExplorer(const char *file)
 {
   // Quotes inside the filename must not be escaped for the SWELL implementation
   WDL_FastString arg;
-  arg.SetFormatted(strlen(file) + 10, "(/select,\"%s\")", file);
+  arg.SetFormatted(strlen(file) + 10, "/select,\"%s\"", file);
 
   return CF_ShellExecute("explorer.exe", arg.Get());
 }


### PR DESCRIPTION
Commit 7dbabb7817284b52f9e6683d44319e002a7ed58e broke it: the parenthesis were part of the [`R"( )"`](
https://en.cppreference.com/w/cpp/language/string_literal) raw string literal syntax and not the actual string value.