### PR TITLE
Remove a line of dead code that would crash if used

### DIFF
--- a/SnM/SnM_Notes.h
+++ b/SnM/SnM_Notes.h
@@ -56,7 +56,6 @@ class SNM_TrackNotes {
 public:
 	SNM_TrackNotes(const GUID* _guid, const char* _notes) {
 		if (_guid) memcpy(&m_guid, _guid, sizeof(GUID));
-		else genGuid(&m_guid); // just in case
 		m_notes.Set(_notes ? _notes : "");
 	}
 	MediaTrack* GetTrack() { return GuidToTrack(&m_guid); }


### PR DESCRIPTION
The genGuid API function hasn't been imported for a very long time (if ever). It is the only mention of that function in the entire SWS codebase. Found this by accident...