### PR TITLE
Auto color/icon/layout: "(vca master)" filter - also apply rules to groups 33 - 64 

### DIFF
--- a/Color/Autocolor.cpp
+++ b/Color/Autocolor.cpp
@@ -770,7 +770,13 @@ void ApplyColorRuleToTrack(SWS_RuleItem* rule, bool bDoColors, bool bDoIcons, bo
 					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_VCA_MASTER]) == 0)
 					{
 						int iVcaMaster = GetSetTrackGroupMembership(tr, "VOLUME_VCA_MASTER", 0, 0);
-						if (iVcaMaster)
+
+						// check newly added groups 33 - 64
+						int iVcaMasterHigh = 0;
+						if (GetSetTrackGroupMembershipHigh) // added as optional API function for now
+							iVcaMasterHigh = GetSetTrackGroupMembershipHigh(tr, "VOLUME_VCA_MASTER", 0, 0);
+
+						if (iVcaMaster || iVcaMasterHigh)
 							bMatch = true;
 					}
 					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_ANY]) == 0)

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -1105,6 +1105,9 @@ error:
 			goto error;
 		}
 
+		// Optional API functions (check for NULL if using!) 
+		IMPAP_OPT(GetSetTrackGroupMembershipHigh); // v5.70+
+
 		// Look for SWS dupe/clone
 		if (rec->GetFunc("SNM_GetIntConfigVar"))
 		{

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -1107,6 +1107,7 @@ error:
 
 		// Optional API functions (check for NULL if using!) 
 		IMPAP_OPT(GetSetTrackGroupMembershipHigh); // v5.70+
+		IMPAP_OPT(TrackFX_GetOffline); // v5.95+
 
 		// Look for SWS dupe/clone
 		if (rec->GetFunc("SNM_GetIntConfigVar"))

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,6 @@
+Fixes:
++Auto color/icon/layout: "(vca master)" filter - also apply rules to groups 33 - 64 (report https://forum.cockos.com/showthread.php?t=207722|here|) (REAPER 5.70+)
+
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!
 


### PR DESCRIPTION
Report: https://forum.cockos.com/showthread.php?t=207722
Added GetSetTrackGroupMembershipHigh() as optional API function for now

SWS/S&M: Float next FX (and close others) for selected tracks - use API instead of chunk parsing if possible
Added TrackFX_GetOffline() as optional API function for now