### PR TITLE
Expose a few PCM_source capabilities to ReaScripts

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -263,6 +263,8 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_ShellExecute), "bool", "const char*", "file", "Open the given file or URL in the default application. See also <a href=\"#CF_LocateInExplorer\">CF_LocateInExplorer</a>.", },
 	{ APIFUNC(CF_LocateInExplorer), "bool", "const char*", "file", "Select the given file in explorer/finder.", },
 	{ APIFUNC(CF_GetMediaSourceBitDepth), "int", "PCM_source*", "src", "Returns the bit depth if available (0 otherwise).", },
+	{ APIFUNC(CF_GetMediaSourceOnline), "bool", "PCM_source*", "src", "Returns the online/offline status of the given source.", },
+	{ APIFUNC(CF_SetMediaSourceOnline), "void", "PCM_source*,bool", "src,set", "Set the online/offline status of the given source (closes files when set=false).", },
 
 	{ NULL, } // denote end of table
 };

--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -266,6 +266,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetMediaSourceOnline), "bool", "PCM_source*", "src", "Returns the online/offline status of the given source.", },
 	{ APIFUNC(CF_SetMediaSourceOnline), "void", "PCM_source*,bool", "src,set", "Set the online/offline status of the given source (closes files when set=false).", },
 	{ APIFUNC(CF_GetMediaSourceMetadata), "bool", "PCM_source*,const char*,char*,int", "src,name,out,out_sz", "Get the value of the given metadata field (eg. DESC, ORIG, ORIGREF, DATE, TIME, UMI, CODINGHISTORY for BWF).", },
+	{ APIFUNC(CF_GetMediaSourceRPP), "bool", "PCM_source*,char*,int", "src,fn,fn_sz", "Get the project associated with this source (BWF, subproject...).", },
 	{ APIFUNC(CF_EnumMediaSourceCues), "int", "PCM_source*,int,double*,double*,bool*,char*,int", "src,index,timeOut,endTimeOut,isRegionOut,nameOut,nameOut_sz", "Enumerate the source's media cues. Returns the next index or 0 when finished.", },
 
 	{ NULL, } // denote end of table

--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -266,6 +266,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetMediaSourceOnline), "bool", "PCM_source*", "src", "Returns the online/offline status of the given source.", },
 	{ APIFUNC(CF_SetMediaSourceOnline), "void", "PCM_source*,bool", "src,set", "Set the online/offline status of the given source (closes files when set=false).", },
 	{ APIFUNC(CF_GetMediaSourceMetadata), "bool", "PCM_source*,const char*,char*,int", "src,name,out,out_sz", "Get the value of the given metadata field (eg. DESC, ORIG, ORIGREF, DATE, TIME, UMI, CODINGHISTORY for BWF).", },
+	{ APIFUNC(CF_EnumMediaSourceCues), "int", "PCM_source*,int,double*,double*,bool*,char*,int", "src,index,timeOut,endTimeOut,isRegionOut,nameOut,nameOut_sz", "Enumerate the source's media cues. Returns the next index or 0 when finished.", },
 
 	{ NULL, } // denote end of table
 };

--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -268,6 +268,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetMediaSourceMetadata), "bool", "PCM_source*,const char*,char*,int", "src,name,out,out_sz", "Get the value of the given metadata field (eg. DESC, ORIG, ORIGREF, DATE, TIME, UMI, CODINGHISTORY for BWF).", },
 	{ APIFUNC(CF_GetMediaSourceRPP), "bool", "PCM_source*,char*,int", "src,fn,fn_sz", "Get the project associated with this source (BWF, subproject...).", },
 	{ APIFUNC(CF_EnumMediaSourceCues), "int", "PCM_source*,int,double*,double*,bool*,char*,int", "src,index,timeOut,endTimeOut,isRegionOut,nameOut,nameOut_sz", "Enumerate the source's media cues. Returns the next index or 0 when finished.", },
+	{ APIFUNC(CF_ExportMediaSource), "bool", "PCM_source*,const char*", "src,fn", "Export the source to the given file (MIDI only).", },
 
 	{ NULL, } // denote end of table
 };

--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -265,6 +265,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetMediaSourceBitDepth), "int", "PCM_source*", "src", "Returns the bit depth if available (0 otherwise).", },
 	{ APIFUNC(CF_GetMediaSourceOnline), "bool", "PCM_source*", "src", "Returns the online/offline status of the given source.", },
 	{ APIFUNC(CF_SetMediaSourceOnline), "void", "PCM_source*,bool", "src,set", "Set the online/offline status of the given source (closes files when set=false).", },
+	{ APIFUNC(CF_GetMediaSourceMetadata), "bool", "PCM_source*,const char*,char*,int", "src,name,out,out_sz", "Get the value of the given metadata field (eg. DESC, ORIG, ORIGREF, DATE, TIME, UMI, CODINGHISTORY for BWF).", },
 
 	{ NULL, } // denote end of table
 };

--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -262,6 +262,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetClipboardBig), "const char*", "WDL_FastString*", "output", "Read the contents of the system clipboard. See <a href=\"#SNM_CreateFastString\">SNM_CreateFastString</a> and <a href=\"#SNM_DeleteFastString\">SNM_DeleteFastString</a>.", },
 	{ APIFUNC(CF_ShellExecute), "bool", "const char*", "file", "Open the given file or URL in the default application. See also <a href=\"#CF_LocateInExplorer\">CF_LocateInExplorer</a>.", },
 	{ APIFUNC(CF_LocateInExplorer), "bool", "const char*", "file", "Select the given file in explorer/finder.", },
+	{ APIFUNC(CF_GetMediaSourceBitDepth), "int", "PCM_source*", "src", "Returns the bit depth if available (0 otherwise).", },
 
 	{ NULL, } // denote end of table
 };

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -170,7 +170,7 @@ bool CF_GetMediaSourceRPP(PCM_source *source, char *buf, const int bufSize)
 
 int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize)
 {
-  REAPER_cue cue{};
+  REAPER_cue cue = {};
   const int add = source->Extended(PCM_SOURCE_EXT_ENUMCUES_EX, (void *)index, &cue, NULL);
 
   if(time)

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -185,3 +185,8 @@ int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, do
 
   return add ? index + add : 0;
 }
+
+bool CF_ExportMediaSource(PCM_source *source, const char *file)
+{ 
+  return source->Extended(PCM_SOURCE_EXT_EXPORTTOFILE, (void *)file, NULL, NULL) > 0;
+}

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -152,7 +152,7 @@ void CF_SetMediaSourceOnline(PCM_source *source, const bool online)
 
 bool CF_GetMediaSourceMetadata(PCM_source *source, const char *name, char *buf, const int bufSize)
 {
-  return source->Extended(PCM_SOURCE_EXT_GETMETADATA, (void *)name, (void *)buf, (void *)bufSize) > 0;
+  return source->Extended(PCM_SOURCE_EXT_GETMETADATA, (void *)name, (void *)buf, (void *)(intptr_t)bufSize) > 0;
 }
 
 bool CF_GetMediaSourceRPP(PCM_source *source, char *buf, const int bufSize)
@@ -171,7 +171,7 @@ bool CF_GetMediaSourceRPP(PCM_source *source, char *buf, const int bufSize)
 int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize)
 {
   REAPER_cue cue = {};
-  const int add = source->Extended(PCM_SOURCE_EXT_ENUMCUES_EX, (void *)index, &cue, NULL);
+  const int add = source->Extended(PCM_SOURCE_EXT_ENUMCUES_EX, (void *)(intptr_t)index, &cue, NULL);
 
   if(time)
     *time = cue.m_time;

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -139,3 +139,13 @@ int CF_GetMediaSourceBitDepth(PCM_source *source)
   // parameter validation is already done on the REAPER side, so we're sure source is a valid PCM_source
   return source->GetBitsPerSample();
 }
+
+bool CF_GetMediaSourceOnline(PCM_source *source)
+{
+  return source->IsAvailable();
+}
+
+void CF_SetMediaSourceOnline(PCM_source *source, const bool online)
+{
+  source->SetAvailable(online);
+}

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -149,3 +149,8 @@ void CF_SetMediaSourceOnline(PCM_source *source, const bool online)
 {
   source->SetAvailable(online);
 }
+
+bool CF_GetMediaSourceMetadata(PCM_source *source, const char *name, char *buf, const int bufSize)
+{
+  return source->Extended(PCM_SOURCE_EXT_GETMETADATA, (void *)name, (void *)buf, (void *)bufSize) > 0;
+}

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -133,3 +133,9 @@ bool CF_LocateInExplorer(const char *file)
 
   return CF_ShellExecute("explorer.exe", arg.Get());
 }
+
+int CF_GetMediaSourceBitDepth(PCM_source *source)
+{
+  // parameter validation is already done on the REAPER side, so we're sure source is a valid PCM_source
+  return source->GetBitsPerSample();
+}

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -155,6 +155,19 @@ bool CF_GetMediaSourceMetadata(PCM_source *source, const char *name, char *buf, 
   return source->Extended(PCM_SOURCE_EXT_GETMETADATA, (void *)name, (void *)buf, (void *)bufSize) > 0;
 }
 
+bool CF_GetMediaSourceRPP(PCM_source *source, char *buf, const int bufSize)
+{
+  char *rpp = NULL;
+  source->Extended(PCM_SOURCE_EXT_GETASSOCIATED_RPP, &rpp, NULL, NULL);
+  
+  if(rpp && buf) {
+    snprintf(buf, bufSize, "%s", rpp);
+    return true;
+  }
+  else
+    return false;
+}
+
 int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize)
 {
   REAPER_cue cue{};

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -154,3 +154,21 @@ bool CF_GetMediaSourceMetadata(PCM_source *source, const char *name, char *buf, 
 {
   return source->Extended(PCM_SOURCE_EXT_GETMETADATA, (void *)name, (void *)buf, (void *)bufSize) > 0;
 }
+
+int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize)
+{
+  REAPER_cue cue{};
+  const int add = source->Extended(PCM_SOURCE_EXT_ENUMCUES_EX, (void *)index, &cue, NULL);
+
+  if(time)
+    *time = cue.m_time;
+  if(endTime)
+    *endTime = cue.m_endtime;
+  if(isRegion)
+    *isRegion = cue.m_isregion;
+
+  if(name && cue.m_name)
+    snprintf(name, nameSize, "%s", cue.m_name);
+
+  return add ? index + add : 0;
+}

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -35,3 +35,4 @@ bool CF_LocateInExplorer(const char *file);
 int CF_GetMediaSourceBitDepth(PCM_source *);
 bool CF_GetMediaSourceOnline(PCM_source *);
 void CF_SetMediaSourceOnline(PCM_source *, bool set);
+bool CF_GetMediaSourceMetadata(PCM_source *, const char *name, char *buf, int bufSize);

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -33,3 +33,5 @@ const char *CF_GetClipboardBig(WDL_FastString *);
 bool CF_ShellExecute(const char *file, const char *args = NULL);
 bool CF_LocateInExplorer(const char *file);
 int CF_GetMediaSourceBitDepth(PCM_source *);
+bool CF_GetMediaSourceOnline(PCM_source *);
+void CF_SetMediaSourceOnline(PCM_source *, bool set);

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -38,3 +38,4 @@ void CF_SetMediaSourceOnline(PCM_source *, bool set);
 bool CF_GetMediaSourceMetadata(PCM_source *, const char *name, char *buf, int bufSize);
 bool CF_GetMediaSourceRPP(PCM_source *source, char *buf, const int bufSize);
 int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize);
+bool CF_ExportMediaSource(PCM_source *source, const char *file);

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -36,4 +36,5 @@ int CF_GetMediaSourceBitDepth(PCM_source *);
 bool CF_GetMediaSourceOnline(PCM_source *);
 void CF_SetMediaSourceOnline(PCM_source *, bool set);
 bool CF_GetMediaSourceMetadata(PCM_source *, const char *name, char *buf, int bufSize);
+bool CF_GetMediaSourceRPP(PCM_source *source, char *buf, const int bufSize);
 int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize);

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -32,3 +32,4 @@ void CF_GetClipboard(char *buf, int bufSize);
 const char *CF_GetClipboardBig(WDL_FastString *);
 bool CF_ShellExecute(const char *file, const char *args = NULL);
 bool CF_LocateInExplorer(const char *file);
+int CF_GetMediaSourceBitDepth(PCM_source *);

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -36,3 +36,4 @@ int CF_GetMediaSourceBitDepth(PCM_source *);
 bool CF_GetMediaSourceOnline(PCM_source *);
 void CF_SetMediaSourceOnline(PCM_source *, bool set);
 bool CF_GetMediaSourceMetadata(PCM_source *, const char *name, char *buf, int bufSize);
+int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize);


### PR DESCRIPTION
Added the following API functions:

- CF_GetMediaSourceBitDepth
- CF_GetMediaSourceOnline
- CF_SetMediaSourceOnline
- CF_GetMediaSourceMetadata
- CF_GetMediaSourceRPP
- CF_EnumMediaSourceCues
- CF_ExportMediaSource

Test build at https://cfillion.ca/files/sws/pcm-source-api/.