### PR TITLE
Add actions: SWS/NF: Cycle through MIDI recording modes (#994), SWS/NF: Cycle through track automation modes (#995)

### DIFF
--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -871,6 +871,7 @@ error:
 		IMPAPI(GetToggleCommandStateThroughHooks);
 		IMPAPI(GetTooltipWindow);
 		IMPAPI(GetTrack);
+		IMPAPI(GetTrackAutomationMode);
 		IMPAPI(GetTrackGUID);
 		IMPAPI(GetTrackEnvelope);
 		IMPAPI(GetTrackEnvelopeByName);
@@ -1018,6 +1019,7 @@ error:
 		IMPAPI(SetProjectMarker4);
 		IMPAPI(SetTempoTimeSigMarker);
 		IMPAPI(SetTakeStretchMarker);
+		IMPAPI(SetTrackAutomationMode);
 		IMPAPI(SetTrackSelected);
 		IMPAPI(SetTrackSendUIPan);
 		IMPAPI(SetTrackSendUIVol);

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,8 @@
+Actions:
++New actions (Main section):
+ - Issue 994: SWS/NF: Cycle through MIDI recording modes (also available in ME section)
+ - Issue 995: SWS/NF: Cycle through track automation modes
+
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!
 


### PR DESCRIPTION
closes #994, closes #995

Test build (Win x64):
https://www.dropbox.com/s/namu009mtgtvupt/reaper_sws64.dll?dl=1
