### PR TITLE
Add project/global save actions

### DIFF
--- a/Menus.cpp
+++ b/Menus.cpp
@@ -304,7 +304,7 @@ void SWSCreateExtensionsMenu(HMENU hMenu)
 	AddSubMenu(hMenu, hStartupSubMenu, __LOCALIZE("Startup actions", "sws_ext_menu"));
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Set project startup action...", "sws_ext_menu"), NamedCommandLookup("_S&M_SET_PRJ_ACTION"));
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Clear project startup action", "sws_ext_menu"), NamedCommandLookup("_S&M_CLR_PRJ_ACTION"));
-  AddToMenu(hStartupSubMenu, __LOCALIZE("Set project save action...", "sws_ext_menu"), NamedCommandLookup("_S&M_SET_PRJ_SAVE_ACTION"));
+	AddToMenu(hStartupSubMenu, __LOCALIZE("Set project save action...", "sws_ext_menu"), NamedCommandLookup("_S&M_SET_PRJ_SAVE_ACTION"));
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Clear project save action", "sws_ext_menu"), NamedCommandLookup("_S&M_CLR_PRJ_SAVE_ACTION"));
 	AddToMenu(hStartupSubMenu, SWS_SEPARATOR, 0);
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Set global startup action...", "sws_ext_menu"), NamedCommandLookup("_S&M_SET_STARTUP_ACTION"));

--- a/Menus.cpp
+++ b/Menus.cpp
@@ -304,9 +304,13 @@ void SWSCreateExtensionsMenu(HMENU hMenu)
 	AddSubMenu(hMenu, hStartupSubMenu, __LOCALIZE("Startup actions", "sws_ext_menu"));
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Set project startup action...", "sws_ext_menu"), NamedCommandLookup("_S&M_SET_PRJ_ACTION"));
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Clear project startup action", "sws_ext_menu"), NamedCommandLookup("_S&M_CLR_PRJ_ACTION"));
+  AddToMenu(hStartupSubMenu, __LOCALIZE("Set project save action...", "sws_ext_menu"), NamedCommandLookup("_S&M_SET_PRJ_SAVE_ACTION"));
+	AddToMenu(hStartupSubMenu, __LOCALIZE("Clear project save action", "sws_ext_menu"), NamedCommandLookup("_S&M_CLR_PRJ_SAVE_ACTION"));
 	AddToMenu(hStartupSubMenu, SWS_SEPARATOR, 0);
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Set global startup action...", "sws_ext_menu"), NamedCommandLookup("_S&M_SET_STARTUP_ACTION"));
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Clear global startup action", "sws_ext_menu"), NamedCommandLookup("_S&M_CLR_STARTUP_ACTION"));
+	AddToMenu(hStartupSubMenu, __LOCALIZE("Set global save action...", "sws_ext_menu"), NamedCommandLookup("_S&M_SET_SAVE_ACTION"));
+	AddToMenu(hStartupSubMenu, __LOCALIZE("Clear global save action", "sws_ext_menu"), NamedCommandLookup("_S&M_CLR_SAVE_ACTION"));
 	AddToMenu(hStartupSubMenu, SWS_SEPARATOR, 0);
 	AddToMenu(hStartupSubMenu, __LOCALIZE("Show project/global startup actions...", "sws_ext_menu"), NamedCommandLookup("_S&M_SHOW_PRJ_ACTION"));
 

--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -220,10 +220,14 @@ static COMMAND_T s_cmdTable[] =
 
 	{ { DEFACCEL, "SWS/S&M: Set project startup action" }, "S&M_SET_PRJ_ACTION", SetStartupAction, NULL, ProjectStartupAction},
 	{ { DEFACCEL, "SWS/S&M: Clear project startup action" }, "S&M_CLR_PRJ_ACTION", ClearStartupAction, NULL, ProjectStartupAction},
+	{ { DEFACCEL, "SWS/S&M: Set project save action" }, "S&M_SET_PRJ_SAVE_ACTION", SetStartupAction, NULL, ProjectSaveAction},
+	{ { DEFACCEL, "SWS/S&M: Clear project save action" }, "S&M_CLR_PRJ_SAVE_ACTION", ClearStartupAction, NULL, ProjectSaveAction},
 	{ { DEFACCEL, "SWS/S&M: Show project/global startup actions" }, "S&M_SHOW_PRJ_ACTION", ShowStartupActions, NULL, },
 	// not project actions, but shared code
 	{ { DEFACCEL, "SWS/S&M: Set global startup action" }, "S&M_SET_STARTUP_ACTION", SetStartupAction, NULL, GlobalStartupAction},
 	{ { DEFACCEL, "SWS/S&M: Clear global startup action" }, "S&M_CLR_STARTUP_ACTION", ClearStartupAction, NULL, GlobalStartupAction},
+	{ { DEFACCEL, "SWS/S&M: Set global save action" }, "S&M_SET_SAVE_ACTION", SetStartupAction, NULL, GlobalSaveAction},
+	{ { DEFACCEL, "SWS/S&M: Clear global save action" }, "S&M_CLR_SAVE_ACTION", ClearStartupAction, NULL, GlobalSaveAction},
 
 	// Images ------------------------------------------------------------
 	{ { DEFACCEL, "SWS/S&M: Open/close image window" }, "S&M_OPEN_IMAGEVIEW", OpenImageWnd, NULL, 0, IsImageWndDisplayed},

--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -218,12 +218,12 @@ static COMMAND_T s_cmdTable[] =
 	{ { DEFACCEL, "SWS/S&M: Insert silence (measures.beats)" }, "S&M_INSERT_SILENCE_MB", InsertSilence, NULL, 1},
 	{ { DEFACCEL, "SWS/S&M: Insert silence (samples)" }, "S&M_INSERT_SILENCE_SMP", InsertSilence, NULL, 2},
 
-	{ { DEFACCEL, "SWS/S&M: Set project startup action" }, "S&M_SET_PRJ_ACTION", SetStartupAction, NULL, 0},
-	{ { DEFACCEL, "SWS/S&M: Clear project startup action" }, "S&M_CLR_PRJ_ACTION", ClearStartupAction, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Set project startup action" }, "S&M_SET_PRJ_ACTION", SetStartupAction, NULL, ProjectStartupAction},
+	{ { DEFACCEL, "SWS/S&M: Clear project startup action" }, "S&M_CLR_PRJ_ACTION", ClearStartupAction, NULL, ProjectStartupAction},
 	{ { DEFACCEL, "SWS/S&M: Show project/global startup actions" }, "S&M_SHOW_PRJ_ACTION", ShowStartupActions, NULL, },
 	// not project actions, but shared code
-	{ { DEFACCEL, "SWS/S&M: Set global startup action" }, "S&M_SET_STARTUP_ACTION", SetStartupAction, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Clear global startup action" }, "S&M_CLR_STARTUP_ACTION", ClearStartupAction, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Set global startup action" }, "S&M_SET_STARTUP_ACTION", SetStartupAction, NULL, GlobalStartupAction},
+	{ { DEFACCEL, "SWS/S&M: Clear global startup action" }, "S&M_CLR_STARTUP_ACTION", ClearStartupAction, NULL, GlobalStartupAction},
 
 	// Images ------------------------------------------------------------
 	{ { DEFACCEL, "SWS/S&M: Open/close image window" }, "S&M_OPEN_IMAGEVIEW", OpenImageWnd, NULL, 0, IsImageWndDisplayed},
@@ -1157,7 +1157,7 @@ void OnInitTimer()
 {
 	plugin_register("-timer",(void*)OnInitTimer); // unregister timer (single call)
 	CAsInit();
-	GlobalStartupActionTimer();
+	ExecStartupAction(GlobalStartupAction);
 }
 
 int SNM_Init(reaper_plugin_info_t* _rec)

--- a/SnM/SnM_Project.cpp
+++ b/SnM/SnM_Project.cpp
@@ -222,10 +222,23 @@ SWSProjConfig<WDL_FastString> g_prjSaveActions;
 WDL_FastString g_globalStartupAction;
 WDL_FastString g_globalSaveAction;
 
-struct ProjActionExtLine { StartupActionType type; const char *extName; };
-static const ProjActionExtLine g_projActionExtLines[] = {
-	{ProjectStartupAction, "S&M_PROJACTION"},
-	{ProjectSaveAction, "S&M_PROJSAVEACTION"},
+struct StartupAction {
+  enum Scope {
+    ProjectScope,
+    GlobalScope,
+  };
+
+  const char *key;
+  Scope scope;
+};
+
+typedef map<StartupActionType, StartupAction> StartupActionMap;
+
+static const StartupActionMap g_startupActions{
+	{ProjectStartupAction, {"S&M_PROJACTION",      StartupAction::ProjectScope}},
+	{ProjectSaveAction,    {"S&M_PROJSAVEACTION",  StartupAction::ProjectScope}},
+	{GlobalStartupAction,  {"GlobalStartupAction", StartupAction::GlobalScope}},
+	{GlobalSaveAction,     {"GlobalSaveAction",    StartupAction::GlobalScope}},
 };
 
 static WDL_FastString *GetStartupAction(const StartupActionType type)
@@ -295,16 +308,17 @@ static void DoSetStartupAction(const COMMAND_T *ct, const char *value)
 	const StartupActionType type = static_cast<StartupActionType>(ct->user);
 	GetStartupAction(type)->Set(value);
 
-	switch(type) {
-	case ProjectStartupAction:
-	case ProjectSaveAction:
+	const StartupActionMap::const_iterator it = g_startupActions.find(type);
+
+	if(it == g_startupActions.end())
+		return;
+
+	switch(it->second.scope) {
+	case StartupAction::ProjectScope:
 		Undo_OnStateChangeEx2(NULL, SWS_CMD_SHORTNAME(ct), UNDO_STATE_MISCCFG, -1);
 		break;
-	case GlobalStartupAction:
-		WritePrivateProfileString("Misc", "GlobalStartupAction", value, g_SNM_IniFn.Get());
-		break;
-	case GlobalSaveAction:
-		WritePrivateProfileString("Misc", "GlobalSaveAction", value, g_SNM_IniFn.Get());
+	case StartupAction::GlobalScope:
+		WritePrivateProfileString("Misc", it->second.key, value, g_SNM_IniFn.Get());
 		break;
 	}
 }
@@ -359,22 +373,18 @@ void ClearStartupAction(COMMAND_T* _ct)
 
 void ShowStartupActions(COMMAND_T* _ct)
 {
-	const StartupActionType lines[] = {
-		ProjectStartupAction, ProjectSaveAction,
-		GlobalStartupAction, GlobalSaveAction,
-	};
-
 	WDL_FastString msg;
 
-	for (const StartupActionType type : lines) {
-		const char *name = GetStartupActionName(type);
+	for (const StartupActionMap::value_type &action : g_startupActions) {
+		const char *type = GetStartupActionName(action.first);
+		WDL_FastString *value = GetStartupAction(action.first);
 
-		if (const int cmdId = SNM_NamedCommandLookup(GetStartupAction(type)->Get())) {
-			const char *action = kbd_getTextFromCmd(cmdId, NULL);
-			msg.AppendFormatted(512, __LOCALIZE_VERFMT("'%s' is defined as %s action.\r\n", "sws_startup_action"), action, name);
+		if (const int cmdId = SNM_NamedCommandLookup(value->Get())) {
+			const char *name = kbd_getTextFromCmd(cmdId, NULL);
+			msg.AppendFormatted(512, __LOCALIZE_VERFMT("'%s' is defined as %s action.\r\n", "sws_startup_action"), name, type);
 		}
 		else
-			msg.AppendFormatted(512, __LOCALIZE_VERFMT("No %s action is defined.\r\n", "sws_startup_action"), name);
+			msg.AppendFormatted(512, __LOCALIZE_VERFMT("No %s action is defined.\r\n", "sws_startup_action"), type);
 	}
 
 	MessageBox(GetMainHwnd(), msg.Get(), SWS_CMD_SHORTNAME(_ct), MB_OK);
@@ -386,14 +396,14 @@ static bool ProcessExtensionLine(const char *line, ProjectStateContext *ctx, boo
 	if (lp.parse(line) || lp.getnumtokens() < 1)
 		return false;
 
-	for(const ProjActionExtLine &line : g_projActionExtLines) {
-		if (strcmp(lp.gettoken_str(0), line.extName))
+	for(const StartupActionMap::value_type &action : g_startupActions) {
+		if (action.second.scope != StartupAction::ProjectScope || strcmp(lp.gettoken_str(0), action.second.key))
 			continue;
 
-		WDL_FastString *value = GetStartupAction(line.type);
+		WDL_FastString *value = GetStartupAction(action.first);
 		value->Set(lp.gettoken_str(1));
 
-		if (line.type == ProjectStartupAction && !isUndo && value->GetLength() && IsActiveProjectInLoadSave())
+		if (action.first == ProjectStartupAction && !isUndo && value->GetLength() && IsActiveProjectInLoadSave())
 			plugin_register("timer", (void *)&ExecStartupActionTimer<ProjectStartupAction>);
 
 		return true;
@@ -409,16 +419,17 @@ static void SaveExtensionConfig(ProjectStateContext *ctx, bool isUndo, struct pr
 
 	const bool runActions = !isUndo && IsActiveProjectInLoadSave();
 
-	for (const ProjActionExtLine &line : g_projActionExtLines) {
-		WDL_FastString *value = GetStartupAction(line.type);
-		if (!value->GetLength())
+	for (const StartupActionMap::value_type &action : g_startupActions) {
+		WDL_FastString *value = GetStartupAction(action.first);
+
+		if (action.second.scope != StartupAction::ProjectScope || !value->GetLength())
 			continue;
 
 		char chunk[SNM_MAX_CHUNK_LINE_LENGTH];
-		if (_snprintfStrict(chunk, sizeof(chunk), "%s %s", line.extName, value->Get()) > 0)
+		if (_snprintfStrict(chunk, sizeof(chunk), "%s %s", action.second.key, value->Get()) > 0)
 			ctx->AddLine("%s", chunk);
 
-		if (line.type == ProjectSaveAction && runActions)
+		if (runActions && action.first == ProjectSaveAction)
 			plugin_register("timer", (void *)&ExecStartupActionTimer<ProjectSaveAction>);
 	}
 
@@ -441,14 +452,16 @@ static project_config_extension_t s_projectconfig = {
 
 void SNM_ProjectInit()
 {
-  char buf[SNM_MAX_ACTION_CUSTID_LEN]="";
-  GetPrivateProfileString("Misc", "GlobalStartupAction", "", buf, sizeof(buf), g_SNM_IniFn.Get());
-  g_globalStartupAction.Set(buf);
+	char buf[SNM_MAX_ACTION_CUSTID_LEN];
 
-  GetPrivateProfileString("Misc", "GlobalSaveAction", "", buf, sizeof(buf), g_SNM_IniFn.Get());
-  g_globalSaveAction.Set(buf);
+	for (const StartupActionMap::value_type &action : g_startupActions) {
+		if (action.second.scope == StartupAction::GlobalScope) {
+			GetPrivateProfileString("Misc", action.second.key, "", buf, sizeof(buf), g_SNM_IniFn.Get());
+			GetStartupAction(action.first)->Set(buf);
+		}
+	}
 
-  plugin_register("projectconfig", &s_projectconfig);
+	plugin_register("projectconfig", &s_projectconfig);
 }
 
 void SNM_ProjectExit()

--- a/SnM/SnM_Project.h
+++ b/SnM/SnM_Project.h
@@ -55,7 +55,12 @@ protected:
 
 void SelectProject(COMMAND_T* _ct, int _val, int _valhw, int _relmode, HWND _hwnd);
 
-void GlobalStartupActionTimer();
+enum StartupActionType {
+	ProjectStartupAction,
+	GlobalStartupAction,
+};
+
+void ExecStartupAction(StartupActionType);
 void SetStartupAction(COMMAND_T*);
 void ClearStartupAction(COMMAND_T*);
 void ShowStartupActions(COMMAND_T*);

--- a/SnM/SnM_Project.h
+++ b/SnM/SnM_Project.h
@@ -57,14 +57,16 @@ void SelectProject(COMMAND_T* _ct, int _val, int _valhw, int _relmode, HWND _hwn
 
 enum StartupActionType {
 	ProjectStartupAction,
+	ProjectSaveAction,
 	GlobalStartupAction,
+	GlobalSaveAction,
 };
 
 void ExecStartupAction(StartupActionType);
 void SetStartupAction(COMMAND_T*);
 void ClearStartupAction(COMMAND_T*);
 void ShowStartupActions(COMMAND_T*);
-int SNM_ProjectInit();
+void SNM_ProjectInit();
 void SNM_ProjectExit();
 
 void InsertSilence(COMMAND_T*);


### PR DESCRIPTION
There are a few behavior differences with the previous implementations (they didn't seem useful enough to keep):

- Removed confirmation after setting an action
- Removed the display of current project name
- Now keeps the setting (empty) in the .ini file when clearing the action

This code should allow adding all kinds of project events in the future with less code & data duplication than before.