### PR TITLE
ReaConsole: Redraw the status label when resizing the window on Windows

### DIFF
--- a/Console/Console.cpp
+++ b/Console/Console.cpp
@@ -992,6 +992,13 @@ void ReaConsoleWnd::OnCommand(WPARAM wParam, LPARAM lParam)
 	}
 }
 
+void ReaConsoleWnd::OnResize()
+{
+#ifdef _WIN32
+	InvalidateRect(GetDlgItem(m_hwnd, IDC_STATUS), NULL, 0);
+#endif
+}
+
 void ReaConsoleWnd::ShowConsole()
 {
 	Show(false, true);

--- a/Console/Console.h
+++ b/Console/Console.h
@@ -101,6 +101,7 @@ protected:
 	void OnInitDlg();
 	HMENU OnContextMenu(int x, int y, bool* wantDefaultItems);
 	int OnKey(MSG* msg, int iKeyState);
+	void OnResize();
 private:
 	char m_strCmd[256];
 	char* m_pTrackId;


### PR DESCRIPTION
Fixes issue #1047.