### PR TITLE
Fix parsing item state chunk lines bigger than 255 chars

### DIFF
--- a/Fingers/RprNode.cpp
+++ b/Fingers/RprNode.cpp
@@ -88,13 +88,11 @@ void RprParentNode::removeChild(int index)
 
 static std::string getTrimmedLine(std::istringstream &iss)
 {
+    while(iss.peek() == '\x20') iss.get();
+
     std::string line;
     std::getline(iss, line);
-    size_t offset = 0;
-    if(line[0] == '\n')
-        offset++;
-    while(line[offset] == ' ') offset++;
-    return line.substr(offset);
+    return line;
 }
 
 void RprParentNode::toReaper(std::ostringstream &oss, int indent)

--- a/Fingers/RprNode.cpp
+++ b/Fingers/RprNode.cpp
@@ -88,15 +88,13 @@ void RprParentNode::removeChild(int index)
 
 static std::string getTrimmedLine(std::istringstream &iss)
 {
-    char lineBuffer[256];
-    iss.getline(lineBuffer, 256);
     std::string line;
-    int offset = 0;
-    if(lineBuffer[0] == '\n')
+    std::getline(iss, line);
+    size_t offset = 0;
+    if(line[0] == '\n')
         offset++;
-    while(lineBuffer[offset] == ' ') offset++;
-    line = std::string(lineBuffer + offset);
-    return line;
+    while(line[offset] == ' ') offset++;
+    return line.substr(offset);
 }
 
 void RprParentNode::toReaper(std::ostringstream &oss, int indent)


### PR DESCRIPTION
Fixes https://github.com/reaper-oss/sws/issues/912#issuecomment-426892230.

REAPER already seems to give trimmed state chunks so I don't know why the code re-trims them. If this was changed at some point, maybe this code could be removed now?