### PR TITLE
Remove useless code vulnerable to buffer overflows

### DIFF
--- a/Xenakios/Parameters.cpp
+++ b/Xenakios/Parameters.cpp
@@ -97,33 +97,19 @@ void ReadINIfile()
 	delete [] g_external_app_paths.PathToAudioEditor1; g_external_app_paths.PathToAudioEditor1 = NULL;
 	delete [] g_external_app_paths.PathToAudioEditor2; g_external_app_paths.PathToAudioEditor2 = NULL;
 
-	const char* cMenuText;
-	SWSGetCommandID(DoLaunchExtTool, 1, &cMenuText);
 	GetPrivateProfileString("XENAKIOSCOMMANDS","EXTERNALTOOL1PATH","",resultString,512,g_XenIniFilename.Get());
 	if (resultString[0])
 	{
 		g_external_app_paths.PathToTool1=new char[strlen(resultString)+sizeof(char)];
 		strcpy(g_external_app_paths.PathToTool1, resultString);
-		char cExeName[100];
-		ExtractFileNameEx(resultString, cExeName, false);
-		_snprintf(g_external_app_paths.Tool1MenuText, 100, "%s : %s", cMenuText, cExeName);
 	}
-	else
-		lstrcpyn(g_external_app_paths.Tool1MenuText, cMenuText ? cMenuText : "", 100);
 
-
-	SWSGetCommandID(DoLaunchExtTool, 2, &cMenuText);
 	GetPrivateProfileString("XENAKIOSCOMMANDS","EXTERNALTOOL2PATH","",resultString,512,g_XenIniFilename.Get());
 	if (resultString[0])
 	{
 		g_external_app_paths.PathToTool2=new char[strlen(resultString)+sizeof(char)];
 		strcpy(g_external_app_paths.PathToTool2, resultString);
-		char cExeName[100];
-		ExtractFileNameEx(resultString, cExeName, false);
-		_snprintf(g_external_app_paths.Tool2MenuText, 100, "%s : %s", cMenuText, cExeName);
 	}
-	else
-		lstrcpyn(g_external_app_paths.Tool2MenuText, cMenuText ? cMenuText : "", 100);
 
 	GetPrivateProfileString("XENAKIOSCOMMANDS","EXTERNALEDITOR1PATH","",resultString,512,g_XenIniFilename.Get());
 	if (resultString[0])
@@ -398,12 +384,6 @@ WDL_DLGRET ExoticParamsDlgProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 						delete [] g_external_app_paths.PathToTool1;
 						g_external_app_paths.PathToTool1 = new char[strlen(cFile)+1];
 						strcpy(g_external_app_paths.PathToTool1, cFile);
-
-						const char* cMenuText;
-						SWSGetCommandID(DoLaunchExtTool, 1, &cMenuText);
-						char cExeName[100];
-						ExtractFileNameEx(cFile, cExeName, false);
-						_snprintf(g_external_app_paths.Tool1MenuText, 100, "%s : %s", cMenuText, cExeName);
 						free(cFile);
 					}
 					SetDlgItemText(hwnd, IDC_EXTTOOLPATH1, g_external_app_paths.PathToTool1);
@@ -417,12 +397,6 @@ WDL_DLGRET ExoticParamsDlgProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 						delete [] g_external_app_paths.PathToTool2;
 						g_external_app_paths.PathToTool2 = new char[strlen(cFile)+1];
 						strcpy(g_external_app_paths.PathToTool2, cFile);
-
-						const char* cMenuText;
-						SWSGetCommandID(DoLaunchExtTool, 2, &cMenuText);
-						char cExeName[100];
-						ExtractFileNameEx(cFile, cExeName, false);
-						_snprintf(g_external_app_paths.Tool2MenuText, 100, "%s : %s", cMenuText, cExeName);
 						free(cFile);
 					}
 					SetDlgItemText(hwnd, IDC_EXTTOOLPATH2, g_external_app_paths.PathToTool2);

--- a/Xenakios/Parameters.h
+++ b/Xenakios/Parameters.h
@@ -63,8 +63,6 @@ typedef struct t_external_app_paths
 	char *PathToTool2;
 	char *PathToAudioEditor1;
 	char *PathToAudioEditor2;
-	char Tool1MenuText[100];
-	char Tool2MenuText[100];
 } t_external_app_paths;
 
 extern t_command_params g_command_params;


### PR DESCRIPTION
A buffer overflow can be triggered by setting an external tool command with a filename larger than 100 characters. The result of the vulnerable code (`Tool{1,2}MenuText`) is actually unused since 2011 (commit 447f82db02108402fc039f7dfd411cefa87f3332). This PR removes it entirely.

The other uses of `ExtractFileNameEx` are safe-ish (but fragile) because the destination buffer is larger than a filename can *currently* be on common filesystems.