### PR TITLE
Fix quantize actions moving items to incorrect positions or hanging in some cases when the grid line spacing is set to Frames

### DIFF
--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -212,38 +212,6 @@ void AppendLine (WDL_FastString& str, const char* line)
 	str.Append("\n");
 }
 
-void AdvanceBySecond (int direction, int& hours, int& minutes, int& seconds)
-{
-	if (direction > 0)
-	{
-		++seconds;
-		if (seconds >= 60)
-		{
-			seconds = 0;
-			++minutes;
-			if (minutes >= 60)
-			{
-				minutes = 0;
-				++hours;
-			}
-		}
-
-	}
-	else
-	{
-		--seconds;
-		if (seconds < 0)
-		{
-			seconds = 59;
-			--minutes;
-			if (minutes < 0)
-			{
-				minutes = 59;
-				--hours;
-			}
-		}
-	}
-}
 const char* strstr_last (const char* haystack, const char* needle)
 {
 	if (!haystack || !needle || *needle == '\0')
@@ -475,39 +443,6 @@ void GetTimeInfoFromPosition (double position, int* hours, int* minutes, int* se
 	WritePtr(minutes, ((str[1].GetLength() > 0) ? atoi(str[1].Get()) : 0));
 	WritePtr(seconds, ((str[2].GetLength() > 0) ? atoi(str[2].Get()) : 0));
 	WritePtr(frames,  ((str[3].GetLength() > 0) ? atoi(str[3].Get()) : 0));
-}
-
-void AdvanceByFrame (int direction, int& hours, int& minutes, int& seconds, int& frames)
-{
-	bool dropFrame;
-	int maxFrame = (int)TimeMap_curFrameRate(NULL, &dropFrame);
-
-	if (direction > 0)
-	{
-		++frames;
-		if (frames > maxFrame)
-		{
-			AdvanceBySecond(direction, hours, minutes, seconds);
-			frames = (dropFrame) ? ((seconds == 0 && minutes % 10 != 0) ? 2 : 0) : (0);
-		}
-	}
-	else
-	{
-		if (frames == 0 && seconds == 0 && minutes == 0 && hours == 0)
-		{
-			return;
-		}
-		else
-		{
-			int minFrame = (dropFrame) ? ((seconds == 0 && minutes % 10 != 0) ? 2 : 0) : (0);
-			--frames;
-			if (frames < minFrame)
-			{
-				AdvanceBySecond(direction, hours, minutes, seconds);
-				frames = maxFrame;
-			}
-		}
-	}
 }
 
 void GetSetLastAdjustedSend (bool set, MediaTrack** track, int* sendId, BR_EnvType* type)
@@ -1751,7 +1686,7 @@ double GetNextGridDiv (double position)
 	{
 		int hours, minutes, seconds, frames;
 		GetTimeInfoFromPosition(position, &hours, &minutes, &seconds, &frames);
-		AdvanceByFrame(1, hours, minutes, seconds, frames);
+		++frames;
 
 		nextGridPosition = GetPositionFromTimeInfo(hours, minutes, seconds, frames);
 	}
@@ -1869,7 +1804,7 @@ double GetPrevGridDiv (double position)
 		double currentFramePos = GetPositionFromTimeInfo(hours, minutes, seconds, frames);
 		if (IsEqual(currentFramePos, position, SNM_FUDGE_FACTOR))
 		{
-			AdvanceByFrame(-1, hours, minutes, seconds, frames);
+			--frames;
 			prevGridDivPos = GetPositionFromTimeInfo(hours, minutes, seconds, frames);
 		}
 		else

--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -454,7 +454,7 @@ double GetPositionFromTimeInfo (int hours, int minutes, int seconds, int frames)
 	WDL_FastString timeString;
 	timeString.AppendFormatted(256, "%d:%d:%d:%d", hours, minutes, seconds, frames);
 
-	return parse_timestr_pos(timeString.Get(), 5);
+	return parse_timestr_len(timeString.Get(), 0, 5);
 }
 
 void GetTimeInfoFromPosition (double position, int* hours, int* minutes, int* seconds, int* frames)

--- a/Breeder/BR_Util.h
+++ b/Breeder/BR_Util.h
@@ -83,7 +83,6 @@ double AltAtof (char* str);
 bool IsFraction (char* str, double& convertedFraction);
 void ReplaceAll (string& str, string oldStr, string newStr);
 void AppendLine (WDL_FastString& str, const char* line);
-void AdvanceBySecond (int direction, int& hours, int& minutes, int& seconds);
 const char* strstr_last (const char* haystack, const char* needle);
 template <typename T> bool WritePtr (T* ptr, T val)  {if (ptr){*ptr = val; return true;} return false;}
 template <typename T> bool ReadPtr  (T* ptr, T& val) {if (ptr){val = *ptr; return true;} return false;}
@@ -107,7 +106,6 @@ double EndOfProject (bool markers, bool regions);
 double GetMidiOscVal (double min, double max, double step, double currentVal, int commandVal, int commandValhw, int commandRelmode);
 double GetPositionFromTimeInfo (int hours, int minutes, int seconds, int frames);
 void GetTimeInfoFromPosition (double position, int* hours, int* minutes, int* seconds, int* frames);
-void AdvanceByFrame (int direction, int& hours, int& minutes, int& seconds, int& frames);
 void GetSetLastAdjustedSend (bool set, MediaTrack** track, int* sendId, BR_EnvType* type);
 void GetSetFocus (bool set, HWND* hwnd, int* context);
 void SetAllCoordsToZero (RECT* r);


### PR DESCRIPTION
1. The quantized position would contain the project's start time offset. Items would be moved to an incorrect position or it would hang if the position comes after the item's original end (forever trying to find a smaller position—see the next bug).
2. Finding the previous frame starting at exactly another frame's position was broken (it returned the given frame unchanged). The various SWS quantize actions would freeze forever attempting to find the previous frame if the next frame comes after the item's end.

I removed `AdvanceByFrame` because it seems to be doing the same job (but with bugs) that `GetPositionFromTimeInfo` does via REAPER's `parse_timestr_len`. This probably needs more testing just in case especially with the [29.97DF](https://larryjordan.com/articles/technique-drop-frame-vs-non-drop-frame-timecode/) framerate.