### PR TITLE
Loudness fixes

### DIFF
--- a/libebur128/ebur128.cpp
+++ b/libebur128/ebur128.cpp
@@ -91,7 +91,7 @@ struct ebur128_state_internal {
   size_t     resampler_buffer_output_frames;
 };
 
-static double relative_gate = -20.0;
+static double relative_gate = -10.0;
 
 /* Those will be calculated when initializing the library */
 static double relative_gate_factor;

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,11 @@
+Fixes:
++Loudness:
+ - Revert (mistakenly) changing integrated Loudness relative gate threshold from -10.0 LU to -20.0 LU in SWS v2.9.8 (https://github.com/jiixyj/libebur128/issues/92#issuecomment-426889385|technical explaination|)
+ - Fix getting project sample rate
+ - Don't apply item vol. and pan/vol. envelope correction beyond actual audio data (Issue 1074)
+ - Fix item Loudness analysis if take contains vol. envelope and item position not 0.0 (thanks X-Raym!) (Issue 957, https://github.com/reaper-oss/sws/issues/957#issuecomment-371233030|details|)
+ - Pan/vol. envelope correction is now sample accurate (instead of being processed in blocks)
+
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!
 


### PR DESCRIPTION
- Revert (mistakenly) changing integrated Loudness relative gate threshold from -10.0 LU to -20.0 LU in SWS v2.9.8

- Fix getting project sample rate

- Don't apply item vol. and pan/vol. envelope correction beyond actual audio data (fixes #1074)

- Fix item Loudness analysis if take contains volume envelope (closes #957)
(moved from https://github.com/reaper-oss/sws/pull/962/commits/3674f7595629f32e9e4d14af107f697de0c2de47 to https://github.com/reaper-oss/sws/commit/bced3384b1627ab177750fa4b98283447d1caa17 to avoid merge conflict)

- Pan/vol. envelope correction is now sample accurate (instead of being processed in blocks)


