### PR TITLE
FNG Groove tool: Add action "SWS/FNG: Apply selected groove(...)"

### DIFF
--- a/Fingers/GrooveCommands.cpp
+++ b/Fingers/GrooveCommands.cpp
@@ -114,6 +114,15 @@ int IsGrooveDialogOpen()
     return me->GetGrooveDialog()->IsWndVisible();
 }
 
+static void ApplySelectedGroove(COMMAND_T* ct, int val, int valhw, int relmode, HWND hwnd)
+{
+	GrooveTemplateHandler *me = GrooveTemplateHandler::Instance();
+	if (!me->GetGrooveDialog()->IsWndVisible())
+		return;
+
+	me->GetGrooveDialog()->ApplySelectedGroove();
+}
+
 //!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
 void GrooveCommands::Init()
 {
@@ -139,6 +148,7 @@ void GrooveCommands::Init()
 	{
 		{ { DEFACCEL, "SWS/FNG: Apply groove to selected MIDI notes (within 16th)" }, "FNG_ME_APPLY_MIDI_GROOVE_16",  NULL, NULL, 16, NULL, 32060, ApplyGrooveInMidiEditor},
 		{ { DEFACCEL, "SWS/FNG: Apply groove to selected MIDI notes (within 32nd)" }, "FNG_ME_APPLY_MIDI_GROOVE_32",  NULL, NULL, 32, NULL, 32060, ApplyGrooveInMidiEditor},
+		{ { DEFACCEL, "SWS/FNG: Apply selected groove (use curent settings from opened groove tool)" }, "FNG_APPLY_SEL_GROOVE",  NULL, NULL, NULL, NULL, NULL, ApplySelectedGroove},
 		{ {}, LAST_COMMAND, },
 	};
 	SWSRegisterCommands(g_commandTable);

--- a/Fingers/GrooveDialog.h
+++ b/Fingers/GrooveDialog.h
@@ -6,6 +6,7 @@ class GrooveDialog : public SWS_DockWnd
 public:
 	GrooveDialog();
 	void Refresh() { if (IsValidWindow()) RefreshGrooveList(); }
+	void ApplySelectedGroove(); // NF: made public, so we can call from action list
 	virtual ~GrooveDialog();
 private:
 	// SWS_DockWnd overrides
@@ -18,7 +19,6 @@ private:
 	void OnGrooveFolderButton(WORD wParam, LPARAM lParam);
 	void OnStrengthChange(WORD wParam, LPARAM lParam);
 	void OnVelStrengthChange(WORD wParam, LPARAM lParam);
-	void ApplySelectedGroove();
 	void RefreshGrooveList();
 
 	std::string currentDir;

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,7 @@
+Actions:
++New actions (Main section):
+ - SWS/FNG: Apply selected groove (use curent settings from opened groove tool)
+
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!
 


### PR DESCRIPTION
Adds action (Main section):
SWS/FNG: Apply selected groove (use curent settings from opened groove tool)

This topic came up [here](https://forum.cockos.com/showpost.php?p=2065352&postcount=2496).
It's not 100% what user requests (because Groove tool must be open for the new action to work), but the problem is the Groove tool doesn't retain selected groove on closing/reopening (see gif below) and I don't know how to change this currently, so I think this action is at least better than nothing for now.
If someone comes up with a better approach, always welcomed.

[gif](https://user-images.githubusercontent.com/7658194/49347247-e4472900-f69c-11e8-84e3-044fd94dc294.gif)


