### PR TITLE
RMS:   rename 'analyze and display item peak and rms' (add 'entire item')

### DIFF
--- a/Misc/Analysis.cpp
+++ b/Misc/Analysis.cpp
@@ -552,15 +552,15 @@ static void SetRMSOptions(COMMAND_T*)
 //!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
 static COMMAND_T g_commandTable[] =
 {
-	{ { DEFACCEL, "SWS: Analyze and display item peak and RMS" },	"SWS_ANALYZEITEM",		DoAnalyzeItem,		NULL, },
-	{ { DEFACCEL, "SWS: Move cursor to item peak sample" },			"SWS_FINDITEMPEAK",		FindItemPeak,		NULL, },
-	{ { DEFACCEL, "SWS: Organize items by peak" },					"SWS_PEAKORGANIZE",		OrganizeByVol,		NULL, 0, },
-	{ { DEFACCEL, "SWS: Organize items by RMS (entire item)" },		"SWS_RMSORGANIZE",		OrganizeByVol,		NULL, 1, },
-	{ { DEFACCEL, "SWS: Organize items by peak RMS" },				"SWS_RMSPEAKORGANIZE",	OrganizeByVol,		NULL, 2, },
-	{ { DEFACCEL, "SWS: Normalize items to RMS (entire item)" },	"SWS_NORMRMS",			DoRMSNormalize,		NULL, 0, },
-	{ { DEFACCEL, "SWS: Normalize item(s) to peak RMS" },			"SWS_NORMPEAKRMS",		DoRMSNormalize,		NULL, 1, },
-	{ { DEFACCEL, "SWS: Normalize items to overall peak RMS" },		"SWS_NORMPEAKRMSALL",	DoRMSNormalize,		NULL, 2, },
-	{ { DEFACCEL, "SWS: Set RMS analysis/normalize options" },		"SWS_SETRMSOPTIONS",	SetRMSOptions,		NULL, },
+    { { DEFACCEL, "SWS: Analyze and display item peak and RMS (entire item)" }, "SWS_ANALYZEITEM",     DoAnalyzeItem,  NULL, },
+    { { DEFACCEL, "SWS: Move cursor to item peak sample" },                     "SWS_FINDITEMPEAK",    FindItemPeak,   NULL, },
+    { { DEFACCEL, "SWS: Organize items by peak" },                              "SWS_PEAKORGANIZE",    OrganizeByVol,  NULL, 0, },
+    { { DEFACCEL, "SWS: Organize items by RMS (entire item)" },                 "SWS_RMSORGANIZE",     OrganizeByVol,  NULL, 1, },
+    { { DEFACCEL, "SWS: Organize items by peak RMS" },                          "SWS_RMSPEAKORGANIZE", OrganizeByVol,  NULL, 2, },
+    { { DEFACCEL, "SWS: Normalize items to RMS (entire item)" },                "SWS_NORMRMS",         DoRMSNormalize, NULL, 0, },
+    { { DEFACCEL, "SWS: Normalize item(s) to peak RMS" },                       "SWS_NORMPEAKRMS",     DoRMSNormalize, NULL, 1, },
+    { { DEFACCEL, "SWS: Normalize items to overall peak RMS" },                 "SWS_NORMPEAKRMSALL",  DoRMSNormalize, NULL, 2, },
+    { { DEFACCEL, "SWS: Set RMS analysis/normalize options" },                  "SWS_SETRMSOPTIONS",   SetRMSOptions,  NULL, },
 
 	{ {}, LAST_COMMAND, }, // Denote end of table
 };

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,5 @@
++Renamed "SWS: Analyze and display item peak and RMS" to "SWS: Analyze and display item peak and RMS (entire item)" (https://forum.cockos.com/showthread.php?p=2074089#post2074089|background|)
+
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!
 


### PR DESCRIPTION
RMS analysis: rename "SWS: Analyze and display item peak and RMS" to "SWS: Analyze and display item peak and RMS (entire item)"
(https://forum.cockos.com/showthread.php?p=2074089#post2074089)

Ok, 'Analyze and display item peak and RMS' kinda implies ''Analyze and display item peak and _item_ RMS' so maybe this PR is a bit redundant, take it as optional. :)
(Still current wording could lead to confusion it seems as linked above...)
