### PR TITLE
'Show / Hide take ... envelopes' actions: rename to 'Show / Hide and unbypass / bypass take ... envelopes'

### DIFF
--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -402,19 +402,29 @@ static COMMAND_T s_cmdTable[] =
 	{ { DEFACCEL, "SWS/S&M: Restore selected tracks folder compact states" }, "S&M_RESTOREFOLDERSTATE2", RestoreTracksFolderStates, NULL, 1},
 
 	// Take envelopes ---------------------------------------------------------
-	{ { DEFACCEL, "SWS/S&M: Show take volume envelopes" }, "S&M_TAKEENV1", ShowHideTakeVolEnvelope, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Show take pan envelopes" }, "S&M_TAKEENV2", ShowHideTakePanEnvelope, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Show take mute envelopes" }, "S&M_TAKEENV3", ShowHideTakeMuteEnvelope, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Hide take volume envelopes" }, "S&M_TAKEENV4", ShowHideTakeVolEnvelope, NULL, 0},
-	{ { DEFACCEL, "SWS/S&M: Hide take pan envelopes" }, "S&M_TAKEENV5", ShowHideTakePanEnvelope, NULL, 0},
-	{ { DEFACCEL, "SWS/S&M: Hide take mute envelopes" }, "S&M_TAKEENV6", ShowHideTakeMuteEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Show and unbypass take volume envelopes" }, "S&M_TAKEENV1", BypassUnbypassShowHideTakeVolEnvelope, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Show and unbypass take pan envelopes" }, "S&M_TAKEENV2", BypassUnbypassShowHideTakePanEnvelope, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Show and unbypass take mute envelopes" }, "S&M_TAKEENV3", BypassUnbypassShowHideTakeMuteEnvelope, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Hide and bypass take volume envelopes" }, "S&M_TAKEENV4", BypassUnbypassShowHideTakeVolEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Hide and bypass take pan envelopes" }, "S&M_TAKEENV5", BypassUnbypassShowHideTakePanEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Hide and bypass take mute envelopes" }, "S&M_TAKEENV6", BypassUnbypassShowHideTakeMuteEnvelope, NULL, 0},
+
+	{ { DEFACCEL, "SWS/S&M: Show take volume envelopes" }, "S&M_TAKEENVSHOW1", ShowHideTakeVolEnvelope, NULL, 1 },
+	{ { DEFACCEL, "SWS/S&M: Show take pan envelopes" }, "S&M_TAKEENVSHOW2", ShowHideTakePanEnvelope, NULL, 1 },
+	{ { DEFACCEL, "SWS/S&M: Show take mute envelopes" }, "S&M_TAKEENVSHOW3", ShowHideTakeMuteEnvelope, NULL, 1 },
+	{ { DEFACCEL, "SWS/S&M: Hide take volume envelopes" }, "S&M_TAKEENVSHOW4", ShowHideTakeVolEnvelope, NULL, 0 },
+	{ { DEFACCEL, "SWS/S&M: Hide take pan envelopes" }, "S&M_TAKEENVSHOW5", ShowHideTakePanEnvelope, NULL, 0 },
+	{ { DEFACCEL, "SWS/S&M: Hide take mute envelopes" }, "S&M_TAKEENVSHOW6", ShowHideTakeMuteEnvelope, NULL, 0 },
+
 
 	{ { DEFACCEL, "SWS/S&M: Set active take pan envelopes to 100% right" }, "S&M_TAKEENV_100R", PanTakeEnvelope, NULL, -1},
 	{ { DEFACCEL, "SWS/S&M: Set active take pan envelopes to 100% left" }, "S&M_TAKEENV_100L", PanTakeEnvelope, NULL, 1},
 	{ { DEFACCEL, "SWS/S&M: Set active take pan envelopes to center" }, "S&M_TAKEENV_CENTER", PanTakeEnvelope, NULL, 0},
 
-	{ { DEFACCEL, "SWS/S&M: Show take pitch envelope" }, "S&M_TAKEENV10", ShowHideTakePitchEnvelope, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Hide take pitch envelope" }, "S&M_TAKEENV11", ShowHideTakePitchEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Show and unbypass take pitch envelope" }, "S&M_TAKEENV10", BypassUnbypassShowHideTakePitchEnvelope, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Hide and bypass take pitch envelope" }, "S&M_TAKEENV11", BypassUnbypassShowHideTakePitchEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Show take pitch envelope" }, "S&M_TAKEENVSHOW7", ShowHideTakePitchEnvelope, NULL, 1 },
+	{ { DEFACCEL, "SWS/S&M: Hide take pitch envelope" }, "S&M_TAKEENVSHOW8", ShowHideTakePitchEnvelope, NULL, 0 },
 
 	// Track envelopes --------------------------------------------------------
 	{ { DEFACCEL, "SWS/S&M: Remove all envelopes for selected tracks" }, "S&M_REMOVE_ALLENVS", RemoveAllEnvsSelTracksNoChunk, NULL, },
@@ -574,9 +584,9 @@ static COMMAND_T s_cmdTable[] =
 	{ { DEFACCEL, "SWS/S&M: Split selected items at edit or play cursor (ignoring grouping)" }, "S&M_SPLIT9", SplitSelectedItems, NULL, 40186},
 
 	// exist natively..
-	{ { DEFACCEL, "SWS/S&M: Toggle show take volume envelope" }, "S&M_TAKEENV7", ShowHideTakeVolEnvelope, NULL, -1, GetFakeToggleState},
-	{ { DEFACCEL, "SWS/S&M: Toggle show take pan envelope" }, "S&M_TAKEENV8", ShowHideTakePanEnvelope, NULL, -1, GetFakeToggleState},
-	{ { DEFACCEL, "SWS/S&M: Toggle show take mute envelope" }, "S&M_TAKEENV9", ShowHideTakeMuteEnvelope, NULL, -1, GetFakeToggleState},
+	{ { DEFACCEL, "SWS/S&M: Toggle show take volume envelope" }, "S&M_TAKEENV7", BypassUnbypassShowHideTakeVolEnvelope, NULL, -1, GetFakeToggleState},
+	{ { DEFACCEL, "SWS/S&M: Toggle show take pan envelope" }, "S&M_TAKEENV8", BypassUnbypassShowHideTakePanEnvelope, NULL, -1, GetFakeToggleState},
+	{ { DEFACCEL, "SWS/S&M: Toggle show take mute envelope" }, "S&M_TAKEENV9", BypassUnbypassShowHideTakeMuteEnvelope, NULL, -1, GetFakeToggleState},
 #endif
 
 	{ {}, LAST_COMMAND, } // denote end of table

--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -402,29 +402,36 @@ static COMMAND_T s_cmdTable[] =
 	{ { DEFACCEL, "SWS/S&M: Restore selected tracks folder compact states" }, "S&M_RESTOREFOLDERSTATE2", RestoreTracksFolderStates, NULL, 1},
 
 	// Take envelopes ---------------------------------------------------------
-	{ { DEFACCEL, "SWS/S&M: Show and unbypass take volume envelopes" }, "S&M_TAKEENV1", BypassUnbypassShowHideTakeVolEnvelope, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Show and unbypass take pan envelopes" }, "S&M_TAKEENV2", BypassUnbypassShowHideTakePanEnvelope, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Show and unbypass take mute envelopes" }, "S&M_TAKEENV3", BypassUnbypassShowHideTakeMuteEnvelope, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Hide and bypass take volume envelopes" }, "S&M_TAKEENV4", BypassUnbypassShowHideTakeVolEnvelope, NULL, 0},
-	{ { DEFACCEL, "SWS/S&M: Hide and bypass take pan envelopes" }, "S&M_TAKEENV5", BypassUnbypassShowHideTakePanEnvelope, NULL, 0},
-	{ { DEFACCEL, "SWS/S&M: Hide and bypass take mute envelopes" }, "S&M_TAKEENV6", BypassUnbypassShowHideTakeMuteEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Show and unbypass take volume envelope" }, "S&M_TAKEENV1", BypassUnbypassShowHideTakeVolEnvelope, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Show and unbypass take pan envelope" }, "S&M_TAKEENV2", BypassUnbypassShowHideTakePanEnvelope, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Show and unbypass take mute envelope" }, "S&M_TAKEENV3", BypassUnbypassShowHideTakeMuteEnvelope, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Hide and bypass take volume envelope" }, "S&M_TAKEENV4", BypassUnbypassShowHideTakeVolEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Hide and bypass take pan envelope" }, "S&M_TAKEENV5", BypassUnbypassShowHideTakePanEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Hide and bypass take mute envelope" }, "S&M_TAKEENV6", BypassUnbypassShowHideTakeMuteEnvelope, NULL, 0},
 
-	{ { DEFACCEL, "SWS/S&M: Show take volume envelopes" }, "S&M_TAKEENVSHOW1", ShowHideTakeVolEnvelope, NULL, 1 },
-	{ { DEFACCEL, "SWS/S&M: Show take pan envelopes" }, "S&M_TAKEENVSHOW2", ShowHideTakePanEnvelope, NULL, 1 },
-	{ { DEFACCEL, "SWS/S&M: Show take mute envelopes" }, "S&M_TAKEENVSHOW3", ShowHideTakeMuteEnvelope, NULL, 1 },
-	{ { DEFACCEL, "SWS/S&M: Hide take volume envelopes" }, "S&M_TAKEENVSHOW4", ShowHideTakeVolEnvelope, NULL, 0 },
-	{ { DEFACCEL, "SWS/S&M: Hide take pan envelopes" }, "S&M_TAKEENVSHOW5", ShowHideTakePanEnvelope, NULL, 0 },
-	{ { DEFACCEL, "SWS/S&M: Hide take mute envelopes" }, "S&M_TAKEENVSHOW6", ShowHideTakeMuteEnvelope, NULL, 0 },
+	{ { DEFACCEL, "SWS/S&M: Show take volume envelope" }, "S&M_TAKEENVSHOW1", ShowHideTakeVolEnvelope, NULL, 1 },
+	{ { DEFACCEL, "SWS/S&M: Show take pan envelope" }, "S&M_TAKEENVSHOW2", ShowHideTakePanEnvelope, NULL, 1 },
+	{ { DEFACCEL, "SWS/S&M: Show take mute envelope" }, "S&M_TAKEENVSHOW3", ShowHideTakeMuteEnvelope, NULL, 1 },
+	{ { DEFACCEL, "SWS/S&M: Hide take volume envelope" }, "S&M_TAKEENVSHOW4", ShowHideTakeVolEnvelope, NULL, 0 },
+	{ { DEFACCEL, "SWS/S&M: Hide take pan envelope" }, "S&M_TAKEENVSHOW5", ShowHideTakePanEnvelope, NULL, 0 },
+	{ { DEFACCEL, "SWS/S&M: Hide take mute envelope" }, "S&M_TAKEENVSHOW6", ShowHideTakeMuteEnvelope, NULL, 0 },
 
 
-	{ { DEFACCEL, "SWS/S&M: Set active take pan envelopes to 100% right" }, "S&M_TAKEENV_100R", PanTakeEnvelope, NULL, -1},
-	{ { DEFACCEL, "SWS/S&M: Set active take pan envelopes to 100% left" }, "S&M_TAKEENV_100L", PanTakeEnvelope, NULL, 1},
-	{ { DEFACCEL, "SWS/S&M: Set active take pan envelopes to center" }, "S&M_TAKEENV_CENTER", PanTakeEnvelope, NULL, 0},
+	{ { DEFACCEL, "SWS/S&M: Set active take pan envelope to 100% right" }, "S&M_TAKEENV_100R", PanTakeEnvelope, NULL, -1},
+	{ { DEFACCEL, "SWS/S&M: Set active take pan envelope to 100% left" }, "S&M_TAKEENV_100L", PanTakeEnvelope, NULL, 1},
+	{ { DEFACCEL, "SWS/S&M: Set active take pan envelope to center" }, "S&M_TAKEENV_CENTER", PanTakeEnvelope, NULL, 0},
 
 	{ { DEFACCEL, "SWS/S&M: Show and unbypass take pitch envelope" }, "S&M_TAKEENV10", BypassUnbypassShowHideTakePitchEnvelope, NULL, 1},
 	{ { DEFACCEL, "SWS/S&M: Hide and bypass take pitch envelope" }, "S&M_TAKEENV11", BypassUnbypassShowHideTakePitchEnvelope, NULL, 0},
 	{ { DEFACCEL, "SWS/S&M: Show take pitch envelope" }, "S&M_TAKEENVSHOW7", ShowHideTakePitchEnvelope, NULL, 1 },
 	{ { DEFACCEL, "SWS/S&M: Hide take pitch envelope" }, "S&M_TAKEENVSHOW8", ShowHideTakePitchEnvelope, NULL, 0 },
+
+	// NF: unlike the deactivated "SWS/S&M: Toggle show take ... envelope" actions below
+	// these *only* toggle visibility (no bypass/unbypass) and aren't available natively
+	{ { DEFACCEL, "SWS/S&M: Toggle show take volume envelope" }, "S&M_TAKEENVSHOW9", ShowHideTakeVolEnvelope, NULL, -1, GetFakeToggleState },
+	{ { DEFACCEL, "SWS/S&M: Toggle show take pan envelope" }, "S&M_TAKEENVSHOW10", ShowHideTakePanEnvelope, NULL, -1, GetFakeToggleState },
+	{ { DEFACCEL, "SWS/S&M: Toggle show take mute envelope" }, "S&M_TAKEENVSHOW11", ShowHideTakeMuteEnvelope, NULL, -1, GetFakeToggleState },
+	{ { DEFACCEL, "SWS/S&M: Toggle show take pitch envelope" }, "S&M_TAKEENVSHOW12", ShowHideTakePitchEnvelope, NULL, -1, GetFakeToggleState },
 
 	// Track envelopes --------------------------------------------------------
 	{ { DEFACCEL, "SWS/S&M: Remove all envelopes for selected tracks" }, "S&M_REMOVE_ALLENVS", RemoveAllEnvsSelTracksNoChunk, NULL, },

--- a/SnM/SnM_Chunk.cpp
+++ b/SnM/SnM_Chunk.cpp
@@ -925,7 +925,7 @@ bool SNM_TakeEnvParserPatcher::NotifyChunkLine(int _mode,
 		if (!m_patchVisibilityOnly)
 			updated = (!strcmp(_lp->gettoken_str(0), "ACT") || !strcmp(_lp->gettoken_str(0), "VIS"));
 		else
-			updated = (!strcmp(_lp->gettoken_str(0), "VIS"));
+			updated = !strcmp(_lp->gettoken_str(0), "VIS");
 		arm = (strcmp(_lp->gettoken_str(0), "ARM") == 0);
 		updated |= arm;
 		if (updated) {

--- a/SnM/SnM_Chunk.cpp
+++ b/SnM/SnM_Chunk.cpp
@@ -922,7 +922,10 @@ bool SNM_TakeEnvParserPatcher::NotifyChunkLine(int _mode,
 	if (_mode == -1)
 	{
 		bool arm = false;
-		updated = (!strcmp(_lp->gettoken_str(0), "ACT") || !strcmp(_lp->gettoken_str(0), "VIS"));
+		if (!m_patchVisibilityOnly)
+			updated = (!strcmp(_lp->gettoken_str(0), "ACT") || !strcmp(_lp->gettoken_str(0), "VIS"));
+		else
+			updated = (!strcmp(_lp->gettoken_str(0), "VIS"));
 		arm = (strcmp(_lp->gettoken_str(0), "ARM") == 0);
 		updated |= arm;
 		if (updated) {
@@ -936,6 +939,11 @@ bool SNM_TakeEnvParserPatcher::NotifyChunkLine(int _mode,
 bool SNM_TakeEnvParserPatcher::SetVal(const char* _envKeyWord, int _val) {
 	m_val = _val;
 	return (ParsePatch(-1, 1, _envKeyWord) > 0);
+}
+
+void SNM_TakeEnvParserPatcher::SetPatchVisibilityOnly(bool visibilityOnly)
+{
+	m_patchVisibilityOnly = visibilityOnly;;
 }
 
 int g_disable_chunk_guid_filtering;

--- a/SnM/SnM_Chunk.h
+++ b/SnM/SnM_Chunk.h
@@ -373,9 +373,12 @@ class SNM_TakeEnvParserPatcher : public SNM_ChunkParserPatcher
 {
 public:
 	SNM_TakeEnvParserPatcher(WDL_FastString* _tkChunk, bool _autoCommit = true) 
-		: SNM_ChunkParserPatcher(_tkChunk, _autoCommit) {m_val = -1;}
+		: SNM_ChunkParserPatcher(_tkChunk, _autoCommit) {m_val = -1; m_patchVisibilityOnly = false;}
 	~SNM_TakeEnvParserPatcher() {}
 	bool SetVal(const char* _envKeyWord, int _val);
+	// NF: #1078, if true, only env. visibilty (show/hide) is patched
+	// (as opposed to also patching env. unbypass/bypass, resp. active/not active)
+	void SetPatchVisibilityOnly(bool patchVisibilityOnly); 
 protected:
 	bool NotifyChunkLine(int _mode, 
 		LineParser* _lp, const char* _parsedLine, int _linePos,
@@ -383,6 +386,7 @@ protected:
 		WDL_FastString* _newChunk, int _updates);
 private:
 	int m_val;
+	bool m_patchVisibilityOnly;
 };
 
 #endif

--- a/SnM/SnM_Item.cpp
+++ b/SnM/SnM_Item.cpp
@@ -1059,7 +1059,7 @@ int GetPitchTakeEnvRangeFromPrefs()
 }
 
 // callers must use UpdateArrange() at some point if it returns true..
-bool PatchTakeEnvelopeVis(MediaItem* _item, int _takeIdx, const char* _envKeyword, const char* _vis, const WDL_FastString* _defaultPoint, bool _reset)
+bool PatchTakeEnvelopeActVis(MediaItem* _item, int _takeIdx, const char* _envKeyword, const char* _vis, const WDL_FastString* _defaultPoint, bool _reset, bool patchVisibilityOnly)
 {
 	bool updated = false;
 	if (_item)
@@ -1104,6 +1104,8 @@ bool PatchTakeEnvelopeVis(MediaItem* _item, int _takeIdx, const char* _envKeywor
 					// prepare the new visibility (in one go)
 					{
 						SNM_TakeEnvParserPatcher pEnv(&takeChunk);
+						if (patchVisibilityOnly)
+							pEnv.SetPatchVisibilityOnly(true);
 						takeUpdate = pEnv.SetVal(_envKeyword, atoi(vis));
 					}
 				}
@@ -1141,7 +1143,7 @@ bool PatchTakeEnvelopeVis(MediaItem* _item, int _takeIdx, const char* _envKeywor
 	return updated;
 }
 
-bool PatchTakeEnvelopeVis(const char* _undoTitle, const char* _envKeyword, const char* _vis, const WDL_FastString* _defaultPoint, bool _reset) 
+bool PatchTakeEnvelopeActVis(const char* _undoTitle, const char* _envKeyword, const char* _vis, const WDL_FastString* _defaultPoint, bool _reset, bool patchVisibilityOnly) 
 {
 	bool updated = false;
 	for (int i = 1; i <= GetNumTracks(); i++) // skip master
@@ -1151,7 +1153,7 @@ bool PatchTakeEnvelopeVis(const char* _undoTitle, const char* _envKeyword, const
 		{
 			MediaItem* item = GetTrackMediaItem(tr,j);
 			if (item && *(bool*)GetSetMediaItemInfo(item,"B_UISEL",NULL))
-				updated |= PatchTakeEnvelopeVis(item, *(int*)GetSetMediaItemInfo(item,"I_CURTAKE",NULL), _envKeyword, _vis, _defaultPoint, _reset);
+				updated |= PatchTakeEnvelopeActVis(item, *(int*)GetSetMediaItemInfo(item,"I_CURTAKE",NULL), _envKeyword, _vis, _defaultPoint, _reset, patchVisibilityOnly);
 		}
 	}
 
@@ -1168,47 +1170,88 @@ void PanTakeEnvelope(COMMAND_T* _ct)
 {
 	WDL_FastString defaultPoint("PT 0.000000 ");
 	defaultPoint.AppendFormatted(128, "%d.000000 0", (int)_ct->user);
-	PatchTakeEnvelopeVis(SWS_CMD_SHORTNAME(_ct), "PANENV", "1", &defaultPoint, true);
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "PANENV", "1", &defaultPoint, true, false);
 }
 
-void ShowHideTakeVolEnvelope(COMMAND_T* _ct) 
+void BypassUnbypassShowHideTakeVolEnvelope(COMMAND_T* _ct) 
 {
 	char cVis[2] = ""; // empty means toggle
 	int value = (int)_ct->user;
 	if (value >= 0 && _snprintfStrict(cVis, sizeof(cVis), "%d", value) < 0)
 		return;
 	WDL_FastString defaultPoint("PT 0.000000 1.000000 0");
-	PatchTakeEnvelopeVis(SWS_CMD_SHORTNAME(_ct), "VOLENV", cVis, &defaultPoint, false);
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "VOLENV", cVis, &defaultPoint, false, false);
 }
 
-void ShowHideTakePanEnvelope(COMMAND_T* _ct) 
+void BypassUnbypassShowHideTakePanEnvelope(COMMAND_T* _ct) 
 {
 	char cVis[2] = ""; // empty means toggle
 	int value = (int)_ct->user;
 	if (value >= 0 && _snprintfStrict(cVis, sizeof(cVis), "%d", value) < 0)
 		return;
 	WDL_FastString defaultPoint("PT 0.000000 0.000000 0");
-	PatchTakeEnvelopeVis(SWS_CMD_SHORTNAME(_ct), "PANENV", cVis, &defaultPoint, false);
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "PANENV", cVis, &defaultPoint, false, false);
 }
 
-void ShowHideTakeMuteEnvelope(COMMAND_T* _ct) 
+void BypassUnbypassShowHideTakeMuteEnvelope(COMMAND_T* _ct) 
 {
 	char cVis[2] = ""; // empty means toggle
 	int value = (int)_ct->user;
 	if (value >= 0 && _snprintfStrict(cVis, sizeof(cVis), "%d", value) < 0)
 		return;
 	WDL_FastString defaultPoint("PT 0.000000 1.000000 1");
-	PatchTakeEnvelopeVis(SWS_CMD_SHORTNAME(_ct), "MUTEENV", cVis, &defaultPoint, false);
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "MUTEENV", cVis, &defaultPoint, false, false);
 }
 
-void ShowHideTakePitchEnvelope(COMMAND_T* _ct) 
+void BypassUnbypassShowHideTakePitchEnvelope(COMMAND_T* _ct) 
 {
 	char cVis[2] = ""; // empty means toggle
 	int value = (int)_ct->user;
 	if (value >= 0 && _snprintfStrict(cVis, sizeof(cVis), "%d", value) < 0)
 		return;
 	WDL_FastString defaultPoint("PT 0.000000 0.000000 0");
-	PatchTakeEnvelopeVis(SWS_CMD_SHORTNAME(_ct), "PITCHENV", cVis, &defaultPoint, false);
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "PITCHENV", cVis, &defaultPoint, false, false);
+}
+
+// NF: these *only* show/hide (no bypass/unbypass), #1078
+void ShowHideTakeVolEnvelope(COMMAND_T* _ct)
+{
+	char cVis[2] = ""; // empty means toggle
+	int value = (int)_ct->user;
+	if (value >= 0 && _snprintfStrict(cVis, sizeof(cVis), "%d", value) < 0)
+		return;
+	WDL_FastString defaultPoint("PT 0.000000 1.000000 0");
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "VOLENV", cVis, &defaultPoint, false, true);
+}
+
+void ShowHideTakePanEnvelope(COMMAND_T* _ct)
+{
+	char cVis[2] = ""; // empty means toggle
+	int value = (int)_ct->user;
+	if (value >= 0 && _snprintfStrict(cVis, sizeof(cVis), "%d", value) < 0)
+		return;
+	WDL_FastString defaultPoint("PT 0.000000 0.000000 0");
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "PANENV", cVis, &defaultPoint, false, true);
+}
+
+void ShowHideTakeMuteEnvelope(COMMAND_T* _ct)
+{
+	char cVis[2] = ""; // empty means toggle
+	int value = (int)_ct->user;
+	if (value >= 0 && _snprintfStrict(cVis, sizeof(cVis), "%d", value) < 0)
+		return;
+	WDL_FastString defaultPoint("PT 0.000000 1.000000 1");
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "MUTEENV", cVis, &defaultPoint, false, true);
+}
+
+void ShowHideTakePitchEnvelope(COMMAND_T* _ct)
+{
+	char cVis[2] = ""; // empty means toggle
+	int value = (int)_ct->user;
+	if (value >= 0 && _snprintfStrict(cVis, sizeof(cVis), "%d", value) < 0)
+		return;
+	WDL_FastString defaultPoint("PT 0.000000 0.000000 0");
+	PatchTakeEnvelopeActVis(SWS_CMD_SHORTNAME(_ct), "PITCHENV", cVis, &defaultPoint, false, true);
 }
 
 // *** some wrappers for Padre ***
@@ -1220,7 +1263,7 @@ bool ShowTakeEnv(MediaItem_Take* _take, const char* _envKeyword, const WDL_FastS
 	{
 		int idx = GetTakeIndex(item, _take);
 		if (idx >= 0) 
-			shown = PatchTakeEnvelopeVis(item, idx, _envKeyword , "1", _defaultPoint, false);
+			shown = PatchTakeEnvelopeActVis(item, idx, _envKeyword , "1", _defaultPoint, false, false);
 	}
 	return shown;
 }

--- a/SnM/SnM_Item.h
+++ b/SnM/SnM_Item.h
@@ -99,10 +99,16 @@ void DeleteTakeAndMedia(COMMAND_T*);
 
 int GetPitchTakeEnvRangeFromPrefs();
 void PanTakeEnvelope(COMMAND_T*);
-void ShowHideTakeVolEnvelope(COMMAND_T*); 
+void BypassUnbypassShowHideTakeVolEnvelope(COMMAND_T*); 
+void BypassUnbypassShowHideTakePanEnvelope(COMMAND_T*);
+void BypassUnbypassShowHideTakeMuteEnvelope(COMMAND_T*);
+void BypassUnbypassShowHideTakePitchEnvelope(COMMAND_T*);
+
+void ShowHideTakeVolEnvelope(COMMAND_T*);
 void ShowHideTakePanEnvelope(COMMAND_T*);
 void ShowHideTakeMuteEnvelope(COMMAND_T*);
 void ShowHideTakePitchEnvelope(COMMAND_T*);
+
 bool ShowTakeEnvVol(MediaItem_Take* _take);
 bool ShowTakeEnvPan(MediaItem_Take* _take);
 bool ShowTakeEnvMute(MediaItem_Take* _take);

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,5 @@
+- Issue 1078: Renamed "Show/Hide take ... envelopes" actions to "Show/Hide and unbypass/bypass take ... envelopes", added "Show/Hide take ... envelopes" actions 
+
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!
 

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,4 +1,7 @@
-- Issue 1078: Renamed "Show/Hide take ... envelopes" actions to "Show/Hide and unbypass/bypass take ... envelopes", added "Show/Hide take ... envelopes" actions 
+Fixes:
++ Issue 1078: Renamed "SWS/S&M: Show/Hide take ... envelope" actions to "SWS/S&M: Show/Hide and unbypass/bypass take ... envelope", added "SWS/S&M: Show/Hide take ... envelope" actions 
+ - Added "SWS/S&M: Toggle show take ... envelope" actions (unlike the native "Take: Toggle take ... envelope" actions these toggle visibility only)
+ - Renamed 'take ... envelopes' to 'take ... envelope' to be consistent with native actions
 
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!


### PR DESCRIPTION
The previous Show / Hide take ... envelopes' actions actually also bypassed/unbypassed the envelopes.

