### PR TITLE
Revert trackheight actions obey trackheight locking

### DIFF
--- a/Xenakios/MixerActions.cpp
+++ b/Xenakios/MixerActions.cpp
@@ -247,7 +247,7 @@ void DoSelTraxHeightA(COMMAND_T*)
 	for (int i=0;i<GetNumTracks();i++)
 	{
 		MediaTrack* CurTrack=CSurf_TrackFromID(i+1,false);
-		if (*(int*)GetSetMediaTrackInfo(CurTrack,"I_SELECTED",NULL) && !SWS_IsTrackHeightLocked(CurTrack))
+		if (*(int*)GetSetMediaTrackInfo(CurTrack,"I_SELECTED",NULL))
 			GetSetMediaTrackInfo(CurTrack,"I_HEIGHTOVERRIDE",&g_command_params.TrackHeightA);
 	}
 	TrackList_AdjustWindows(false);
@@ -259,7 +259,7 @@ void DoSelTraxHeightB(COMMAND_T*)
 	for (int i=0;i<GetNumTracks();i++)
 	{
 		MediaTrack* CurTrack=CSurf_TrackFromID(i+1,false);
-		if (*(int*)GetSetMediaTrackInfo(CurTrack,"I_SELECTED",NULL) && !SWS_IsTrackHeightLocked(CurTrack))
+		if (*(int*)GetSetMediaTrackInfo(CurTrack,"I_SELECTED",NULL))
 			GetSetMediaTrackInfo(CurTrack,"I_HEIGHTOVERRIDE",&g_command_params.TrackHeightB);
 	}
 	TrackList_AdjustWindows(false);
@@ -288,7 +288,7 @@ void DoRecallSelectedTrackHeights(COMMAND_T*)
 	for (int i=0;i<GetNumTracks();i++)
 	{
 		MediaTrack* CurTrack = CSurf_TrackFromID(i+1,false);
-		if (*(int*)GetSetMediaTrackInfo(CurTrack,"I_SELECTED",NULL) && !SWS_IsTrackHeightLocked(CurTrack))
+		if (*(int*)GetSetMediaTrackInfo(CurTrack,"I_SELECTED",NULL))
 		{
 			GUID curGUID=*(GUID*)GetSetMediaTrackInfo(CurTrack,"GUID",NULL);
 			for (int j=0;j<(int)g_vec_trackheighs.size();j++)
@@ -710,8 +710,8 @@ void DoToggleTrackHeightAB(COMMAND_T*)
 		}
 	for (i=0;i<(int)TheTracks.size();i++)
 	{
-		if (!SWS_IsTrackHeightLocked(TheTracks[i]))
-			GetSetMediaTrackInfo(TheTracks[i],"I_HEIGHTOVERRIDE",&newHei);
+		
+		GetSetMediaTrackInfo(TheTracks[i],"I_HEIGHTOVERRIDE",&newHei);
 	}
 	TrackList_AdjustWindows(false);
 	UpdateTimeline();

--- a/Zoom.cpp
+++ b/Zoom.cpp
@@ -127,12 +127,8 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 	if (bMinimizeOthers)
 	{
 		*(int*)GetConfigVar("vzoom2") = 0;
-		for (int i = 0; i <= GetNumTracks(); i++) {
-			MediaTrack* tr = CSurf_TrackFromID(i, false);
-			if (!SWS_IsTrackHeightLocked(tr))
-				GetSetMediaTrackInfo(tr, "I_HEIGHTOVERRIDE", &g_i0);
-		}
-			
+		for (int i = 0; i <= GetNumTracks(); i++)
+			GetSetMediaTrackInfo(CSurf_TrackFromID(i, false), "I_HEIGHTOVERRIDE", &g_i0);
 		Main_OnCommand(40112, 0); // Zoom out vert to minimize envelope lanes too (since vZoom is now 0) (calls refresh)
 		//TrackList_AdjustWindows(false);
 		//UpdateTimeline();
@@ -144,7 +140,7 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 		for (int i = 0; i < iNum; i++)
 		{
 			MediaTrack* tr = CSurf_TrackFromID(i+iFirst, false);
-			if (bZoomed[i] && !SWS_IsTrackHeightLocked(tr))
+			if (bZoomed[i])
 			{
 				iZoomed++;
 				if (tr == masterTrack && TcpVis(tr) && iNum > 1) iNotZoomedSize += GetMasterTcpGap();
@@ -263,12 +259,8 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 		} while (iHeight > iTotalHeight && iZoom > 0);
 
 		// Reset custom track sizes
-		for (int i = 0; i <= GetNumTracks(); i++) {
-			MediaTrack* tr = CSurf_TrackFromID(i, false);
-			if (!SWS_IsTrackHeightLocked(tr))
-				GetSetMediaTrackInfo(tr, "I_HEIGHTOVERRIDE", &g_i0);
-		}
-			
+		for (int i = 0; i <= GetNumTracks(); i++)
+			GetSetMediaTrackInfo(CSurf_TrackFromID(i, false), "I_HEIGHTOVERRIDE", &g_i0);
 		*(int*)GetConfigVar("vzoom2") = iZoom;
 		TrackList_AdjustWindows(false);
 		UpdateTimeline();

--- a/nofish/nofish.cpp
+++ b/nofish/nofish.cpp
@@ -170,7 +170,7 @@ void EnableDisableMultichannelMetering(COMMAND_T* ct, bool enable)
 			MediaTrack* track = CSurf_TrackFromID(i, false);
 			SNM_ChunkParserPatcher p(track);
 			int VUlineFound = p.Parse(SNM_GET_SUBCHUNK_OR_LINE, 1, "TRACK", "VU", 0, -1, NULL, NULL, "TRACKHEIGHT");
-			if (enable && VUlineFound == 0 || !enable && VUlineFound > 0) {
+			if ((enable && VUlineFound == 0) || (!enable && VUlineFound > 0)) {
 				SetOnlyTrackSelected(track);
 				Main_OnCommand(41726, 0); // Track: Toggle full multichannel metering
 			}
@@ -182,7 +182,7 @@ void EnableDisableMultichannelMetering(COMMAND_T* ct, bool enable)
 			MediaTrack* track = selTracks.Get()[i];
 			SNM_ChunkParserPatcher p(track);
 			int VUlineFound = p.Parse(SNM_GET_SUBCHUNK_OR_LINE, 1, "TRACK", "VU", 0, -1, NULL, NULL, "TRACKHEIGHT");
-			if (enable && VUlineFound == 0 || !enable && VUlineFound > 0) {
+			if ((enable && VUlineFound == 0) || (!enable && VUlineFound > 0)) {
 				SetOnlyTrackSelected(track);
 				Main_OnCommand(41726, 0); // Track: Toggle full multichannel metering
 			}

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,4 @@
+Revert 'Track height actions and vertical zoom actions obey track height locking' (for not breaking existing workflows, may come back as optional later on)
 "SWS/NF: Enable / Disable multichannel metering (...)" actions: Improve performance (report https://forum.cockos.com/showthread.php?p=2090523#post2090523|here|, thanks Edgemeal!)
 
 !v2.10.0 pre-release build (February 2, 2019)
@@ -61,7 +62,7 @@ Fixes:
 +ReaScript:
  +Issue 950: Make BR_SetItemEdges() only work on item passed in function (rather than all selected items), refix from v2.9.8
  - Avoid crashing in BR_Win32{Get,Write}PrivateProfileString when keyName is empty
- - BR_GetMouseCursorContext_MIDI() - add support for Notation Events lane (Issue 1082) (Note: currently returning 0x208, maybe this is due to change, see https://forum.cockos.com/showthread.php?p=2081634#post2081634|here|)
+ - BR_GetMouseCursorContext_MIDI() - add support for Notation Events lane (Issue 1082)
  - Fix BR_MIDI_CCLaneRemove(), BR_MIDI_CCLaneReplace() (report https://forum.cockos.com/showpost.php?p=2002814&postcount=1|here|.)
  - Repair CF_LocateInExplorer()
 
@@ -140,7 +141,7 @@ Other changes:
 +ReaScript:
  - Mark SNM_MoveOrRemoveTrackFX() as deprecated (native API equivalent added in REAPER 5.95)
  - Remove NF_TrackFX/TakeFX_ Set/GetOffline() (native API equivalent added in REAPER 5.95)
- - TagLib VS 2017 update for Windows (from v1.6.3. to v1.11.1)
++TagLib VS 2017 update for Windows (from v1.6.3. to v1.11.1)
 
 !v2.9.8 pre-release build (March 5, 2018)
 Now requires REAPER 5.50+!


### PR DESCRIPTION
https://forum.cockos.com/showthread.php?p=2091251#post2091251

\+ multichannel metering actions: fix OSX compiler warning
\+ whatsnew.txt tweaks

