### PR TITLE
Don't scale values from envelope chunks [p=2094872]

### DIFF
--- a/Breeder/BR_EnvelopeUtil.cpp
+++ b/Breeder/BR_EnvelopeUtil.cpp
@@ -1433,7 +1433,7 @@ bool BR_Envelope::Commit (bool force /*=false*/)
 
 		WDL_FastString chunkStart = this->GetProperties();
 		for (vector<BR_Envelope::EnvPoint>::iterator i = m_points.begin(); i != m_points.end(); ++i)
-			i->Append(chunkStart, m_tempoMap, playrate, m_properties.faderMode);
+			i->Append(chunkStart, m_tempoMap, playrate);
 		chunkStart.Append(">");
 		GetSetObjectState(m_envelope, chunkStart.Get());
 
@@ -1593,7 +1593,7 @@ void BR_Envelope::Build (bool takeEnvelopesUseProjectTime)
 		{
 			lp.parse(token);
 			BR_Envelope::EnvPoint point;
-			if (point.ReadLine(lp, playrate, m_properties.faderMode))
+			if (point.ReadLine(lp, playrate))
 			{
 				++id;
 				start = true;
@@ -1976,14 +1976,14 @@ bool BR_Envelope::EnvPoint::operator==(const EnvPoint &point) const
 	;
 }
 
-bool BR_Envelope::EnvPoint::ReadLine (const LineParser& lp, const double playrate, const int faderMode)
+bool BR_Envelope::EnvPoint::ReadLine (const LineParser& lp, const double playrate)
 {
 	if (strcmp(lp.gettoken_str(0), "PT"))
 		return false;
 	else
 	{
 		this->position   = lp.gettoken_float(1) / playrate;
-		this->value      = ScaleFromEnvelopeMode(faderMode, lp.gettoken_float(2));
+		this->value      = lp.gettoken_float(2);
 		this->shape      = lp.gettoken_int(3);
 		this->sig        = lp.gettoken_int(4);
 		this->selected   = (lp.gettoken_int(5)&1)==1;
@@ -1997,7 +1997,7 @@ bool BR_Envelope::EnvPoint::ReadLine (const LineParser& lp, const double playrat
 	}
 }
 
-void BR_Envelope::EnvPoint::Append (WDL_FastString& string, const bool tempoPoint, const double playrate, const int faderMode)
+void BR_Envelope::EnvPoint::Append (WDL_FastString& string, const bool tempoPoint, const double playrate)
 {
 	if (tempoPoint)
 	{
@@ -2024,7 +2024,7 @@ void BR_Envelope::EnvPoint::Append (WDL_FastString& string, const bool tempoPoin
 			256,
 			"PT %.12lf %.10lf %d %d %d %d %.8lf\n",
 			this->position * playrate,
-			ScaleToEnvelopeMode(faderMode, this->value),
+			this->value,
 			this->shape,
 			this->sig,
 			this->selected ? 1 : 0,

--- a/Breeder/BR_EnvelopeUtil.h
+++ b/Breeder/BR_EnvelopeUtil.h
@@ -219,8 +219,8 @@ private:
 		EnvPoint (double position, double value, int shape, int sig, bool selected, int partial, double bezier);
 		explicit EnvPoint (double position);
 		bool operator==(const EnvPoint &) const;
-		bool ReadLine (const LineParser& lp, double playrate, int faderMode); // use only once per object (for efficiency, tempoStr is never deleted, only appended too)
-		void Append (WDL_FastString& string, bool tempoPoint, double playrate, int faderMode);
+		bool ReadLine (const LineParser& lp, double playrate); // use only once per object (for efficiency, tempoStr is never deleted, only appended too)
+		void Append (WDL_FastString& string, bool tempoPoint, double playrate);
 		struct ComparePoints
 		{
 			bool operator() (const EnvPoint& first, const EnvPoint& second)

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,6 @@
+Fixes:
++Fix wrong point values when using envelope-related actions with fader scaling mode (regression from 2.10.0, report https://forum.cockos.com/showthread.php?p=2094872|here|)
+
 !v2.10.0 #1 Featured build (February 6, 2019)
 Mega thanks to nofish and cfillion for their many contributions, and X-Raym for doing the tedious work of merging everything into a release.
 Recommended use of REAPER 5.965.


### PR DESCRIPTION
Envelope chunks are already scaled and BR_Envelope deals with scaled values (the REAPER API uses raw values).

Fixes regression from bc21260134b6a6ad18d9106ca61cbc6b1100fe53.