### PR TITLE
Loudness: 'high precision' mode tweaks

### DIFF
--- a/Breeder/BR_Loudness.cpp
+++ b/Breeder/BR_Loudness.cpp
@@ -757,13 +757,19 @@ bool BR_LoudnessObject::IsSelectedInProject ()
 		return *(bool*)GetSetMediaItemInfo(this->GetItem(), "B_UISEL", NULL);
 }
 
-bool BR_LoudnessObject::CreateGraph (BR_Envelope& envelope, double minLUFS, double maxLUFS, bool momentary, HWND warningHwnd /*=g_hwndParent*/)
+bool BR_LoudnessObject::CreateGraph (BR_Envelope& envelope, double minLUFS, double maxLUFS, bool momentary, bool highPrecisionMode, HWND warningHwnd /*=g_hwndParent*/)
 {
 	SWS_SectionLock lock(&m_mutex);
 	if (!this->IsTargetValid() || envelope.IsTempo())
 	{
 		if (envelope.IsTempo())
 			MessageBox(warningHwnd, __LOCALIZE("Can't create loudness graph in tempo map.","sws_mbox"), __LOCALIZE("SWS/BR - Error","sws_mbox"), 0);
+		return false;
+	}
+
+	if (highPrecisionMode)
+	{
+		MessageBox(warningHwnd, __LOCALIZE("Can't create loudness graph in high precision mode.", "sws_mbox"), __LOCALIZE("SWS/BR - Error", "sws_mbox"), 0);
 		return false;
 	}
 
@@ -903,6 +909,12 @@ void BR_LoudnessObject::GoToMomentaryMax (bool timeSelection)
 	if (!this->IsTargetValid())
 		return;
 
+	if (g_loudnessWndManager.Get()->GetProperty(BR_AnalyzeLoudnessWnd::DO_HIGH_PRECISION_MODE))
+	{
+		MessageBox(g_loudnessWndManager.GetMsgHWND(), __LOCALIZE("Can't go to maximum momentary in high precision mode.", "sws_mbox"), __LOCALIZE("SWS/BR - Error", "sws_mbox"), 0);
+		return;
+	}
+		
 	PreventUIRefresh(1);
 
 	double position = this->GetMaxMomentaryPos(true);
@@ -922,6 +934,12 @@ void BR_LoudnessObject::GoToShortTermMax (bool timeSelection)
 	SWS_SectionLock lock(&m_mutex);
 	if (!this->IsTargetValid())
 		return;
+
+	if (g_loudnessWndManager.Get()->GetProperty(BR_AnalyzeLoudnessWnd::DO_HIGH_PRECISION_MODE))
+	{
+		MessageBox(g_loudnessWndManager.GetMsgHWND(), __LOCALIZE("Can't go to maximum short-term in high precision mode.", "sws_mbox"), __LOCALIZE("SWS/BR - Error", "sws_mbox"), 0);
+		return;
+	}
 
 	PreventUIRefresh(1);
 
@@ -3301,7 +3319,7 @@ void BR_AnalyzeLoudnessWnd::OnCommand (WPARAM wParam, LPARAM lParam)
 				int x = 0;
 				while (BR_LoudnessObject* listItem = (BR_LoudnessObject*)m_list->EnumSelected(&x))
 				{
-					if (listItem->CreateGraph(envelope, g_pref.GetGraphMin(), g_pref.GetGraphMax(), (wParam == DRAW_MOMENTARY) ? (true) : (false), m_hwnd))
+					if (listItem->CreateGraph(envelope, g_pref.GetGraphMin(), g_pref.GetGraphMax(), (wParam == DRAW_MOMENTARY) ? (true) : (false), this->GetProperty(DO_HIGH_PRECISION_MODE), m_hwnd))
 						update = true;
 				}
 
@@ -4435,9 +4453,8 @@ bool NFDoAnalyzeTakeLoudness2(MediaItem_Take* take, bool analyzeTruePeak, double
 		if (isTargetValid) {
 			objects.Get(0)->SetDoTruePeak(analyzeTruePeak);
 
-			// check if user set high precision mode 
-			bool doHighPrecisionMode = !!IsHighPrecisionOptionEnabled(NULL);
-			objects.Get(0)->SetDoHighPrecisionMode(doHighPrecisionMode);
+			// don't use high precision mode here to ensure correct max. short-term / momentary positions
+			objects.Get(0)->SetDoHighPrecisionMode(false);
 
 			BR_NormalizeData analyzeData = { &objects, -23, false, false }; // full analyze mode
 			NFAnalyzeItemsLoudnessAndShowProgress(&analyzeData);

--- a/Breeder/BR_Loudness.h
+++ b/Breeder/BR_Loudness.h
@@ -65,7 +65,7 @@ public:
 	bool CheckTarget (MediaTrack* track);
 	bool CheckTarget (MediaItem_Take* take);
 	bool IsSelectedInProject ();
-	bool CreateGraph (BR_Envelope& envelope, double minLUFS, double maxLUFS, bool momentary, HWND warningHwnd = g_hwndParent);
+	bool CreateGraph (BR_Envelope& envelope, double minLUFS, double maxLUFS, bool momentary, bool highPrecisionMode, HWND warningHwnd = g_hwndParent);
 	bool NormalizeIntegrated (double targetLUFS); // uses existing analyze data
 	void SetSelectedInProject (bool selected);
 	void GoToTarget ();

--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -1646,7 +1646,7 @@ int NotesInit()
 		if (infile.IsOpen() == true) {
 			std::vector<char> buffer((size_t)infile.GetSize() + 1); // +1 to have space for the terminating zero
 			// infile.Read(buffer.data(), infile.GetSize()); // C++11
-            infile.Read(&buffer.front(), (int)infile.GetSize());
+			infile.Read(&buffer.front(), (int)infile.GetSize());
 			buffer[(size_t)infile.GetSize()] = '\0'; // put in the string terminating zero
 			g_glbNotes.Get()->Set(&buffer[0]);
 		}

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,8 @@
+Fixes:
+Loudness - 'high precision' mode:
+ - Disable creating graph, disable go to max. short-term / momentary (Issue 1120) (as this mode works with overlapping measurements, results wouldn't make sense)
+ - ReaScript: automatically disable 'high precision' mode for NF_AnalyzeTakeLoudness2() (to ensure correct max. short-term / momentary positions)
+
 !v2.10.0 #1 Featured build (February 6, 2019)
 Mega thanks to nofish and cfillion for their many contributions, and X-Raym for doing the tedious work of merging everything into a release.
 Recommended use of REAPER 5.965.


### PR DESCRIPTION
- disable creating graph, disable go to max. short-term / momentary (Issue #1120)
- ReaScript: disable 'high precision' mode for NF_AnalyzeTakeLoudness2()

\+ SnM_Notes.cpp: fix indention