### PR TITLE
Loudness: 'high precision' mode tweaks

### DIFF
--- a/Breeder/BR_Loudness.h
+++ b/Breeder/BR_Loudness.h
@@ -65,7 +65,7 @@ public:
 	bool CheckTarget (MediaTrack* track);
 	bool CheckTarget (MediaItem_Take* take);
 	bool IsSelectedInProject ();
-	bool CreateGraph (BR_Envelope& envelope, double minLUFS, double maxLUFS, bool momentary, HWND warningHwnd = g_hwndParent);
+	bool CreateGraph (BR_Envelope& envelope, double minLUFS, double maxLUFS, bool momentary, bool highPrecisionMode, HWND warningHwnd = g_hwndParent);
 	bool NormalizeIntegrated (double targetLUFS); // uses existing analyze data
 	void SetSelectedInProject (bool selected);
 	void GoToTarget ();

--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -1646,7 +1646,7 @@ int NotesInit()
 		if (infile.IsOpen() == true) {
 			std::vector<char> buffer((size_t)infile.GetSize() + 1); // +1 to have space for the terminating zero
 			// infile.Read(buffer.data(), infile.GetSize()); // C++11
-            infile.Read(&buffer.front(), (int)infile.GetSize());
+			infile.Read(&buffer.front(), (int)infile.GetSize());
 			buffer[(size_t)infile.GetSize()] = '\0'; // put in the string terminating zero
 			g_glbNotes.Get()->Set(&buffer[0]);
 		}

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,9 @@
+Fixes:
+Loudness - high precision mode:
+ - Fix potential crash when analyzing items shorter than 3 seconds
+ - Disable creating graph, disable go to max. short-term / momentary (Issue 1120) (these are currently not implemented for high precision mode)
+ - ReaScript: automatically disable high precision mode for NF_AnalyzeTakeLoudness2() (to ensure correct max. short-term / momentary positions)
+
 !v2.10.0 #1 Featured build (February 6, 2019)
 Mega thanks to nofish and cfillion for their many contributions, and X-Raym for doing the tedious work of merging everything into a release.
 Recommended use of REAPER 5.965.


### PR DESCRIPTION
- Fix potential crash when analyzing items shorter than 3 seconds
- Disable creating graph, disable go to max. short-term / momentary (closes #1120) 
- ReaScript: automatically disable high precision mode for NF_AnalyzeTakeLoudness2()

`+` SnM_Notes.cpp: fix indention

