### PR TITLE
SWS/S&M: Remove all env's for sel. tracks - prompt before executing action (may be overridden)

### DIFF
--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -1111,6 +1111,11 @@ void IniFileInit()
 	g_SNM_ToolbarRefresh = (GetPrivateProfileInt("General", "ToolbarsAutoRefresh", 1, g_SNM_IniFn.Get()) == 1);
 	g_SNM_ToolbarRefreshFreq = BOUNDED(GetPrivateProfileInt("General", "ToolbarsAutoRefreshFreq", SNM_DEF_TOOLBAR_RFRSH_FREQ, g_SNM_IniFn.Get()), 100, 5000);
 	g_SNM_SupportBuggyPlug = GetPrivateProfileInt("General", "BuggyPlugsSupport", 0, g_SNM_IniFn.Get());
+
+	// #1175, prompt by default, may be overridden
+	if (GetPrivateProfileInt("Misc", "RemoveAllEnvsSelTracksPrompt", -666, g_SNM_IniFn.Get()) == -666)
+		WritePrivateProfileString("Misc", "RemoveAllEnvsSelTracksPrompt", "1", g_SNM_IniFn.Get());
+		
 #ifdef _WIN32
 	g_SNM_ClearType = (GetPrivateProfileInt("General", "ClearTypeFont", 1, g_SNM_IniFn.Get()) == 1);
 

--- a/SnM/SnM_Track.cpp
+++ b/SnM/SnM_Track.cpp
@@ -32,6 +32,7 @@
 #include "SnM_Track.h"
 #include "SnM_Util.h"
 #include "WDL/projectcontext.h"
+#include "../reaper/localize.h"
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -597,6 +598,18 @@ void RemoveAllEnvsSelTracks(COMMAND_T* _ct)
 
 void RemoveAllEnvsSelTracksNoChunk(COMMAND_T* _ct)
 {
+	// #1175
+	bool prompt = GetPrivateProfileInt("Misc", "RemoveAllEnvsSelTracksPrompt", 0, g_SNM_IniFn.Get()) ? true : false;
+	if (prompt && SNM_CountSelectedTracks(NULL, true)) 
+	{
+		int r = MessageBox(GetMainHwnd(),
+			__LOCALIZE("All envelopes for selected tracks will be removed.\nDo you want to continue?", "sws_DLG_155"),
+			__LOCALIZE("S&M - Question", "sws_DLG_155"),
+			MB_OKCANCEL);
+		if (r == IDCANCEL)
+			return;
+	}
+
 	bool updated = false;
 	TrackEnvelope *tempoEnv = NULL;
 

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,6 @@
+Other changes:
+Issue 1175: "SWS/S&M: Remove all envelopes for selected tracks" - prompt before executing action, may be overridden by setting <REAPER resource path>/S&M.ini/[Misc]/RemoveAllEnvsSelTracksPrompt=0
+
 !v2.10.0 #1 Featured build (February 6, 2019)
 Mega thanks to nofish and cfillion for their many contributions, and X-Raym for doing the tedious work of merging everything into a release.
 Recommended use of REAPER 5.965.


### PR DESCRIPTION
SWS/S&M: Remove all envelopes for selected tracks - prompt before executing action
may be overridden by setting
`<REAPER resource path>/S&M.ini/[Misc]/RemoveAllEnvsSelTracksPrompt=0`
closes #1175