### PR TITLE
Harden configvar against invalid type interpretation 

### DIFF
--- a/Breeder/BR.cpp
+++ b/Breeder/BR.cpp
@@ -96,11 +96,12 @@ void BR_MenuHook (COMMAND_T* ct, HMENU menu, int id)
 	{
 		// Disable the action "Flush FX on stop" if the option "Run FX when stopped" is turned off
 		if ((int)ct->user == 1)
-			EnableMenuItem(menu, id, (GetBit(*static_cast<int*>(GetConfigVar("runallonstop")), 0) ? MF_ENABLED : MF_GRAYED) | MF_BYPOSITION);
+			EnableMenuItem(menu, id,
+				(GetBit(*ConfigVar<int>("runallonstop"), 0) ? MF_ENABLED : MF_GRAYED) | MF_BYPOSITION);
 
 		// Disable the action to set "Run FX after stopping for" if the option "Run FX when stopped" is turned on
 		else if ((int)ct->user <= 0)
-			EnableMenuItem(menu, id, (!GetBit(*static_cast<int*>(GetConfigVar("runallonstop")), 0) ? MF_ENABLED : MF_GRAYED) | MF_BYPOSITION);
+			EnableMenuItem(menu, id, (!GetBit(*ConfigVar<int>("runallonstop"), 0) ? MF_ENABLED : MF_GRAYED) | MF_BYPOSITION);
 	}
 }
 

--- a/Breeder/BR_ContextualToolbars.cpp
+++ b/Breeder/BR_ContextualToolbars.cpp
@@ -246,7 +246,7 @@ void BR_ContextualToolbar::LoadToolbar (bool exclusive)
 				bool undoTake  = this->ActivateTake(executeOnToolbarLoad);
 
 				// Create undo point
-				int undoMask; GetConfig("undomask", undoMask);
+				const int undoMask = ConfigVar<int>("undomask").value_or(0);
 				if (!GetBit(undoMask, 0)) // "Create undo points for item/track selection" is off
 				{
 					undoTrack = false;

--- a/Breeder/BR_ContinuousActions.cpp
+++ b/Breeder/BR_ContinuousActions.cpp
@@ -226,7 +226,8 @@ static void KillNativeTooltip ()
 {
 	if (g_actionInProgress && !g_removedNativeTooltip)
 	{
-		SetConfig("tooltips", SetBit(SetBit(SetBit(g_tooltips, 0), 1), 2));
+		ConfigVar<int>("tooltips").try_set(SetBit(SetBit(SetBit(g_tooltips, 0), 1), 2));
+
 		for (list<HWND>::const_iterator it = g_registeredWindows.begin(), end = g_registeredWindows.end(); it != end; ++it)
 			InvalidateRect(*it,  NULL, TRUE);
 		g_removedNativeTooltip = true;
@@ -379,7 +380,7 @@ static bool ContinuousActionInit (bool init, COMMAND_T* ct, HWND hwnd, BR_Contin
 	if (initSuccessful)
 	{
 		// Reset variables
-		GetConfig("tooltips", g_tooltips);
+		g_tooltips = ConfigVar<int>("tooltips").value_or(0);
 		g_actionInProgress     = action;
 		g_removedNativeTooltip = false;
 		g_midiEditorWnd        = (action && action->ct->uniqueSectionId == SECTION_MIDI_EDITOR) ? hwnd                          : NULL;
@@ -476,7 +477,7 @@ static bool ContinuousActionInit (bool init, COMMAND_T* ct, HWND hwnd, BR_Contin
 		// Reset tooltips options in case they were changed and remove our tooltip
 		if (g_removedNativeTooltip)
 		{
-			SetConfig("tooltips", g_tooltips);
+			ConfigVar<int>("tooltips").try_set(g_tooltips);
 
 			// Make sure native tooltip is draw before hiding our tooltip
 			POINT p; GetCursorPos(&p);

--- a/Breeder/BR_EnvelopeUtil.cpp
+++ b/Breeder/BR_EnvelopeUtil.cpp
@@ -649,7 +649,7 @@ double BR_Envelope::ValueAtPosition (double position, bool fastMode /*= false*/)
 	if (!m_pointsEdited && !fastMode)
 	{
 		if (m_sampleRate == -1)
-			GetConfig("projsrate", m_sampleRate);
+			m_sampleRate = ConfigVar<int>("projsrate").value_or(-1);
 
 		double value;
 		Envelope_Evaluate(m_envelope, position, m_sampleRate, 1, &value, NULL, NULL, NULL); // slower than our way with high point count (probably because we use binary search while Cockos uses linear) but more accurate
@@ -817,7 +817,7 @@ double BR_Envelope::SnapValue (double value)
 {
 	if (this->Type() == PITCH)
 	{
-		int pitchenvrange; GetConfig("pitchenvrange", pitchenvrange);
+		const int pitchenvrange = ConfigVar<int>("pitchenvrange").value_or(0);
 		int mode = pitchenvrange >> 8; // range is in high 8 bits
 
 		if      (mode == 0) return value;
@@ -1299,12 +1299,12 @@ double BR_Envelope::LaneMinValue ()
 {
 	if (m_tempoMap)
 	{
-		int min; GetConfig("tempoenvmin", min);
+		const int min = ConfigVar<int>("tempoenvmin").value_or(0);
 		return (double)min;
 	}
 	else if (this->Type() == PITCH)
 	{
-		int min; GetConfig("pitchenvrange", min);
+		const int min = ConfigVar<int>("pitchenvrange").value_or(0);
 		return -(min & 0x0F); // range is in low 8 bits
 	}
 	return this->MinValueAbs();
@@ -1314,14 +1314,14 @@ double BR_Envelope::LaneMaxValue ()
 {
 	if (m_tempoMap)
 	{
-		int max; GetConfig("tempoenvmax", max);
+		const int max = ConfigVar<int>("tempoenvmax").value_or(0);
 		return (double)max;
 	}
 	else if (this->Type() == VOLUME || this->Type() == VOLUME_PREFX)
 	{
 		static int s_max = -666;
 		static int s_val = -666;
-		int max; GetConfig("volenvrange", max);
+		const int max = ConfigVar<int>("volenvrange").value_or(0);
 
 		// LaneMaxValue tends to get called a lot so instead of doing all comparisons each time, rather cache value and do one comparison only
 		if (max != s_max)
@@ -1336,7 +1336,7 @@ double BR_Envelope::LaneMaxValue ()
 	}
 	else if (this->Type() == PITCH)
 	{
-		int max; GetConfig("pitchenvrange", max);
+		const int max = ConfigVar<int>("pitchenvrange").value_or(0);
 		return max & 0x0F; // range is in low 8 bits
 	}
 	return this->MaxValueAbs();
@@ -1424,10 +1424,12 @@ bool BR_Envelope::Commit (bool force /*=false*/)
 	if ((force || (m_update && !this->IsLocked())) && m_envelope)
 	{
 		// Prevents reselection of points in time selection
-		int envClickSegMode; GetConfig("envclicksegmode", envClickSegMode);
-		SetConfig("envclicksegmode", ClearBit(envClickSegMode, 6));
-		int pooledenvs; GetConfig("pooledenvs", pooledenvs);
-		SetConfig("pooledenvs", pooledenvs & (~12));
+		const ConfigVar<int> envClickSegMode("envclicksegmode");
+		ConfigVarOverride<int> tempEnvClickSegMode(envClickSegMode,
+			ClearBit(envClickSegMode.value_or(0), 6));
+
+		const ConfigVar<int> pooledenvs("pooledenvs");
+		ConfigVarOverride<int> tempPooledEnvs(pooledenvs, pooledenvs.value_or(0) & (~12));
 
 		const double playrate = m_take ? GetMediaItemTakeInfo_Value(m_take, "D_PLAYRATE") : 1;
 
@@ -1440,8 +1442,6 @@ bool BR_Envelope::Commit (bool force /*=false*/)
 		if (m_tempoMap)
 			UpdateTempoTimeline();
 
-		SetConfig("envclicksegmode", envClickSegMode);
-		SetConfig("pooledenvs", pooledenvs);
 		UpdateArrange();
 		m_update       = false;
 		m_pointsEdited = false;
@@ -2152,8 +2152,8 @@ WDL_FastString ConstructReceiveEnv (BR_EnvType type, double firstPointValue, boo
 	if (type != VOLUME && type != PAN && type != MUTE)
 		return envelope;
 
-	int defAutoMode; GetConfig("defautomode", defAutoMode);
-	int envLanes;    GetConfig("envlanes", envLanes);
+	const int defAutoMode = ConfigVar<int>("defautomode").value_or(0);
+	const int envLanes = ConfigVar<int>("envlanes").value_or(0);
 
 	BR_EnvShape defShape = (type == MUTE) ? SQUARE : GetDefaultPointShape();
 
@@ -2164,7 +2164,7 @@ WDL_FastString ConstructReceiveEnv (BR_EnvType type, double firstPointValue, boo
 	else if (type == PAN)    (hardwareSend) ? AppendLine(envelope, "<HWPANENV")  : AppendLine(envelope, "<AUXPANENV");
 	else if (type == MUTE)   (hardwareSend) ? AppendLine(envelope, "<HWMUTEENV") : AppendLine(envelope, "<AUXMUTEENV");
 
-	int volenvrange; GetConfig("volenvrange", volenvrange);
+	const int volenvrange = ConfigVar<int>("volenvrange").value_or(0);
 	envelope.AppendFormatted(128, "%s %d\n",             "ACT", 1);
 	envelope.AppendFormatted(128, "%s %d %d %d\n",       "VIS", 1, GetBit(envLanes, 0), 1);
 	envelope.AppendFormatted(128, "%s %d %d\n",          "LANEHEIGHT", 0, 0);
@@ -2306,7 +2306,7 @@ bool ToggleShowSendEnvelope (MediaTrack* track, int sendId, BR_EnvType type)
 						}
 
 						bool trim = false;
-						int trimMode; GetConfig("envtrimadjmode", trimMode);
+						const int trimMode = ConfigVar<int>("envtrimadjmode").value_or(0);
 						if (trimMode == 0 || (trimMode == 1 && GetEffectiveAutomationMode(hwSend ? track : CSurf_TrackFromID(sendTrackId + 1, false)) != 0))
 						{
 							trim = true;
@@ -2491,7 +2491,7 @@ bool ShowSendEnvelopes (vector<MediaTrack*>& tracks, BR_EnvType envelopeTypes)
 						}
 
 						bool trim = false;
-						int trimMode; GetConfig("envtrimadjmode", trimMode);
+						const int trimMode = ConfigVar<int>("envtrimadjmode").value_or(0);
 						if (trimMode == 0 || (trimMode == 1 && GetEffectiveAutomationMode(hwSend ? track : CSurf_TrackFromID(sendTrackId + 1, false)) != 0))
 						{
 							trim = true;
@@ -2628,7 +2628,7 @@ int CountTrackEnvelopePanels (MediaTrack* track)
 
 BR_EnvShape GetDefaultPointShape ()
 {
-	int defEnvs; GetConfig("defenvs", defEnvs);
+	const int defEnvs = ConfigVar<int>("defenvs").value_or(0);
 	return static_cast<BR_EnvShape>(defEnvs >> 16);
 }
 

--- a/Breeder/BR_MidiEditor.cpp
+++ b/Breeder/BR_MidiEditor.cpp
@@ -1031,7 +1031,7 @@ void ME_EnvPointsToCC (COMMAND_T* ct, int val, int valhw, int relmode, HWND hwnd
 				bool beatsTimebase = (midiEditor.GetTimebase() == PROJECT_BEATS || midiEditor.GetTimebase() == SOURCE_BEATS);
 
 				double stepSize = 0;
-				int midiCcDensity; GetConfig("midiccdensity", midiCcDensity);
+				const int midiCcDensity = ConfigVar<int>("midiccdensity").value_or(0);
 				if (midiCcDensity > 0)
 				{
 					stepSize = (double)midiEditor.GetPPQ() / (double)midiCcDensity;

--- a/Breeder/BR_Misc.cpp
+++ b/Breeder/BR_Misc.cpp
@@ -70,7 +70,7 @@ static void MousePlaybackTimer ()
 {
 	// do not do this, it is generally unsafe: PreventUIRefresh(-1);
 	// (is this timer necessary with this removed?)
-	SetConfig("viewadvance", g_mousePlaybackReaperOptions);
+	ConfigVar<int>("viewadvance").try_set(g_mousePlaybackReaperOptions);
 	plugin_register("-timer", (void*)MousePlaybackTimer);
 }
 
@@ -84,7 +84,7 @@ static void MousePlaybackPlayState (bool play, bool pause, bool rec)
 	{
 		if (g_mousePlaybackRestoreView && g_activeCommand && (int)g_activeCommand->user > 0)
 		{
-			GetConfig("viewadvance", g_mousePlaybackReaperOptions);
+			g_mousePlaybackReaperOptions = ConfigVar<int>("viewadvance").value_or(0);
 			if (GetBit(g_mousePlaybackReaperOptions, 3))
 				g_mousePlaybackForceMoveView = true;
 		}
@@ -100,7 +100,7 @@ static void MousePlaybackPlayState (bool play, bool pause, bool rec)
 			//do not do this, it is generally unsafe: PreventUIRefresh(1);
 
 
-			SetConfig("viewadvance", ClearBit(g_mousePlaybackReaperOptions, 3));
+			ConfigVar<int>("viewadvance").try_set(g_mousePlaybackReaperOptions);
 			plugin_register("timer", (void*)MousePlaybackTimer);
 		}
 	}
@@ -290,8 +290,7 @@ static bool MousePlaybackInit (COMMAND_T* ct, bool init)
 
 		if (g_mousePlaybackRestoreView)
 		{
-			int viewAdvance;
-			GetConfig("viewadvance", viewAdvance);
+			const int viewAdvance = ConfigVar<int>("viewadvance").value_or(0);
 			if ((GetBit(viewAdvance, 3) || g_mousePlaybackForceMoveView) && (int)ct->user > 0) // Move view to edit cursor on stop (analogously applied here when starting playback from mouse cursor)
 			{
 				double arrangeStart, arrangeEnd;
@@ -1091,30 +1090,29 @@ void RestoreTrackSoloMuteStateSlot (COMMAND_T* ct)
 ******************************************************************************/
 void SnapFollowsGridVis (COMMAND_T* ct)
 {
-	int option;
-	GetConfig("projshowgrid", option);
-	SetConfig("projshowgrid", ToggleBit(option, 15));
+	if(ConfigVar<int> projshowgrid = "projshowgrid")
+		*projshowgrid = ToggleBit(*projshowgrid, 15);
 	RefreshToolbar(0);
 }
 
 void PlaybackFollowsTempoChange (COMMAND_T* ct)
 {
 	const char* configStr = "seekmodes";
-	int option; GetConfig(configStr, option);
+	ConfigVar<int> option(configStr);
+	if(!option) return;
 
-	option = ToggleBit(option, 5);
-	SetConfig(configStr, option);
+	*option = ToggleBit(*option, 5);
 	RefreshToolbar(0);
 
 	char tmp[256];
-	_snprintfSafe(tmp, sizeof(tmp), "%d", option);
+	_snprintfSafe(tmp, sizeof(tmp), "%d", *option);
 	WritePrivateProfileString("reaper", configStr, tmp, get_ini_file());
 }
 
 void TrimNewVolPanEnvs (COMMAND_T* ct)
 {
 	const char* configStr = "envtrimadjmode";
-	SetConfig(configStr, (int)ct->user);
+	ConfigVar<int>(configStr).try_set((int)ct->user);
 	RefreshToolbar(0);
 
 	char tmp[256];
@@ -1126,12 +1124,12 @@ void ToggleDisplayItemLabels (COMMAND_T* ct)
 {
 	const char* configStr = "labelitems2";
 
-	int option; GetConfig(configStr, option);
-	option = ToggleBit(option, (int)ct->user);
-	SetConfig(configStr, option);
+	ConfigVar<int> option(configStr);
+	if(!option) return;
+	*option = ToggleBit(*option, (int)ct->user);
 
 	char tmp[256];
-	_snprintfSafe(tmp, sizeof(tmp), "%d", option);
+	_snprintfSafe(tmp, sizeof(tmp), "%d", *option);
 	WritePrivateProfileString("reaper", configStr, tmp, get_ini_file());
 
 	UpdateArrange();
@@ -1140,13 +1138,13 @@ void ToggleDisplayItemLabels (COMMAND_T* ct)
 void SetMidiResetOnPlayStop (COMMAND_T* ct)
 {
 	const char* configStr = "midisendflags";
-	int option; GetConfig(configStr, option);
 
-	option = ToggleBit(option, (int)ct->user);
-	SetConfig(configStr, option);
+	ConfigVar<int> option(configStr);
+	if(!option) return;
+	*option = ToggleBit(*option, (int)ct->user);
 
 	char tmp[256];
-	_snprintfSafe(tmp, sizeof(tmp), "%d", option);
+	_snprintfSafe(tmp, sizeof(tmp), "%d", *option);
 	WritePrivateProfileString("reaper", configStr, tmp, get_ini_file());
 }
 
@@ -1155,41 +1153,39 @@ void SetOptionsFX (COMMAND_T* ct)
 	if ((int)ct->user == 1)
 	{
 		const char* configStr = "runallonstop";
-		int option; GetConfig(configStr, option);
+		ConfigVar<int> option(configStr);
 
 		// Set only if "Run FX when stopped" is turned on (otherwise the option is disabled so we don't allow the user to change it)
-		if (GetBit(option, 0))
+		if (option && GetBit(*option, 0))
 		{
-			option = ToggleBit(option, 3);
-			SetConfig(configStr, option);
+			*option = ToggleBit(*option, 3);
 
 			char tmp[256];
-			_snprintfSafe(tmp, sizeof(tmp), "%d", option);
+			_snprintfSafe(tmp, sizeof(tmp), "%d", *option);
 			WritePrivateProfileString("reaper", configStr, tmp, get_ini_file());
 		}
 	}
 	else if ((int)ct->user == 2)
 	{
 		const char* configStr = "loopstopfx";
-		int option; GetConfig(configStr, option);
+		ConfigVar<int> option(configStr);
+		if(!option) return;
 
-		option = ToggleBit(option, 0);
-		SetConfig(configStr, option);
+		*option = ToggleBit(*option, 0);
 
 		char tmp[256];
-		_snprintfSafe(tmp, sizeof(tmp), "%d", option);
+		_snprintfSafe(tmp, sizeof(tmp), "%d", *option);
 		WritePrivateProfileString("reaper", configStr, tmp, get_ini_file());
 	}
 	else
 	{
-		const char* configStr = "runallonstop";
-		int runallonstop; GetConfig(configStr, runallonstop);
+		const ConfigVar<int> runallonstop("runallonstop");
 
 		// Set only if "Run FX when stopped" is turned of (otherwise the option is disabled so we don't allow the user to change it)
-		if (!GetBit(runallonstop, 0))
+		if (runallonstop && !GetBit(*runallonstop, 0))
 		{
 			const char* configStr = "runafterstop";
-			SetConfig(configStr, abs((int)ct->user));
+			*ConfigVar<int>(configStr) = abs((int)ct->user);
 			char tmp[256];
 			_snprintfSafe(tmp, sizeof(tmp), "%d", abs((int)ct->user));
 			WritePrivateProfileString("reaper", configStr, tmp, get_ini_file());
@@ -1200,26 +1196,26 @@ void SetOptionsFX (COMMAND_T* ct)
 void SetMoveCursorOnPaste (COMMAND_T* ct)
 {
 	const char* configStr = "itemclickmovecurs";
-	int option; GetConfig(configStr, option);
 
-	option = ToggleBit(option, abs((int)ct->user));
-	SetConfig(configStr, option);
+	ConfigVar<int> option(configStr);
+	if(!option) return;
+	*option = ToggleBit(*option, abs((int)ct->user));
 
 	char tmp[256];
-	_snprintfSafe(tmp, sizeof(tmp), "%d", option);
+	_snprintfSafe(tmp, sizeof(tmp), "%d", *option);
 	WritePrivateProfileString("reaper", configStr, tmp, get_ini_file());
 }
 
 void SetPlaybackStopOptions (COMMAND_T* ct)
 {
-	const char* configStr = (((int)ct->user == 0) ? "stopprojlen" : "viewadvance");
-	int option; GetConfig(configStr, option);
+	const char* configStr = (int)ct->user == 0 ? "stopprojlen" : "viewadvance";
 
-	option = ToggleBit(option, ((int)ct->user));
-	SetConfig(configStr, option);
+	ConfigVar<int> option(configStr);
+	if(!option) return;
+	*option = ToggleBit(*option, (int)ct->user);
 
 	char tmp[256];
-	_snprintfSafe(tmp, sizeof(tmp), "%d", option);
+	_snprintfSafe(tmp, sizeof(tmp), "%d", *option);
 	WritePrivateProfileString("reaper", configStr, tmp, get_ini_file());
 }
 
@@ -1228,7 +1224,7 @@ void SetGridMarkerZOrder (COMMAND_T* ct)
 	const char* configStr = (((int)ct->user > 0) ? "gridinbg" : "gridinbg2");
 
 	int option = abs((int)ct->user) - 1;
-	SetConfig(configStr, option);
+	ConfigVar<int>(configStr).try_set(option);
 
 	char tmp[256];
 	_snprintfSafe(tmp, sizeof(tmp), "%d", option);
@@ -1246,13 +1242,13 @@ void SetAutoStretchMarkers(COMMAND_T* ct)
 
 void CycleRecordModes (COMMAND_T* ct)
 {
-	const char* configStr = "projrecmode";
-	int mode; GetConfig(configStr, mode);
-	if (++mode > 2) mode = 0;
+	ConfigVar<int> mode("projrecmode");
+	if(!mode) return;
+	if (++*mode > 2) mode = 0;
 
-	if      (mode == 0) Main_OnCommandEx(40253, 0, NULL);
-	else if (mode == 1) Main_OnCommandEx(40252, 0, NULL);
-	else if (mode == 2) Main_OnCommandEx(40076, 0, NULL);
+	if      (*mode == 0) Main_OnCommandEx(40253, 0, NULL);
+	else if (*mode == 1) Main_OnCommandEx(40252, 0, NULL);
+	else if (*mode == 2) Main_OnCommandEx(40076, 0, NULL);
 }
 
 /******************************************************************************
@@ -1562,31 +1558,31 @@ void ClearProjectTrackSelAction (COMMAND_T* ct)
 ******************************************************************************/
 int IsSnapFollowsGridVisOn (COMMAND_T* ct)
 {
-	int option; GetConfig("projshowgrid", option);
+	const int option = ConfigVar<int>("projshowgrid").value_or(0);
 	return !GetBit(option, 15);
 }
 
 int IsPlaybackFollowsTempoChangeOn (COMMAND_T* ct)
 {
-	int option; GetConfig("seekmodes", option);
+	const int option = ConfigVar<int>("seekmodes").value_or(0);
 	return GetBit(option, 5);
 }
 
 int IsTrimNewVolPanEnvsOn (COMMAND_T* ct)
 {
-	int option; GetConfig("envtrimadjmode", option);
+	const int option = ConfigVar<int>("envtrimadjmode").value_or(0);
 	return (option == (int)ct->user);
 }
 
 int IsToggleDisplayItemLabelsOn (COMMAND_T* ct)
 {
-	int option; GetConfig("labelitems2", option);
+	const int option = ConfigVar<int>("labelitems2").value_or(0);
 	return ((int)ct->user == 4) ? !GetBit(option, (int)ct->user) : GetBit(option, (int)ct->user);
 }
 
 int IsSetMidiResetOnPlayStopOn (COMMAND_T* ct)
 {
-	int option; GetConfig("midisendflags", option);
+	const int option = ConfigVar<int>("midisendflags").value_or(0);
 	return !GetBit(option, (int)ct->user);
 }
 
@@ -1594,37 +1590,37 @@ int IsSetOptionsFXOn (COMMAND_T* ct)
 {
 	if ((int)ct->user == 1)
 	{
-		int option; GetConfig("runallonstop", option);
+		const int option = ConfigVar<int>("runallonstop").value_or(0);
 		return GetBit(option, 0) ? GetBit(option, 3) : 0; // report as false if "Run FX when stopped" is turned off (because the option is then disabled in the preferences)
 	}
 	else if ((int)ct->user == 2)
 	{
-		int option; GetConfig("loopstopfx", option);
+		const int option = ConfigVar<int>("loopstopfx").value_or(0);
 		return GetBit(option, 0);
 	}
 	else
 	{
-		int runallonstop; GetConfig("runallonstop", runallonstop);
-		int option; GetConfig("runafterstop", option);
+		const int runallonstop = ConfigVar<int>("runallonstop").value_or(0);
+		const int option = ConfigVar<int>("runafterstop").value_or(0);
 		return GetBit(runallonstop, 0) ? 0 : option == abs((int)ct->user) ; // report as false if "Run FX when stopped" is turned on (because the option is then disabled in the preferences)
 	}
 }
 
 int IsSetMoveCursorOnPasteOn (COMMAND_T* ct)
 {
-	int option; GetConfig("itemclickmovecurs", option);
+	const int option = ConfigVar<int>("itemclickmovecurs").value_or(0);
 	return ((int)ct->user < 0) ? !GetBit(option, abs((int)ct->user)) : GetBit(option, abs((int)ct->user));
 }
 
 int IsSetPlaybackStopOptionsOn (COMMAND_T* ct)
 {
-	int option; GetConfig((((int)ct->user == 0) ? "stopprojlen" : "viewadvance"), option);
+	const int option = ConfigVar<int>((int)ct->user == 0 ? "stopprojlen" : "viewadvance").value_or(0);
 	return !!GetBit(option, (int)ct->user);
 }
 
 int IsSetGridMarkerZOrderOn (COMMAND_T* ct)
 {
-	int option; GetConfig((((int)ct->user > 0) ? "gridinbg" : "gridinbg2"), option);
+	const int option = ConfigVar<int>((int)ct->user > 0 ? "gridinbg" : "gridinbg2").value_or(0);
 
 	return option == abs((int)ct->user) - 1;
 }

--- a/Breeder/BR_MouseUtil.cpp
+++ b/Breeder/BR_MouseUtil.cpp
@@ -110,8 +110,7 @@ static MediaItem_Take* GetTakeFromItemY (MediaItem* item, int itemY, MediaTrack*
 	MediaItem_Take* take = NULL;
 	WritePtr(takeId, -1);
 
-	int takeLanes;
-	GetConfig("projtakelane", takeLanes);
+	const int takeLanes = ConfigVar<int>("projtakelane").value_or(0);
 
 	// Take lanes displayed
 	if (GetBit(takeLanes, 0))
@@ -550,7 +549,7 @@ bool BR_MouseInfo::SetDetectedCCLaneAsLastClicked ()
 		{
 			POINT point = m_ccLaneClickPoint;
 
-			int lockSettings; GetConfig("projsellock", lockSettings);
+			const int lockSettings = ConfigVar<int>("projsellock").value_or(0);
 			char itemLock = m_mouseInfo.inlineMidi ? (char)GetMediaItemInfo_Value(GetMediaItemTake_Item(m_mouseInfo.take), "C_LOCK") : 0;
 
 			// Get HWND and update point if needed
@@ -578,7 +577,7 @@ bool BR_MouseInfo::SetDetectedCCLaneAsLastClicked ()
 				}
 				else
 				{
-					SetConfig("projsellock", 23492); // lock item edges, fades, volume handles, stretch markers, item movement, take and track envelopes
+					ConfigVar<int>("projsellock").try_set(23492); // lock item edges, fades, volume handles, stretch markers, item movement, take and track envelopes
 					SetMediaItemInfo_Value(GetMediaItemTake_Item(m_mouseInfo.take), "C_LOCK", 0);
 				}
 			}
@@ -593,7 +592,7 @@ bool BR_MouseInfo::SetDetectedCCLaneAsLastClicked ()
 				SimulateMouseClick(hwnd, point, true);
 				if (m_mouseInfo.inlineMidi)
 				{
-					SetConfig("projsellock", lockSettings);
+					ConfigVar<int>("projsellock").try_set(lockSettings);
 					SetMediaItemInfo_Value(GetMediaItemTake_Item(m_mouseInfo.take), "C_LOCK", (double)itemLock);
 				}
 				update = true;
@@ -1344,7 +1343,7 @@ int BR_MouseInfo::IsMouseOverEnvelopeLineTrackLane (MediaTrack* track, int track
 	if (envLaneCount > 0)
 	{
 		int overlapLimit,trackGapTop, trackGapBottom;
-		GetConfig("env_ol_minh", overlapLimit);
+		overlapLimit = ConfigVar<int>("env_ol_minh").value_or(0);
 		GetTrackGap(trackHeight, &trackGapTop, &trackGapBottom);
 
 		int envLaneFull = trackHeight - trackGapTop - trackGapBottom;
@@ -1422,8 +1421,7 @@ int BR_MouseInfo::IsMouseOverEnvelopeLineTake (MediaItem_Take* take, int takeHei
 	int envelopeCount = (int)envelopes.size();
 	if (envelopeCount > 0)
 	{
-		int overlapLimit;
-		GetConfig("env_ol_minh", overlapLimit);
+		const int overlapLimit = ConfigVar<int>("env_ol_minh").value_or(0);
 		bool envelopesOverlapping = (overlapLimit >= 0 && takeHeight / envelopeCount < overlapLimit) ? (true) : (false);
 
 		// Each envelope has it's own lane, find the right one

--- a/Breeder/BR_ProjState.cpp
+++ b/Breeder/BR_ProjState.cpp
@@ -622,7 +622,7 @@ bool BR_MidiCCEvents::Restore (BR_MidiEditor& midiEditor, int lane, bool allVisi
 			if (!loopedItem)
 			{
 				// Extend item if needed
-				int midiVu; GetConfig("midivu", midiVu);
+				const int midiVu = ConfigVar<int>("midivu").value_or(0);
 				if (GetBit(midiVu, 14))
 				{
 					double itemStart = GetMediaItemInfo_Value(item, "D_POSITION");

--- a/Breeder/BR_Tempo.cpp
+++ b/Breeder/BR_Tempo.cpp
@@ -280,7 +280,7 @@ static bool MoveGridInit (COMMAND_T* ct, bool init)
 	bool initSuccessful = true;
 	if (init)
 	{
-		int projgridframe; GetConfig("projgridframe", projgridframe);
+		const int projgridframe = ConfigVar<int>("projgridframe").value_or(0);
 		if (((int)ct->user == 1 || (int)ct->user == 2) && projgridframe > 0)
 		{
 			initSuccessful = false;
@@ -294,15 +294,16 @@ static bool MoveGridInit (COMMAND_T* ct, bool init)
 		}
 		else
 		{
-			GetConfig("undomask", s_editCursorUndo);
+			ConfigVar<int> undomask("undomask");
+			s_editCursorUndo = undomask.value_or(0);
 			initSuccessful = PositionAtMouseCursor(true) != -1;
 			if (initSuccessful)
-				SetConfig("undomask", ClearBit(s_editCursorUndo, 3));
+				undomask.try_set(ClearBit(s_editCursorUndo, 3));
 		}
 	}
 	else
 	{
-		SetConfig("undomask", s_editCursorUndo);
+		ConfigVar<int>("undomask").try_set(s_editCursorUndo);
 		delete g_moveGridTempoMap;
 		g_moveGridTempoMap = NULL;
 	}
@@ -475,9 +476,10 @@ void MoveGridToEditPlayCursor (COMMAND_T* ct)
 	BR_Envelope tempoMap(GetTempoEnv());
 
 	// Prevent play cursor from jumping
-	int seekmodes; GetConfig("seekmodes", seekmodes);
+	ConfigVar<int> seekmodes("seekmodes");
+	const int originalSeekmodes = seekmodes.value_or(0);
 	if ((int)ct->user == 1 || (int)ct->user == 3)
-		SetConfig("seekmodes", ClearBit(seekmodes, 5));
+		seekmodes.try_set(ClearBit(originalSeekmodes, 5));
 
 	// Find closest grid
 	double grid = 0;
@@ -530,7 +532,7 @@ void MoveGridToEditPlayCursor (COMMAND_T* ct)
 		RemoveTempoMap();
 
 	PreventUIRefresh(-1);
-	SetConfig("seekmodes", seekmodes);
+	seekmodes.try_set(originalSeekmodes);
 }
 
 void MoveTempo (COMMAND_T* ct)
@@ -1179,7 +1181,7 @@ void DeleteTempoPreserveItems (COMMAND_T* ct)
 	}
 
 	// Readjust unselected tempo markers if needed
-	int timeBase; GetConfig("tempoenvtimelock", timeBase);
+	const int timeBase = ConfigVar<int>("tempoenvtimelock").value_or(0);
 	if (timeBase != 0)
 	{
 		double offset = 0;
@@ -1293,8 +1295,8 @@ void SelectMovePartialTimeSig (COMMAND_T* ct)
 {
 	PreventUIRefresh(1);
 
-	int tempoTimeBase; GetConfig("tempoenvtimelock", tempoTimeBase); // always work with tempo timbase beats
-	SetConfig("tempoenvtimelock", 1);                                // when running these actions
+	// always work with tempo timbase beats when running these actions
+	ConfigVarOverride<int> tempoTimeBase("tempoenvtimelock", 1);
 
 	bool update = false;
 	BR_Envelope tempoMap(GetTempoEnv());
@@ -1359,7 +1361,6 @@ void SelectMovePartialTimeSig (COMMAND_T* ct)
 		}
 	}
 
-	SetConfig("tempoenvtimelock", tempoTimeBase);
 	if (tempoMap.Commit() || update)
 		Undo_OnStateChangeEx2(NULL, SWS_CMD_SHORTNAME(ct), UNDO_STATE_TRACKCFG, -1);
 
@@ -1617,11 +1618,11 @@ void ConvertMarkersToTempoDialog (COMMAND_T* ct)
 	{
 		// Detect timebase
 		bool cancel = false;
-		int timebase; GetConfig("itemtimelock", timebase);
-		if (timebase)
+		ConfigVar<int> timebase("itemtimelock");
+		if (timebase && *timebase != 0)
 		{
 			int answer = MessageBox(g_hwndParent, __LOCALIZE("Project timebase is not set to time. Do you want to set it now?","sws_DLG_166"), __LOCALIZE("SWS/BR - Warning", "sws_mbox"), MB_YESNOCANCEL);
-			if      (answer == 6) SetConfig("itemtimelock", 0);
+			if      (answer == 6) *timebase = 0;
 			else if (answer == 2) cancel = true;
 		}
 

--- a/Breeder/BR_Util.h
+++ b/Breeder/BR_Util.h
@@ -116,16 +116,6 @@ bool IsPaused (ReaProject* proj);
 bool IsRecording (ReaProject* proj);
 bool AreAllCoordsZero (RECT& r);
 PCM_source* DuplicateSource (PCM_source* source); // if the option "Toggle pooled (ghost) MIDI source data when copying media items", using PCM_source->Duplicate() will pool original and new source...use this function to escape this when necessary
-template <typename T> void GetConfig (const char* key, T& val) 
-{
-  void *p = GetConfigVar(key);
-  val = p ? *static_cast<T*>(p) : (T)0;
-}
-template <typename T> void SetConfig (const char* key, T  val) 
-{
-  void *p = GetConfigVar(key);
-  if (p) *static_cast<T*>(p) = val;
-}
 
 /******************************************************************************
 * Tracks                                                                      *

--- a/Fingers/EnvelopeCommands.cpp
+++ b/Fingers/EnvelopeCommands.cpp
@@ -214,7 +214,7 @@ void CompressExpandPoints::doCommand(int flag)
 
     double m = m_dGradientFactor * (m_dAmount - 1) * (pN - p0);
 
-    if (envelope.IsTempo() && *(int*)GetConfigVar("tempoenvtimelock") == 1)
+    if (envelope.IsTempo() && *ConfigVar<int>("tempoenvtimelock") == 1)
     {
         double t0, b0; int s0;
         envelope.GetPoint(0, &t0, &b0, &s0, NULL);

--- a/Fingers/FNG_Settings.h
+++ b/Fingers/FNG_Settings.h
@@ -1,9 +1,8 @@
 #ifndef _FNG_SETTINGS_H_
 #define _FNG_SETTINGS_H_
 
-template
-<typename T>
-__inline void setReaperProperty(const std::string &key, const T& value)
+template <typename T>
+inline void setReaperProperty(const std::string &key, const T& value)
 {
 	std::ostringstream oss;
 	oss << value;
@@ -11,26 +10,16 @@ __inline void setReaperProperty(const std::string &key, const T& value)
 }
 
 template <>
-__inline void setReaperProperty<std::string>(const std::string &key, const std::string &value)
+inline void setReaperProperty<std::string>(const std::string &key, const std::string &value)
 {
 	WritePrivateProfileString("fingers", key.c_str(), value.c_str(), get_ini_file());
 }
 
-__inline std::string getReaperProperty(const std::string &key)
+inline std::string getReaperProperty(const std::string &key)
 {
 	char value[512];
 	GetPrivateProfileString("fingers", key.c_str(), NULL, value, 512, get_ini_file());
 	return std::string(value);
-}
-
-__inline void *getInternalReaperProperty(const std::string &key)
-{
-	int temp;
-	int offset = projectconfig_var_getoffs(key.c_str(), &temp);
-	if (offset)
-		return projectconfig_var_addr(0, offset);
-	else
-		return get_config_var(key.c_str(), &offset);
 }
 
 #endif /*_FNG_SETTINGS_H_ */

--- a/MarkerList/MarkerList.cpp
+++ b/MarkerList/MarkerList.cpp
@@ -224,9 +224,9 @@ void SWS_MarkerListWnd::Update(bool bForce)
 	// Change the time string if the project time mode changes
 	static int prevTimeMode = -1;
 	bool bChanged = bForce;
-	if (*(int*)GetConfigVar("projtimemode") != prevTimeMode)
+	if (*ConfigVar<int>("projtimemode") != prevTimeMode)
 	{
-		prevTimeMode = *(int*)GetConfigVar("projtimemode");
+		prevTimeMode = *ConfigVar<int>("projtimemode");
 		bChanged = true;
 	}
 

--- a/Misc/Adam.cpp
+++ b/Misc/Adam.cpp
@@ -431,19 +431,20 @@ void AWFillGapsAdv(const char* title, char* retVals)
 							// (don't need take loop to adjust all start offsets)
 							double splitPoint = item1TransPos + presTrans - transFade;
 
-							// Check for default item fades
-							int fadeStateStore = fadeStateStore = *(int*)(GetConfigVar("splitautoxfade"));
-							*(int*)(GetConfigVar("splitautoxfade")) = 12;
+							MediaItem *item1B;
 
-							// Split item1 at the split point
-							MediaItem* item1B = SplitMediaItem(item1, splitPoint);
+							{
+								// Check for default item fades
+								ConfigVarOverride<int> fadeState("splitautoxfade", 12);
 
-							int item1Group = (int)GetMediaItemInfo_Value(item1, "I_GROUPID");
+								// Split item1 at the split point
+								item1B = SplitMediaItem(item1, splitPoint);
 
-							if (item1Group)
-								SetMediaItemInfo_Value(item1B, "I_GROUPID", item1Group + maxGroupID);
+								int item1Group = (int)GetMediaItemInfo_Value(item1, "I_GROUPID");
 
-							*(int*)(GetConfigVar("splitautoxfade")) = fadeStateStore;
+								if (item1Group)
+									SetMediaItemInfo_Value(item1B, "I_GROUPID", item1Group + maxGroupID);
+							}
 
 							// Get new item1 length after split
 							item1Length = GetMediaItemInfo_Value(item1, "D_LENGTH") + transFade;
@@ -671,7 +672,7 @@ void AWFillGapsQuick(COMMAND_T* t)
 
 void AWFillGapsQuickXFade(COMMAND_T* t)
 {
-	double fadeLength = fabs(*(double*)GetConfigVar("deffadelen"));
+	double fadeLength = fabs(*ConfigVar<double>("deffadelen"));
 
 	// Run loop for every track in project
 	for (int trackIndex = 0; trackIndex < GetNumTracks(); trackIndex++)
@@ -844,7 +845,7 @@ void AWRecordConditional(COMMAND_T* t)
 	double t1, t2;
 	GetSet_LoopTimeRange(false, false, &t1, &t2, false);
 
-	if (*(int*)GetConfigVar("projrecmode") != 0) // 0 is item punch mode
+	if (*ConfigVar<int>("projrecmode") != 0) // 0 is item punch mode
 	{
 		if (t1 != t2)
 		{
@@ -951,12 +952,12 @@ void AWDoAutoGroup(bool rec)
 		{
 			WDL_TypedBuf<MediaItem*> selItems;
 			SWS_GetSelectedMediaItems(&selItems);        
-			if (selItems.GetSize() > 1 && ((*(int*)GetConfigVar("autoxfade") & 4) || (*(int*)GetConfigVar("autoxfade") & 8))) // (Don't group if not in tape or overlap record mode, takes mode is messy) NF: added new auto group in takes mode functionality below
+			if (selItems.GetSize() > 1 && ((*ConfigVar<int>("autoxfade") & 4) || (*ConfigVar<int>("autoxfade") & 8))) // (Don't group if not in tape or overlap record mode, takes mode is messy) NF: added new auto group in takes mode functionality below
 			{
 				// check if we're in 'Autopunch selected items' mode
 				// because in this mode sel. items don't get automatically unselected after recording,
 				// so 'simple' grouping would screw things up
-				if ((*(int*)GetConfigVar("projrecmode")) == 0) {
+				if ((*ConfigVar<int>("projrecmode")) == 0) {
 					NFDoAutoGroupTakesMode(selItems);
 					g_AWIsRecording = false;
 					return;
@@ -993,7 +994,7 @@ void AWDoAutoGroup(bool rec)
 			}
 
 			// #587 Auto group in takes mode
-			else if (selItems.GetSize() > 1 && !(*(int*)GetConfigVar("autoxfade") & 4) && !(*(int*)GetConfigVar("autoxfade") & 8))
+			else if (selItems.GetSize() > 1 && !(*ConfigVar<int>("autoxfade") & 4) && !(*ConfigVar<int>("autoxfade") & 8))
 			{
 				NFDoAutoGroupTakesMode(selItems);
 			}
@@ -1241,7 +1242,7 @@ void AWRecordConditionalAutoGroup(COMMAND_T* t)
 	double t1, t2;
 	GetSet_LoopTimeRange(false, false, &t1, &t2, false);
 
-	if (*(int*)GetConfigVar("projrecmode") != 0) // 0 is item punch mode for projrecmode
+	if (*ConfigVar<int>("projrecmode") != 0) // 0 is item punch mode for projrecmode
 	{
 		if (t1 != t2)
 		{
@@ -1280,7 +1281,7 @@ void AWPlayStopAutoGroup(COMMAND_T* t)
 		Main_OnCommand(1016, 0); //If recording, Stop
 		int numItems = CountSelectedMediaItems(0);
 
-		if ((numItems > 1) && ((*(int*)GetConfigVar("autoxfade") & 4) || (*(int*)GetConfigVar("autoxfade") & 8))) // Don't group if not in tape or overlap record mode, takes mode is messy
+		if ((numItems > 1) && ((*ConfigVar<int>("autoxfade") & 4) || (*ConfigVar<int>("autoxfade") & 8))) // Don't group if not in tape or overlap record mode, takes mode is messy
 		{
 			Main_OnCommand(40032, 0); //Group selected items
 		}
@@ -1439,7 +1440,7 @@ void AWFadeSelection(COMMAND_T* t)
 
 							else
 							{
-								dFadeLen = fabs(*(double*)GetConfigVar("defsplitxfadelen")); // Abs because neg value means "not auto"
+								dFadeLen = fabs(*ConfigVar<double>("defsplitxfadelen")); // Abs because neg value means "not auto"
 								dEdgeAdj1 = dFadeLen / 2.0;
 								dEdgeAdj2 = dFadeLen / 2.0;
 
@@ -1792,7 +1793,7 @@ void AWFadeSelection(COMMAND_T* t)
 
 					else if (selStart <= dStart1 && selEnd >= dEnd1)
 					{
-						fadeLength = fabs(*(double*)GetConfigVar("deffadelen")); // Abs because neg value means "not auto"
+						fadeLength = fabs(*ConfigVar<double>("deffadelen")); // Abs because neg value means "not auto"
 						SetMediaItemInfo_Value(item1, "D_FADEINLEN", fadeLength);
 
 					}
@@ -1837,7 +1838,7 @@ void AWFadeSelection(COMMAND_T* t)
 					}
 					else if (selStart <= dStart1 && selEnd >= dEnd1)
 					{
-						fadeLength = fabs(*(double*)GetConfigVar("deffadelen")); // Abs because neg value means "not auto"
+						fadeLength = fabs(*ConfigVar<double>("deffadelen")); // Abs because neg value means "not auto"
 						SetMediaItemInfo_Value(item1, "D_FADEOUTLEN", fadeLength);
 					}
 
@@ -2457,18 +2458,15 @@ void AWPaste(COMMAND_T* t)
 {
 	Undo_BeginBlock();
 
-	int* pTrimMode = (int*)GetConfigVar("autoxfade");
+	const int pTrimMode = *ConfigVar<int>("autoxfade");
 
 	if (GetCursorContext() == 1)
 	{
-		int* pCursorMode = (int*)GetConfigVar("itemclickmovecurs");
-		int savedMode = *pCursorMode;
-		*pCursorMode &= ~8; // Enable "move edit cursor on paste" so that the time selection can be set properly
+		// Enable "move edit cursor on paste" so that the time selection can be set properly
+		const ConfigVar<int> pCursorMode("itemclickmovecurs");
+		ConfigVarOverride<int> tmpCursorMode("itemclickmodecurs", *pCursorMode & ~8);
 
-
-
-
-		if (*pTrimMode & 2)
+		if (pTrimMode & 2)
 		{
 			double cursorPos = GetCursorPosition();
 
@@ -2486,10 +2484,9 @@ void AWPaste(COMMAND_T* t)
 			// Go to beginning of selection, this is smoother than using actual action and easier
 			SetEditCurPos(cursorPos, 0, 0);
 
-
 			DoSelectFirstOfSelectedTracks(NULL);
 
-			*pCursorMode = savedMode;
+			tmpCursorMode.rollback();
 
 			Main_OnCommand(40058, 0); // Paste items
 			Main_OnCommand(40380, 0); // Set item timebase to project default (wish could copy time base from source item but too hard)
@@ -2499,7 +2496,6 @@ void AWPaste(COMMAND_T* t)
 		}
 		else
 			Main_OnCommand(40058, 0); // Std paste
-
 	}
 
 	else
@@ -2508,7 +2504,6 @@ void AWPaste(COMMAND_T* t)
 	UpdateTimeline();
 
 	Undo_EndBlock(SWS_CMD_SHORTNAME(t), UNDO_STATE_ALL);
-
 }
 
 
@@ -2528,17 +2523,13 @@ void AWConsolidateSelection(COMMAND_T* t)
 
 	int trackOn = 1;
 
-	// Save trim mode state
-	int* pTrimMode = (int*)GetConfigVar("autoxfade");
-	int savedMode = *pTrimMode;
-
 	// Turn trim mode off
-	*pTrimMode &= ~2;
+	const ConfigVar<int> autoxfade("autoxfade");
+	ConfigVarOverride<int> pTrimMode(autoxfade, *autoxfade & ~2);
 
 	SelTracksWItems();
 
 	SaveSelected();
-
 
 	for (int iTrack = 1; iTrack <= GetNumTracks(); iTrack++)
 	{
@@ -2560,12 +2551,9 @@ void AWConsolidateSelection(COMMAND_T* t)
 		}
 	}
 
-	*pTrimMode = savedMode;
-
 	RestoreSelected();
 
 	Undo_EndBlock(SWS_CMD_SHORTNAME(t), UNDO_STATE_ALL);
-
 }
 
 
@@ -2591,49 +2579,49 @@ void AWSelectStretched(COMMAND_T* t)
 }
 
 // Metronome actions
-void AWMetrPlayOn(COMMAND_T* = NULL)        { *(int*)GetConfigVar("projmetroen") |= 2;}
-void AWMetrPlayOff(COMMAND_T* = NULL)       { *(int*)GetConfigVar("projmetroen") &= ~2;}
-void AWMetrRecOn(COMMAND_T* = NULL)         { *(int*)GetConfigVar("projmetroen") |= 4;}
-void AWMetrRecOff(COMMAND_T* = NULL)        { *(int*)GetConfigVar("projmetroen") &= ~4;}
-void AWCountPlayOn(COMMAND_T* = NULL)       { *(int*)GetConfigVar("projmetroen") |= 8;}
-void AWCountPlayOff(COMMAND_T* = NULL)      { *(int*)GetConfigVar("projmetroen") &= ~8;}
-void AWCountRecOn(COMMAND_T* = NULL)        { *(int*)GetConfigVar("projmetroen") |= 16;}
-void AWCountRecOff(COMMAND_T* = NULL)       { *(int*)GetConfigVar("projmetroen") &= ~16;}
-void AWMetrPlayToggle(COMMAND_T* = NULL)    { *(int*)GetConfigVar("projmetroen") ^= 2;}
-void AWMetrRecToggle(COMMAND_T* = NULL)     { *(int*)GetConfigVar("projmetroen") ^= 4;}
-void AWCountPlayToggle(COMMAND_T* = NULL)   { *(int*)GetConfigVar("projmetroen") ^= 8;}
-void AWCountRecToggle(COMMAND_T* = NULL)    { *(int*)GetConfigVar("projmetroen") ^= 16;}
-int IsMetrPlayOn(COMMAND_T* = NULL)     { return (*(int*)GetConfigVar("projmetroen") & 2)  != 0; }
-int IsMetrRecOn(COMMAND_T* = NULL)          { return (*(int*)GetConfigVar("projmetroen") & 4)  != 0; }
-int IsCountPlayOn(COMMAND_T* = NULL)        { return (*(int*)GetConfigVar("projmetroen") & 8)  != 0; }
-int IsCountRecOn(COMMAND_T* = NULL)     { return (*(int*)GetConfigVar("projmetroen") & 16) != 0; }
+void AWMetrPlayOn(COMMAND_T* = NULL)        { *ConfigVar<int>("projmetroen") |= 2;}
+void AWMetrPlayOff(COMMAND_T* = NULL)       { *ConfigVar<int>("projmetroen") &= ~2;}
+void AWMetrRecOn(COMMAND_T* = NULL)         { *ConfigVar<int>("projmetroen") |= 4;}
+void AWMetrRecOff(COMMAND_T* = NULL)        { *ConfigVar<int>("projmetroen") &= ~4;}
+void AWCountPlayOn(COMMAND_T* = NULL)       { *ConfigVar<int>("projmetroen") |= 8;}
+void AWCountPlayOff(COMMAND_T* = NULL)      { *ConfigVar<int>("projmetroen") &= ~8;}
+void AWCountRecOn(COMMAND_T* = NULL)        { *ConfigVar<int>("projmetroen") |= 16;}
+void AWCountRecOff(COMMAND_T* = NULL)       { *ConfigVar<int>("projmetroen") &= ~16;}
+void AWMetrPlayToggle(COMMAND_T* = NULL)    { *ConfigVar<int>("projmetroen") ^= 2;}
+void AWMetrRecToggle(COMMAND_T* = NULL)     { *ConfigVar<int>("projmetroen") ^= 4;}
+void AWCountPlayToggle(COMMAND_T* = NULL)   { *ConfigVar<int>("projmetroen") ^= 8;}
+void AWCountRecToggle(COMMAND_T* = NULL)    { *ConfigVar<int>("projmetroen") ^= 16;}
+int IsMetrPlayOn(COMMAND_T* = NULL)     { return (*ConfigVar<int>("projmetroen") & 2)  != 0; }
+int IsMetrRecOn(COMMAND_T* = NULL)          { return (*ConfigVar<int>("projmetroen") & 4)  != 0; }
+int IsCountPlayOn(COMMAND_T* = NULL)        { return (*ConfigVar<int>("projmetroen") & 8)  != 0; }
+int IsCountRecOn(COMMAND_T* = NULL)     { return (*ConfigVar<int>("projmetroen") & 16) != 0; }
 
 // Editing Preferences
-void AWRelEdgeOn(COMMAND_T* = NULL)         { *(int*)GetConfigVar("relativeedges") |= 1;}
-void AWRelEdgeOff(COMMAND_T* = NULL)        { *(int*)GetConfigVar("relativeedges") &= ~1;}
-void AWRelEdgeToggle(COMMAND_T* = NULL)     { *(int*)GetConfigVar("relativeedges") ^= 1;}
-bool IsRelEdgeOn(COMMAND_T* = NULL)         { return (*(int*)GetConfigVar("relativeedges") & 1)  != 0; }
+void AWRelEdgeOn(COMMAND_T* = NULL)         { *ConfigVar<int>("relativeedges") |= 1;}
+void AWRelEdgeOff(COMMAND_T* = NULL)        { *ConfigVar<int>("relativeedges") &= ~1;}
+void AWRelEdgeToggle(COMMAND_T* = NULL)     { *ConfigVar<int>("relativeedges") ^= 1;}
+bool IsRelEdgeOn(COMMAND_T* = NULL)         { return (*ConfigVar<int>("relativeedges") & 1)  != 0; }
 
-void AWClrTimeSelClkOn(COMMAND_T* = NULL)           { *(int*)GetConfigVar("itemclickmovecurs") |= 68;}
-void AWClrTimeSelClkOff(COMMAND_T* = NULL)          { *(int*)GetConfigVar("itemclickmovecurs") &= ~68;}
+void AWClrTimeSelClkOn(COMMAND_T* = NULL)           { *ConfigVar<int>("itemclickmovecurs") |= 68;}
+void AWClrTimeSelClkOff(COMMAND_T* = NULL)          { *ConfigVar<int>("itemclickmovecurs") &= ~68;}
 
 void AWClrTimeSelClkToggle(COMMAND_T* = NULL)
 {
 	// If "click to clear" and "move cursor on time change" are both ON or both OFF, just toggle
-	if ((*(int*)GetConfigVar("itemclickmovecurs") & 64 && *(int*)GetConfigVar("itemclickmovecurs") & 4) || (!(*(int*)GetConfigVar("itemclickmovecurs") & 64) && !(*(int*)GetConfigVar("itemclickmovecurs") & 4)))
-		*(int*)GetConfigVar("itemclickmovecurs") ^= 68;
+	if ((*ConfigVar<int>("itemclickmovecurs") & 64 && *ConfigVar<int>("itemclickmovecurs") & 4) || (!(*ConfigVar<int>("itemclickmovecurs") & 64) && !(*ConfigVar<int>("itemclickmovecurs") & 4)))
+		*ConfigVar<int>("itemclickmovecurs") ^= 68;
 
 	// If one of them is different than the other, turn them both ON
 	else
-		*(int*)GetConfigVar("itemclickmovecurs") |= 68;
+		*ConfigVar<int>("itemclickmovecurs") |= 68;
 }
 
-int IsClrTimeSelClkOn(COMMAND_T* = NULL)        { return (*(int*)GetConfigVar("itemclickmovecurs") & 68)  != 0; }
+int IsClrTimeSelClkOn(COMMAND_T* = NULL)        { return (*ConfigVar<int>("itemclickmovecurs") & 68)  != 0; }
 
-void AWClrLoopClkOn(COMMAND_T* = NULL)          { *(int*)GetConfigVar("itemclickmovecurs") |= 32;}
-void AWClrLoopClkOff(COMMAND_T* = NULL)         { *(int*)GetConfigVar("itemclickmovecurs") &= ~32;}
-void AWClrLoopClkToggle(COMMAND_T* = NULL)      { *(int*)GetConfigVar("itemclickmovecurs") ^= 32;}
-int IsClrLoopClkOn(COMMAND_T* = NULL)           { return (*(int*)GetConfigVar("itemclickmovecurs") & 32)  != 0; }
+void AWClrLoopClkOn(COMMAND_T* = NULL)          { *ConfigVar<int>("itemclickmovecurs") |= 32;}
+void AWClrLoopClkOff(COMMAND_T* = NULL)         { *ConfigVar<int>("itemclickmovecurs") &= ~32;}
+void AWClrLoopClkToggle(COMMAND_T* = NULL)      { *ConfigVar<int>("itemclickmovecurs") ^= 32;}
+int IsClrLoopClkOn(COMMAND_T* = NULL)           { return (*ConfigVar<int>("itemclickmovecurs") & 32)  != 0; }
 
 void UpdateTimebaseToolbar()
 {
@@ -2649,20 +2637,20 @@ void UpdateTimebaseToolbar()
 
 void AWProjectTimebase(COMMAND_T* t)
 {
-	*(int*)GetConfigVar("itemtimelock") = (int)t->user;
+	*ConfigVar<int>("itemtimelock") = (int)t->user;
 	UpdateTimebaseToolbar();
 	// ?Undo_OnStateChangeEx(SWS_CMD_SHORTNAME(t), UNDO_STATE_MISCCFG, -1);
 }
 
 int IsProjectTimebase(COMMAND_T* t)
 {
-	return (*(int*)GetConfigVar("itemtimelock") == (int)t->user);
+	return (*ConfigVar<int>("itemtimelock") == (int)t->user);
 }
 
 
 int IsGridTriplet(COMMAND_T* = NULL)
 {
-	double grid = *(double*)GetConfigVar("projgriddiv");
+	double grid = *ConfigVar<double>("projgriddiv");
 	if (grid < 1e-8) return 0;
 	double n = 1.0/grid;
 
@@ -2674,7 +2662,7 @@ int IsGridTriplet(COMMAND_T* = NULL)
 
 int IsGridDotted(COMMAND_T* = NULL)
 {
-	double grid = *(double*)GetConfigVar("projgriddiv");
+	double grid = *ConfigVar<double>("projgriddiv");
 	if (grid < 1e-8) return 0;
 	double n = 1.0/grid;
 
@@ -2690,7 +2678,7 @@ void AWToggleDotted(COMMAND_T* = NULL);
 
 void AWToggleTriplet(COMMAND_T* = NULL)
 {
-	double* pGridDiv = (double*)GetConfigVar("projgriddiv");
+	ConfigVar<double> pGridDiv("projgriddiv");
 
 	if (IsGridDotted())
 		AWToggleDotted();
@@ -2710,7 +2698,7 @@ void AWToggleTriplet(COMMAND_T* = NULL)
 
 void AWToggleDotted(COMMAND_T*)
 {
-	double* pGridDiv = (double*)GetConfigVar("projgriddiv");
+	ConfigVar<double> pGridDiv("projgriddiv");
 
 	if (IsGridTriplet())
 		AWToggleTriplet();
@@ -2806,7 +2794,7 @@ int IsClickUnmuted(COMMAND_T* = NULL)
 		}
 
 	}
-	if (*(int*)GetConfigVar("projmetroen") & 1)
+	if (*ConfigVar<int>("projmetroen") & 1)
 		return 1;
 	return 0;
 }
@@ -2865,7 +2853,7 @@ void AWCascadeInputs(COMMAND_T* t)
 
 void AWSelectGroupIfGrouping(COMMAND_T* = NULL)
 {
-	bool groupOverride = *(bool*)GetConfigVar("projgroupover");
+	const bool groupOverride = *ConfigVar<int>("projgroupover");
 
 	if (!groupOverride)
 		Main_OnCommand(40034, 0); //Select all items in groups
@@ -2876,15 +2864,13 @@ void AWSplitXFadeLeft(COMMAND_T* t)
 	Undo_BeginBlock();
 
 	double cursorPos = GetCursorPositionEx(0);
-	double dFadeLen;
-	int fadeShape;
-	dFadeLen = fabs(*(double*)GetConfigVar("defsplitxfadelen")); // Abs because neg value means "not auto"
-	fadeShape = *(int*)GetConfigVar("defxfadeshape");
+
+	// Abs because neg value means "not auto"
+	const double dFadeLen = fabs(*ConfigVar<double>("defsplitxfadelen"));
+	const int fadeShape = *ConfigVar<int>("defxfadeshape");
 
 	//turn OFF autocrossfades on split
-
-	int fadeStateStore = *(int*)(GetConfigVar("splitautoxfade"));
-	*(int*)(GetConfigVar("splitautoxfade")) = 12;
+	ConfigVarOverride<int> tmpXfade("splitautoxfade", 12);
 
 	WDL_TypedBuf<MediaItem*> items;
 	SWS_GetSelectedMediaItems(&items);
@@ -2929,9 +2915,6 @@ void AWSplitXFadeLeft(COMMAND_T* t)
 		SetMediaItemInfo_Value(items.Get()[i], "B_UISEL", 0);
 	}
 	PreventUIRefresh(-1);
-
-	// restore xfade setting
-	*(int*)(GetConfigVar("splitautoxfade")) = fadeStateStore;
 
 	UpdateArrange();
 	Undo_EndBlock(SWS_CMD_SHORTNAME(t), UNDO_STATE_ITEMS);

--- a/Misc/EditCursor.cpp
+++ b/Misc/EditCursor.cpp
@@ -94,17 +94,18 @@ void MoveCursorAndSel(COMMAND_T* ct)
 void MoveCursorSample(COMMAND_T* ct)
 {
 	double dPos = GetCursorPosition();
-	int* pSrate = (int*)GetConfigVar("projsrate");
-	if (!pSrate)
+
+	const ConfigVar<int> projsrate("projsrate");
+	if (!projsrate)
 		return;
-	double dSrate = (double)*pSrate;
-	INT64 iCurSample = (INT64)(dPos * dSrate + 0.5);
-	if (ct->user == -1 && (dPos == (double)(iCurSample / dSrate)))
+
+	INT64 iCurSample = (INT64)(dPos * *projsrate + 0.5);
+	if (ct->user == -1 && (dPos == (double)(iCurSample / *projsrate)))
 		iCurSample--;
 	else if (ct->user == 1)
 		iCurSample++;
 
-	double dNewPos = (double)(iCurSample / dSrate);
+	double dNewPos = (double)(iCurSample / *projsrate);
 
 	SetEditCurPos(dNewPos, true, false);
 }
@@ -121,7 +122,7 @@ void MoveCursorMs(COMMAND_T* ct)
 void MoveCursorFade(COMMAND_T* ct)
 {
 	double dPos = GetCursorPosition();
-	dPos += fabs(*(double*)GetConfigVar("deffadelen")) * (double)ct->user; // Abs because neg value means "not auto"
+	dPos += fabs(*ConfigVar<double>("deffadelen")) * (double)ct->user; // Abs because neg value means "not auto"
 	SetEditCurPos(dPos, true, false);
 }
 

--- a/Misc/ItemParams.cpp
+++ b/Misc/ItemParams.cpp
@@ -411,7 +411,7 @@ void SetItemChannels(COMMAND_T* t)
 
 void CrossfadeSelItems(COMMAND_T* t)
 {
-	double dFadeLen = fabs(*(double*)GetConfigVar("deffadelen")); // Abs because neg value means "not auto"
+	double dFadeLen = fabs(*ConfigVar<double>("deffadelen")); // Abs because neg value means "not auto"
 	double dEdgeAdj = dFadeLen / 2.0;
 	bool bChanges = false;
 

--- a/Misc/ProjPrefs.cpp
+++ b/Misc/ProjPrefs.cpp
@@ -33,34 +33,45 @@ static int g_prevautoxfade = 0;
 #define SAVED_DEF_FADE_LEN_KEY "deffadelen"
 static double g_dDefFadeLen = 0.01;
 
-void SaveXFade(COMMAND_T* = NULL)    { if (GetConfigVar("autoxfade")) g_prevautoxfade = *(int*)GetConfigVar("autoxfade"); }
-void RestoreXFade(COMMAND_T* = NULL) { if (GetConfigVar("autoxfade") && g_prevautoxfade != *(int*)GetConfigVar("autoxfade")) Main_OnCommand(40041, 0); }
+void SaveXFade(COMMAND_T* = NULL)
+{
+	if (const ConfigVar<int> autoxfade = "autoxfade")
+		g_prevautoxfade = *autoxfade;
+}
+
+void RestoreXFade(COMMAND_T* = NULL)
+{
+	const ConfigVar<int> autoxfade("autoxfade");
+	if (autoxfade && g_prevautoxfade != *autoxfade)
+		Main_OnCommand(40041, 0);
+}
+
 void XFadeOn(COMMAND_T* = NULL)      { if (!GetToggleCommandState(40041)) Main_OnCommand(40041, 0); }
 void XFadeOff(COMMAND_T* = NULL)     { if (GetToggleCommandState(40041)) Main_OnCommand(40041, 0); }
 void MEPWIXOn(COMMAND_T* = NULL)     { if (!GetToggleCommandState(40070)) Main_OnCommand(40070, 0); }
 void MEPWIXOff(COMMAND_T* = NULL)    { if (GetToggleCommandState(40070)) Main_OnCommand(40070, 0); }
 
-int IsOnRecStopMoveCursor(COMMAND_T*)  { int* p = (int*)GetConfigVar("itemclickmovecurs"); return p && (*p & 16); }
-void TogOnRecStopMoveCursor(COMMAND_T*) { int* p = (int*)GetConfigVar("itemclickmovecurs"); if (p) *p ^= 16; }
+void TogOnRecStopMoveCursor(COMMAND_T*) { if(ConfigVar<int> cv = "itemclickmovecurs") *cv ^= 16; }
+int IsOnRecStopMoveCursor(COMMAND_T*)   { return ConfigVar<int>("itemclickmovecurs").value_or(0) & 16; }
 
-void TogSeekMode(COMMAND_T* ct)	{ int* p = (int*)GetConfigVar("seekmodes"); if (p) *p ^= ct->user; }
-int IsSeekMode(COMMAND_T* ct)	{ int* p = (int*)GetConfigVar("seekmodes"); return p && (*p & ct->user); }
+void TogSeekMode(COMMAND_T* ct) { if(ConfigVar<int> cv = "seekmodes") *cv ^= ct->user; }
+int IsSeekMode(COMMAND_T* ct)   { return ConfigVar<int>("seekmodes").value_or(0) & ct->user; }
 
-void TogAutoAddEnvs(COMMAND_T*) { int* p = (int*)GetConfigVar("env_autoadd"); if (p) *p ^= 1; }
-int IsAutoAddEnvs(COMMAND_T*)  { int* p = (int*)GetConfigVar("env_autoadd"); return p && (*p & 1); }
+void TogAutoAddEnvs(COMMAND_T*) { if (ConfigVar<int> cv = "env_autoadd") *cv ^= 1; }
+int IsAutoAddEnvs(COMMAND_T*)   { return ConfigVar<int>("env_autoadd").value_or(0) & 1; }
 
-void TogGridOverUnder(COMMAND_T*) { int* p = (int*)GetConfigVar("gridinbg"); if (p) *p = *p == 2 ? 0 : 2; UpdateArrange(); }
-int IsGridOver(COMMAND_T*)  { int* p = (int*)GetConfigVar("gridinbg"); return p && !*p; }
+void TogGridOverUnder(COMMAND_T*) { if (ConfigVar<int> cv = "gridinbg") { *cv = *cv == 2 ? 0 : 2; UpdateArrange(); } }
+int IsGridOver(COMMAND_T*)        { return !ConfigVar<int>("gridinbg").value_or(1); }
 
-void TogSelGroupMode(COMMAND_T*) { int* p = (int*)GetConfigVar("projgroupsel"); if (p) *p = !*p; }
-int IsSelGroupMode(COMMAND_T*)  { int* p = (int*)GetConfigVar("projgroupsel"); return p && *p; }
+void TogSelGroupMode(COMMAND_T*) { if (ConfigVar<int> cv = "projgroupsel") *cv = !*cv; }
+int IsSelGroupMode(COMMAND_T*)   { return ConfigVar<int>("projgroupsel").value_or(0); }
 
 void SwitchGridSpacing(COMMAND_T*)
 {
 	// TODO
 	/*
 	const double dSpacings[] = { 0.0208331, };
-	double div = *(double*)GetConfigVar("projgriddiv");
+	double div = *ConfigVar<double>("projgriddiv");
 	char debugStr[64];
 	sprintf(debugStr, "Div is %.14f\n", div);
 	OutputDebugString(debugStr);
@@ -97,19 +108,19 @@ void HideDock(COMMAND_T* = NULL)
 
 void ShowMaster(COMMAND_T* = NULL)
 {
-	if (GetConfigVar("showmaintrack") && !*(int*)GetConfigVar("showmaintrack"))
+	if (!ConfigVar<int>("showmaintrack").value_or(1))
 		Main_OnCommand(40075, 0);
 }
 
 void HideMaster(COMMAND_T* = NULL)
 {
-	if (GetConfigVar("showmaintrack") && *(int*)GetConfigVar("showmaintrack"))
+	if (ConfigVar<int>("showmaintrack").value_or(0))
 		Main_OnCommand(40075, 0);
 }
 
 void TogDefFadeZero(COMMAND_T*)
 {
-	double* pdDefFade = (double*)GetConfigVar("deffadelen");
+	ConfigVar<double> pdDefFade("deffadelen");
 	if (*pdDefFade != 0.0)
 	{
 		if (*pdDefFade != g_dDefFadeLen)
@@ -129,19 +140,19 @@ void TogDefFadeZero(COMMAND_T*)
 
 int IsDefFadeOverriden(COMMAND_T*)
 {
-	double dDefFade = *(double*)GetConfigVar("deffadelen");
+	double dDefFade = *ConfigVar<double>("deffadelen");
 	return g_dDefFadeLen != 0.0 && dDefFade != g_dDefFadeLen;
 }
 
 void MetronomeOn(COMMAND_T*)
 {
-	if (!(*(int*)GetConfigVar("projmetroen") & 1))
+	if (!(*ConfigVar<int>("projmetroen") & 1))
 		Main_OnCommand(40364, 0);
 }
 
 void MetronomeOff(COMMAND_T*)
 {
-	if (*(int*)GetConfigVar("projmetroen") & 1)
+	if (*ConfigVar<int>("projmetroen") & 1)
 		Main_OnCommand(40364, 0);
 }
 
@@ -185,12 +196,12 @@ int ProjPrefsInit()
 {
 	SWSRegisterCommands(g_commandTable);
 
-	g_prevautoxfade = *(int*)GetConfigVar("autoxfade");
+	g_prevautoxfade = *ConfigVar<int>("autoxfade");
 
 	// Get saved default fade length
 	char str[64];
 	char strDef[64];
-	sprintf(strDef, "%.8f", *(double*)GetConfigVar("deffadelen"));
+	sprintf(strDef, "%.8f", *ConfigVar<double>("deffadelen"));
 	GetPrivateProfileString(SWS_INI, SAVED_DEF_FADE_LEN_KEY, strDef, str, 64, get_ini_file());
 	g_dDefFadeLen = atof(str);
 

--- a/Padre/padreUtils.cpp
+++ b/Padre/padreUtils.cpp
@@ -309,7 +309,7 @@ void GetTimeSegmentPositions(TimeSegment timeSegment, double &dStartPos, double 
 			dEndPos = GetCursorPositionEx(0);
 			//Main_OnCommandEx(ID_GOTO_PROJECT_START, 0, 0);
 			//dStartPos = GetCursorPositionEx(0);
-			dStartPos = *(int*)GetConfigVar("projtimeoffs");
+			dStartPos = *ConfigVar<int>("projtimeoffs");
 			bRefreshCurPos = true;
 		break;
 		//case eTIMESEGMENT_CURRENTMEASURE:

--- a/Projects/ProjectMgr.cpp
+++ b/Projects/ProjectMgr.cpp
@@ -88,11 +88,8 @@ void OpenProjectsFromList(COMMAND_T*)
 		if (f)
 		{
 			// Save "prompt on new project" variable
-			int iNewProjOpts;
-			int sztmp;
-			int* pNewProjOpts = (int*)get_config_var("newprojdo", &sztmp);
-			iNewProjOpts = *pNewProjOpts;
-			*pNewProjOpts = 0;
+			ConfigVarOverride<int> newprojdo("newprojdo", 0);
+
 			int i = 0;
 
 			int iProjects = -1;
@@ -121,8 +118,6 @@ void OpenProjectsFromList(COMMAND_T*)
 				}
 			}
 			fclose(f);
-
-			*pNewProjOpts = iNewProjOpts;
 		}
 		else
 			MessageBox(g_hwndParent, __LOCALIZE("Unable to open file.","sws_mbox"), __LOCALIZE("SWS Project List Open","sws_mbox"), MB_OK);
@@ -181,11 +176,7 @@ void OpenRelatedProject(COMMAND_T* pCmd)
 
 	// Nope, open in new tab
 	// Save "prompt on new project" variable
-	int iNewProjOpts;
-	int sztmp;
-	int* pNewProjOpts = (int*)get_config_var("newprojdo", &sztmp);
-	iNewProjOpts = *pNewProjOpts;
-	*pNewProjOpts = 0;
+	ConfigVarOverride<int> newprojdo("newprojdo", 0);
 	pProj = EnumProjects(-1, NULL, 0);
 	Main_OnCommand(41929, 0); // New project tab (ignore default template)
 	Main_openProject(pStr->Get());
@@ -196,7 +187,6 @@ void OpenRelatedProject(COMMAND_T* pCmd)
 		SelectProjectInstance(pProj);
 		g_relatedProjects.Get()->Delete((int)pCmd->user, true);
 	}
-	*pNewProjOpts = iNewProjOpts;
 }
 
 void OpenLastProject(COMMAND_T*)

--- a/SnM/SnM_Chunk.cpp
+++ b/SnM/SnM_Chunk.cpp
@@ -81,7 +81,7 @@ bool SNM_SendPatcher::NotifyChunkLine(int _mode,
 		// add rcv
 		case -1:
 		{
-			int defSndFlags = *(int*)GetConfigVar("defsendflag");
+			int defSndFlags = *ConfigVar<int>("defsendflag");
 			bool audioSnd = ((defSndFlags & 512) != 512);
 			bool midiSnd =  ((defSndFlags & 256) != 256);
 			_newChunk->AppendFormatted(

--- a/SnM/SnM_ChunkParserPatcher.h
+++ b/SnM/SnM_ChunkParserPatcher.h
@@ -1107,7 +1107,7 @@ static int SNM_PreObjectState(WDL_FastString* _str, bool _wantsMinState)
 	}
 	// when getting: enables/disables the "VST full state" pref (that also minimize AU states, if REAPER >= v4)
 	// it also fixes possible incomplete chunk bug (pref overrided when needed)
-	else if (int* fxstate = (int*)GetConfigVar("vstfullstate")) {
+	else if (ConfigVar<int> fxstate = "vstfullstate") {
 		int old = *fxstate;
 		int tmp = _wantsMinState ? *fxstate&0xFFFFFFFE : *fxstate|1;
 		if (old != tmp) // prevents useless RW access to REAPER.ini
@@ -1121,7 +1121,7 @@ static void SNM_PostObjectState(int _oldfxstate)
 {
 	// restore the "VST full state" pref, if needed
 	if (_oldfxstate >= 0)
-		if (int* fxstate = (int*)GetConfigVar("vstfullstate"))
+		if (ConfigVar<int> fxstate = "vstfullstate")
 			if (*fxstate != _oldfxstate)
 				*fxstate = _oldfxstate;
 }

--- a/SnM/SnM_CueBuss.cpp
+++ b/SnM/SnM_CueBuss.cpp
@@ -72,7 +72,7 @@ bool AddReceiveWithVolPan(MediaTrack * _srcTr, MediaTrack * _destTr, int _type, 
 	}
 
 	// default volume
-	if (!update && _snprintfStrict(vol, sizeof(vol), "%.14f", *(double*)GetConfigVar("defsendvol")) > 0)
+	if (!update && _snprintfStrict(vol, sizeof(vol), "%.14f", *ConfigVar<double>("defsendvol")) > 0)
 		update = (_p->AddReceive(_srcTr, _type, vol, pan) > 0);
 	return update;
 }
@@ -167,7 +167,7 @@ bool CueBuss(const char* _undoMsg, const char* _busName, int _type, bool _showRo
 							mainSend.AppendFormatted(32, "HWOUT %d ", _hwOuts[i]-1);
 
 						mainSend.Append("0 ");
-						mainSend.AppendFormatted(20, "%.14f ", *(double*)GetConfigVar("defhwvol"));
+						mainSend.AppendFormatted(20, "%.14f ", *ConfigVar<double>("defhwvol"));
 						mainSend.Append("0.00000000000000 0 0 0 -1.00000000000000 -1\n");
 					}
 				}

--- a/SnM/SnM_Item.cpp
+++ b/SnM/SnM_Item.cpp
@@ -1051,7 +1051,7 @@ void DeleteTakeAndMedia(COMMAND_T* _ct) {
 
 int GetPitchTakeEnvRangeFromPrefs()
 {
-	int range = *(int*)GetConfigVar("pitchenvrange");
+	int range = *ConfigVar<int>("pitchenvrange");
 	// "snap to semitones" bit set ?
 	if (range > 0xFF)
 		range &= 0xFF;
@@ -1130,8 +1130,8 @@ bool PatchTakeEnvelopeActVis(MediaItem* _item, int _takeIdx, const char* _envKey
 					takeChunk.Append(vis);
 					takeChunk.Append("\nDEFSHAPE 0\n");
 					// NF: #1054, obey volume fader scaling pref.
-					int sz = 0; int *volenvrange = (int *)get_config_var("volenvrange", &sz);
-					if (sz == sizeof(int) && *volenvrange & (1 << 1))
+					const ConfigVar<int> volenvrange("volenvrange");
+					if (volenvrange && *volenvrange & (1 << 1))
 						takeChunk.Append("VOLTYPE 1\n");
 					takeChunk.Append(_defaultPoint);
 					takeChunk.Append("\n>\n");

--- a/SnM/SnM_LiveConfigs.cpp
+++ b/SnM/SnM_LiveConfigs.cpp
@@ -1013,7 +1013,7 @@ void LiveConfigsWnd::OnCommand(WPARAM wParam, LPARAM lParam)
 		
 		case MUTE_OTHERS_MSG:
 			if (!(lc->m_options&1))
-				if (int* dontProcessMutedTrs = (int*)GetConfigVar("norunmute"))
+				if (ConfigVar<int> dontProcessMutedTrs = "norunmute")
 					if (!*dontProcessMutedTrs)
 					{
 						// do not enable in the user's back:
@@ -2113,7 +2113,7 @@ void LiveConfigsTrackListChange()
 
 int LiveConfigInit()
 {
-	g_reaPref_fadeLen = (int*)GetConfigVar("mutefadems10");
+	g_reaPref_fadeLen = ConfigVar<int>("mutefadems10").get();
 	GetPrivateProfileString("LiveConfigs", "BigFontName", SNM_DYN_FONT_NAME, g_lcBigFontName, sizeof(g_lcBigFontName), g_SNM_IniFn.Get());
 
 	// instanciate the editor if needed, can be NULL

--- a/SnM/SnM_Marker.cpp
+++ b/SnM/SnM_Marker.cpp
@@ -77,9 +77,9 @@ int UpdateMarkerRegionCache()
 		g_mkrRgnCache.Delete(j, true);
 	}
 	// project time mode update?
-	static int sPrevTimemode = *(int*)GetConfigVar("projtimemode");
+	static int sPrevTimemode = *ConfigVar<int>("projtimemode");
 	if (updateFlags != (SNM_MARKER_MASK|SNM_REGION_MASK))
-		if (int* timemode = (int*)GetConfigVar("projtimemode"))
+		if (const ConfigVar<int> timemode = "projtimemode")
 			if (*timemode != sPrevTimemode) {
 				sPrevTimemode = *timemode;
 				return SNM_MARKER_MASK|SNM_REGION_MASK;
@@ -313,8 +313,8 @@ bool GotoMarkerRegion(ReaProject* _proj, int _num, int _flags, bool _select = fa
 			if (_select && isrgn && (_flags&SNM_REGION_MASK))
 				GetSet_LoopTimeRange2(NULL, true, true, &pos, &end, false); // seek is managed below
 
-			int* opt = (int*)GetConfigVar("smoothseek"); // obeys smooth seek
-			SetEditCurPos2(_proj, pos, true, opt && *opt); // includes an undo point, if enabled in prefs
+			const int opt = ConfigVar<int>("smoothseek").value_or(0); // obeys smooth seek
+			SetEditCurPos2(_proj, pos, true, opt); // includes an undo point, if enabled in prefs
 
 			PreventUIRefresh(-1);
 

--- a/SnM/SnM_Misc.cpp
+++ b/SnM/SnM_Misc.cpp
@@ -204,32 +204,20 @@ bool SNM_GetProjectMarkerName(ReaProject* _proj, int _num, bool _isrgn, WDL_Fast
 	return false;
 }
 
-int SNM_GetIntConfigVar(const char* _varName, int _errVal) {
-	if (int* pVar = (int*)(GetConfigVar(_varName)))
-		return *pVar;
-	return _errVal;
+int SNM_GetIntConfigVar(const char *varName, const int fallback) {
+	return ConfigVar<int>(varName).value_or(fallback);
 }
 
-bool SNM_SetIntConfigVar(const char* _varName, int _newVal) {
-	if (int* pVar = (int*)(GetConfigVar(_varName))) {
-		*pVar = _newVal;
-		return true;
-	}
-	return false;
+bool SNM_SetIntConfigVar(const char *varName, const int newValue) {
+	return ConfigVar<int>(varName).try_set(newValue);
 }
 
-double SNM_GetDoubleConfigVar(const char* _varName, double _errVal) {
-	if (double* pVar = (double*)(GetConfigVar(_varName)))
-		return *pVar;
-	return _errVal;
+double SNM_GetDoubleConfigVar(const char *varName, double fallback) {
+	return ConfigVar<double>(varName).value_or(fallback);
 }
 
-bool SNM_SetDoubleConfigVar(const char* _varName, double _newVal) {
-	if (double* pVar = (double*)(GetConfigVar(_varName))) {
-		*pVar = _newVal;
-		return true;
-	}
-	return false;
+bool SNM_SetDoubleConfigVar(const char *varName, double newValue) {
+	return ConfigVar<double>(varName).try_set(newValue);
 }
 
 // host some funcs from Ultraschall, https://github.com/Ultraschall

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1308,7 +1308,7 @@ bool SeekItem(int _plId, int _nextItemId, int _curItemId)
 		if (_nextItemId<0)
 		{
 			// temp override of the "stop play at project end" option
-			if (int* opt = (int*)GetConfigVar("stopprojlen")) {
+			if (ConfigVar<int> opt = "stopprojlen") {
 				g_oldStopprojlenPref = *opt;
 				*opt = 1;
 			}
@@ -1544,7 +1544,7 @@ void PlaylistPlay(int _plId, int _itemId)
 				PlaylistStop();
 
 			// temp override of the "smooth seek" option
-			if (int* opt = (int*)GetConfigVar("smoothseek")) {
+			if (ConfigVar<int> opt = "smoothseek") {
 				g_oldSeekPref = *opt;
 				*opt = 3;
 			}
@@ -1639,12 +1639,12 @@ void PlaylistStopped(bool _pause)
 
 		// restore options
 		if (g_oldSeekPref >= 0)
-			if (int* opt = (int*)GetConfigVar("smoothseek")) {
+			if (ConfigVar<int> opt = "smoothseek") {
 				*opt = g_oldSeekPref;
 				g_oldSeekPref = -1;
 			}
 		if (g_oldStopprojlenPref >= 0)
-			if (int* opt = (int*)GetConfigVar("stopprojlen")) {
+			if (ConfigVar<int> opt = "stopprojlen") {
 				*opt = g_oldStopprojlenPref;
 				g_oldStopprojlenPref = -1;
 			}
@@ -1762,17 +1762,10 @@ void AppendPasteCropPlaylist(RegionPlaylist* _playlist, int _mode)
 
 //	OnStopButton();
 
-	// make sure some envelope options are enabled: move with items + add edge points
-	int oldOpt[2] = {-1,-1};
-	int* options[2] = {NULL,NULL};
-	if ((options[0] = (int*)GetConfigVar("envattach"))) {
-		oldOpt[0] = *options[0];
-		*options[0] = 1;
-	}
-	if ((options[1] = (int*)GetConfigVar("env_reduce"))) {
-		oldOpt[1] = *options[1];
-		*options[1] = 2;
-	}
+	ConfigVarOverride<int> options[] = {
+		{"envattach",     1}, // move with items
+		{"env_reduce",    2}, // add edge points
+	};
 
 	WDL_PtrList_DeleteOnDestroy<MarkerRegion> rgns;
 	for (int i=0; i<_playlist->GetSize(); i++)
@@ -1838,10 +1831,6 @@ void AppendPasteCropPlaylist(RegionPlaylist* _playlist, int _mode)
 			}
 		}
 	}
-
-	// restore options
-	if (options[0]) *options[0] = oldOpt[0];
-	if (options[1]) *options[1] = oldOpt[1];
 
 	// nothing done..
 	if (!updated)

--- a/SnM/SnM_Resources.cpp
+++ b/SnM/SnM_Resources.cpp
@@ -1497,7 +1497,7 @@ void ResourcesWnd::OnCommand(WPARAM wParam, LPARAM lParam)
 
 		// ***** Track template *****
 		case BTNID_OFFSET_TR_TEMPLATE:
-			if (int* offsPref = (int*)GetConfigVar("templateditcursor")) { // >= REAPER v4.15
+			if (ConfigVar<int> offsPref = "templateditcursor") { // >= REAPER v4.15
 				if (*offsPref) *offsPref = 0;
 				else *offsPref = 1;
 			}
@@ -2161,7 +2161,7 @@ void ResourcesWnd::DrawControls(LICE_IBitmap* _bm, const RECT* _r, int* _tooltip
 
 		if (GetTypeForUser() == SNM_SLOT_TR)
 		{
-			if (int* offsPref = (int*)GetConfigVar("templateditcursor")) // >= REAPER v4.15
+			if (const ConfigVar<int> offsPref = "templateditcursor") // >= REAPER v4.15
 			{
 				if (g_dblClickPrefs[g_resType] != 1) // propose offset option except if "apply to sel tracks"
 				{

--- a/SnM/SnM_Routing.cpp
+++ b/SnM/SnM_Routing.cpp
@@ -432,19 +432,18 @@ bool SNM_RemoveReceivesFrom(MediaTrack* _tr, MediaTrack* _srcTr)
 int g_defSndFlags = -1;
 
 void SaveDefaultTrackSendPrefs(COMMAND_T*) {
-	if (int* flags = (int*)GetConfigVar("defsendflag"))
+	if (const ConfigVar<int> flags = "defsendflag")
 		g_defSndFlags = *flags;
 }
 
 void RecallDefaultTrackSendPrefs(COMMAND_T*) {
 	if (g_defSndFlags>=0)
-		if (int* flags = (int*)GetConfigVar("defsendflag"))
-			*flags = g_defSndFlags;
+		ConfigVar<int>("defsendflag").try_set(g_defSndFlags);
 }
 
 // flags != _ct->user because of the weird state of midi+audio which is not 0x300 but 0 (!)
 void SetDefaultTrackSendPrefs(COMMAND_T* _ct) {
-	if (int* flags = (int*)GetConfigVar("defsendflag")) {
+	if (ConfigVar<int> flags = "defsendflag") {
 		switch((int)_ct->user) {
 			case 0: *flags&=0xFF; break; // both
 			case 1: *flags&=0xF0FF; *flags|=0x100; break; // audio

--- a/SnM/SnM_Track.cpp
+++ b/SnM/SnM_Track.cpp
@@ -715,7 +715,7 @@ bool MakeSingleTrackTemplateChunk(WDL_FastString* _in, WDL_FastString* _out, boo
 		SNM_ChunkParserPatcher pin(_in);
 		if (pin.GetSubChunk("TRACK", 1, _tmpltIdx, _out) >= 0)
 		{
-			int* offsOpt = _obeyOffset ? (int*)GetConfigVar("templateditcursor") : NULL; // >= REAPER v4.15
+			const int offsOpt = _obeyOffset ? ConfigVar<int>("templateditcursor").value_or(0) : 0; // >= REAPER v4.15
 
 			// remove receives from the template as we deal with a single track
 			// note: possible with multiple tracks in a same template file (w/ routings between those tracks)
@@ -724,14 +724,14 @@ bool MakeSingleTrackTemplateChunk(WDL_FastString* _in, WDL_FastString* _out, boo
 
 			if (_delItems) // remove items from template (in one go)
 				pout.RemoveSubChunk("ITEM", 2, -1);
-			else if (offsOpt && *offsOpt) { // or offset them if needed
+			else if (offsOpt) { // or offset them if needed
 				double add = GetCursorPositionEx(NULL);
 				pout.ParsePatch(SNM_D_ADD, 2, "ITEM", "POSITION", -1, 1, &add);
 			}
 
 			if (_delEnvs) // remove all envs from template (in one go)
 				pout.RemoveEnvelopes();
-			else if (offsOpt && *offsOpt) // or offset them if needed
+			else if (offsOpt) // or offset them if needed
 				pout.OffsetEnvelopes(GetCursorPositionEx(NULL));
 			return true;
 		}
@@ -782,8 +782,7 @@ bool ReplacePasteItemsFromTrackTemplate(MediaTrack* _tr, WDL_FastString* _tmpltI
 			WDL_FastString tmpltItems(_tmpltItems); // do not alter _tmpltItems!
 
 			// offset items if needed
-			int* offsOpt = (int*)GetConfigVar("templateditcursor"); // >= REAPER v4.15
-			if (offsOpt && *offsOpt)
+			if (ConfigVar<int>("templateeditcursor").value_or(0)) // >= REAPER v4.15
 			{
 				double add = GetCursorPositionEx(NULL);
 				SNM_ChunkParserPatcher pitems(&tmpltItems);

--- a/Snapshots/SnapshotClass.cpp
+++ b/Snapshots/SnapshotClass.cpp
@@ -439,7 +439,7 @@ void TrackSnapshot::GetDetails(WDL_FastString* details, int iMask)
 	{
 		int iPanMode = m_iPanMode;
 		if (iPanMode == -1)
-			iPanMode = *(int*)GetConfigVar("panmode"); // display pan in project format
+			iPanMode = *ConfigVar<int>("panmode"); // display pan in project format
 
 		if (iPanMode != 6)
 		{

--- a/Utility/configvar.h
+++ b/Utility/configvar.h
@@ -1,0 +1,98 @@
+/******************************************************************************
+/ configvar.h
+/
+/ Copyright (c) 2019 Christian Fillion
+/ https://cfillion.ca
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#pragma once
+
+template<typename T>
+class ConfigVar {
+public:
+  ConfigVar(const char *name, ReaProject *project = NULL)
+    : m_addr(NULL)
+  {
+    int size = 0;
+    void *addr = NULL;
+
+    if(const int offset = projectconfig_var_getoffs(name, &size))
+      addr = projectconfig_var_addr(project, offset);
+    else
+      addr = get_config_var(name, &size);
+
+    if(size == sizeof(T))
+      m_addr = static_cast<T *>(addr);
+  }
+
+  explicit operator bool() const { return m_addr != NULL; }
+
+  T &operator*() { return *m_addr; }
+  const T &operator*() const { return *m_addr; }
+  T *get() { return m_addr; }
+  const T *get() const { return m_addr; }
+
+  T value_or(const T fallback) const
+  {
+    return m_addr ? *m_addr : fallback;
+  }
+
+  bool try_set(const T newValue)
+  {
+    if(!m_addr)
+      return false;
+
+    *m_addr = newValue;
+    return true;
+  }
+
+private:
+  T *m_addr;
+};
+
+template<typename T>
+class ConfigVarOverride {
+public:
+  ConfigVarOverride(ConfigVar<T> var, const T tempValue)
+    : m_var(var)
+  {
+    if(m_var) {
+      m_initialValue = *m_var;
+      *m_var = tempValue;
+    }
+  }
+
+  void rollback()
+  {
+    m_var.try_set(m_initialValue);
+  }
+
+  ~ConfigVarOverride()
+  {
+    rollback();
+  }
+
+private:
+  ConfigVar<T> m_var;
+  T m_initialValue;
+};

--- a/Wol/wol_Util.cpp
+++ b/Wol/wol_Util.cpp
@@ -267,7 +267,7 @@ int GetEnvelopeOverlapState(TrackEnvelope* envelope, int* laneCount, int* envCou
 		return -1;
 
 	int visEnvCount = CountVisibleTrackEnvelopesInTrackLane(GetEnvParent(envelope));
-	int overlapMinHeight = *(int*)GetConfigVar("env_ol_minh");
+	int overlapMinHeight = *ConfigVar<int>("env_ol_minh");
 	if (overlapMinHeight < 0)
 		return (WritePtr(laneCount, visEnvCount), WritePtr(envCount, visEnvCount), 0);
 

--- a/Wol/wol_Zoom.cpp
+++ b/Wol/wol_Zoom.cpp
@@ -169,7 +169,7 @@ void SetVerticalZoomSelectedEnvelope(COMMAND_T* ct)
 		{
 			bool ScrollToEnv = true;
 			int height, trackGapTop, trackGapBottom;
-			int overlapMinHeight = *(int*)GetConfigVar("env_ol_minh");
+			int overlapMinHeight = *ConfigVar<int>("env_ol_minh");
 			int mul = CountVisibleTrackEnvelopesInTrackLane(brEnv.GetParent());
 			GetTrackHeight(brEnv.GetParent(), NULL, &trackGapTop, &trackGapBottom);
 			if ((int)ct->user == 2)
@@ -236,28 +236,31 @@ int IsEnvelopesExtendedZoomEnabled(COMMAND_T*)
 
 void ToggleEnableEnvelopeOverlap(COMMAND_T*)
 {
-	SetConfig("env_ol_minh", -((*(int*)GetConfigVar("env_ol_minh")) + 1));
+	ConfigVar<int> env_ol_minh("env_ol_minh");
+	*env_ol_minh = -((*env_ol_minh) + 1);
 	TrackList_AdjustWindows(false);
 	UpdateTimeline();
 }
 
 int IsEnvelopeOverlapEnabled(COMMAND_T*)
 {
-	return (*(int*)GetConfigVar("env_ol_minh") >= 0);
+	return (*ConfigVar<int>("env_ol_minh") >= 0);
 }
 
 void ForceEnvelopeOverlap(COMMAND_T* ct)
 {
+	ConfigVar<int> env_ol_minh("env_ol_minh");
+
 	if ((int)ct->user == 0)
 	{
 		if (TrackEnvelope* env = GetSelectedTrackEnvelope(NULL))
 		{
-			g_SavedEnvelopeOverlapSettings = *(int*)GetConfigVar("env_ol_minh");
+			g_SavedEnvelopeOverlapSettings = *env_ol_minh;
 			bool lane; EnvVis(env, &lane);
 			if ((CountVisibleTrackEnvelopesInTrackLane(GetEnvParent(env)) > 1) && !lane)
 			{
 				int envHeight = GetTrackEnvHeight(env, NULL, false);
-				SetConfig("env_ol_minh", envHeight + 1);
+				*env_ol_minh = envHeight + 1;
 				TrackList_AdjustWindows(false);
 				UpdateTimeline();
 				RefreshToolbar(SWSGetCommandID(ToggleEnableEnvelopeOverlap));
@@ -266,7 +269,7 @@ void ForceEnvelopeOverlap(COMMAND_T* ct)
 	}
 	else
 	{
-		SetConfig("env_ol_minh", g_SavedEnvelopeOverlapSettings);
+		*env_ol_minh = g_SavedEnvelopeOverlapSettings;
 		TrackList_AdjustWindows(false);
 		UpdateTimeline();
 		RefreshToolbar(SWSGetCommandID(ToggleEnableEnvelopeOverlap));
@@ -336,7 +339,7 @@ void VerticalZoomSelectedEnvelopeLoUpHalf(COMMAND_T* ct)
 
 void SetVerticalZoomCenter(COMMAND_T* ct)
 {
-	SetConfig("vzoommode", (int)ct->user);
+	*ConfigVar<int>("vzoommode") = (int)ct->user;
 
 	char tmp[256];
 	_snprintfSafe(tmp, sizeof(tmp), "%d", (int)ct->user);
@@ -345,7 +348,7 @@ void SetVerticalZoomCenter(COMMAND_T* ct)
 
 void SetHorizontalZoomCenter(COMMAND_T* ct)
 {
-	SetConfig("zoommode", (int)ct->user);
+	*ConfigVar<int>("zoommode") = (int)ct->user;
 
 	char tmp[256];
 	_snprintfSafe(tmp, sizeof(tmp), "%d", (int)ct->user);
@@ -424,7 +427,7 @@ void SaveApplyHeightSelectedEnvelopeSlot(COMMAND_T* ct)
 void wol_ZoomInit()
 {
 	g_EnvelopesExtendedZoom = GetPrivateProfileInt(SWS_INI, "WOLExtZoomEnvInTrLane", 0, get_ini_file()) ? true : false;
-	g_SavedEnvelopeOverlapSettings = *(int*)GetConfigVar("env_ol_minh");
+	g_SavedEnvelopeOverlapSettings = *ConfigVar<int>("env_ol_minh");
 
 	WDL_FastString key;
 	for (int i = 0; i < 7; ++i)

--- a/Xenakios/ExoticCommands.cpp
+++ b/Xenakios/ExoticCommands.cpp
@@ -197,7 +197,7 @@ void DoNudgeItemsRightBeatsAndConfBased(COMMAND_T*)
 
 void DoNudgeSamples(COMMAND_T* ct)
 {
-	double dSrate = (double)(*(int*)GetConfigVar("projsrate"));
+	double dSrate = (double)(*ConfigVar<int>("projsrate"));
 	for (int i = 1; i <= GetNumTracks(); i++)
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);

--- a/Xenakios/ItemTakeCommands.cpp
+++ b/Xenakios/ItemTakeCommands.cpp
@@ -280,7 +280,7 @@ void PasteMultipletimes(int NumPastes, double TimeIntervalQN, int RepeatMode)
 {
 	if (NumPastes > 0)
 	{
-		int* pCursorMode = (int*)GetConfigVar("itemclickmovecurs");
+		const ConfigVar<int> pCursorMode("itemclickmovecurs");
 		double dStartTime = GetCursorPosition();
 
 		Undo_BeginBlock();
@@ -291,11 +291,9 @@ void PasteMultipletimes(int NumPastes, double TimeIntervalQN, int RepeatMode)
 			{
 				// Cursor mode must set to move the cursor after paste
 				// Clear bit 8 of itemclickmovecurs
-				int savedMode = *pCursorMode;
-				*pCursorMode &= ~8;
+				ConfigVarOverride<int> tmpCursorMode(pCursorMode, *pCursorMode & ~8);
 				for (int i = 0; i < NumPastes; i++)
 					Main_OnCommand(40058,0); // Paste
-				*pCursorMode = savedMode; // Restore the cursor mode
 				break;
 			}
 			case 1: // Time interval
@@ -936,43 +934,26 @@ double g_lastTailLen;
 void DoWorkForRenderItemsWithTail(double TailLen)
 {
 	// Unselect all tracks
-
-	MediaTrack* MunRaita;
-	MediaItem* CurItem;
-
-	int numItems;;
-
-	char textbuf[100];
-	int sz=0; int *fxtail = (int *)get_config_var("itemfxtail",&sz);
-    int OldTail=*fxtail;
-	if (sz==sizeof(int) && fxtail)
-	{
-
-		int msTail=int(1000*TailLen);
-		*fxtail=msTail;
-		sprintf(textbuf,"%d",msTail);
-	}
+	const int msTail=1000*TailLen;
+	ConfigVarOverride<int> fxtail("itemfxtail", msTail);
 
 	bool ItemSelected=false;
-	int i;
-	int j;
-	for (i=0;i<GetNumTracks();i++)
+	for (int i=0;i<GetNumTracks();i++)
 	{
-		MunRaita = CSurf_TrackFromID(i+1,FALSE);
-		numItems=GetTrackNumMediaItems(MunRaita);
+		MediaTrack *MunRaita = CSurf_TrackFromID(i+1,false);
+		const int numItems=GetTrackNumMediaItems(MunRaita);
 		Main_OnCommand(40635,0);
-		for (j=0;j<numItems;j++)
+		for (int j=0;j<numItems;j++)
 		{
-			CurItem = GetTrackMediaItem(MunRaita,j);
+			MediaItem *CurItem = GetTrackMediaItem(MunRaita,j);
 			//propertyName="D_";
 			ItemSelected=*(bool*)GetSetMediaItemInfo(CurItem,"B_UISEL",NULL);
-			if (ItemSelected==TRUE)
+			if (ItemSelected)
 			{
 				Main_OnCommand(40601,0); // render items as new take
 			}
 		}
 	}
-	*fxtail=OldTail;
 	UpdateTimeline();
 }
 

--- a/Xenakios/MixerActions.cpp
+++ b/Xenakios/MixerActions.cpp
@@ -674,13 +674,8 @@ void DoMaxMixFxPanHeight(COMMAND_T*)
 
 void DoRemoveTimeSelectionLeaveLoop(COMMAND_T*)
 {
-	int sz=0; int *locklooptotime = (int *)get_config_var("locklooptotime",&sz);
-    int OldLockLoopToTime=*locklooptotime;
-	if (sz==sizeof(int) && locklooptotime) 
-	{ 
-		int newLockLooptotime=0;
-		*locklooptotime=newLockLooptotime; /* update reaper's copy */
-	}
+	ConfigVarOverride<int> locklooptotime("locklooptotime", 0);
+
 	double a=0.0;
 	double b=0.0;
 	GetSet_LoopTimeRange(false, true, &a,&b,false); // get current loop
@@ -688,7 +683,6 @@ void DoRemoveTimeSelectionLeaveLoop(COMMAND_T*)
 	double d=0;
 	GetSet_LoopTimeRange(true, false, &c,&d,false); // set time sel to 0 and 0
 	GetSet_LoopTimeRange(true, true, &a,&b,false); // restore loop
-	*locklooptotime=OldLockLoopToTime;
 }
 
 int g_CurTrackHeightIdx=0;
@@ -872,10 +866,9 @@ void DoRenderReceivesAsStems(COMMAND_T*)
 
 void DoSetRenderSpeedToRealtime2(COMMAND_T*)
 {
-	int sz=0; int *renderspeedmode = (int *)get_config_var("workrender",&sz);
-    if (sz==sizeof(int) && renderspeedmode) 
+	if (ConfigVar<int> renderspeedmode = "workrender")
 	{ 
-		bitset<32> blah(*renderspeedmode);	
+		bitset<32> blah(*renderspeedmode);
 		blah.set(3);
 		*renderspeedmode=blah.to_ulong();
 	}
@@ -885,10 +878,9 @@ void DoSetRenderSpeedToRealtime2(COMMAND_T*)
 
 void DoSetRenderSpeedToNonLim(COMMAND_T*)
 {
-	int sz=0; int *renderspeedmode = (int *)get_config_var("workrender",&sz);
-    if (sz==sizeof(int) && renderspeedmode) 
+	if (ConfigVar<int> renderspeedmode = "workrender")
 	{ 
-		bitset<32> blah(*renderspeedmode);	
+		bitset<32> blah(*renderspeedmode);
 		blah.reset(3);
 		*renderspeedmode=blah.to_ulong();
 	}
@@ -900,8 +892,7 @@ int g_renderspeed=-1;
 
 void DoStoreRenderSpeed(COMMAND_T*)
 {
-	int sz=0; int *renderspeedmode = (int *)get_config_var("workrender",&sz);
-    if (sz==sizeof(int) && renderspeedmode) 
+	if (const ConfigVar<int> renderspeedmode = "workrender")
 	{ 
 		g_renderspeed=*renderspeedmode;
 	}
@@ -911,8 +902,7 @@ void DoStoreRenderSpeed(COMMAND_T*)
 
 void DoRecallRenderSpeed(COMMAND_T*)
 {
-	int sz=0; int *renderspeedmode = (int *)get_config_var("workrender",&sz);
-    if (sz==sizeof(int) && renderspeedmode) 
+	if (ConfigVar<int> renderspeedmode = "workrender")
 	{ 
 		if (g_renderspeed>=0)
 			*renderspeedmode=g_renderspeed;

--- a/Xenakios/MoreItemCommands.cpp
+++ b/Xenakios/MoreItemCommands.cpp
@@ -736,7 +736,7 @@ void DoSetFadeToCrossfade(COMMAND_T* ct)
 
 void DoSetFadeToDefaultFade(COMMAND_T* ct)
 {
-	double* pdDefFade = (double*)GetConfigVar("deffadelen");
+	double* pdDefFade = ConfigVar<double>("deffadelen").get();
 	double dZero = 0.0;
 	const int cnt=CountSelectedMediaItems(NULL);
 	for (int i = 0; i < cnt; i++)

--- a/Xenakios/main.cpp
+++ b/Xenakios/main.cpp
@@ -37,13 +37,12 @@ using namespace std;
 int *ShuffledNumbers;
 int ShuffledNumbersGenerated=0;
 
-int IsRippleOneTrack(COMMAND_T*) { return *(int*)GetConfigVar("projripedit") == 1; }
-int IsRippleAll(COMMAND_T*)      { return *(int*)GetConfigVar("projripedit") == 2; }
+int IsRippleOneTrack(COMMAND_T*) { return *ConfigVar<int>("projripedit") == 1; }
+int IsRippleAll(COMMAND_T*)      { return *ConfigVar<int>("projripedit") == 2; }
 
 void DoToggleRippleOneTrack(COMMAND_T*)
 {
-	int* ripplemode = (int*)GetConfigVar("projripedit");
-	if (ripplemode)
+	if (const ConfigVar<int> ripplemode = "projripedit")
 	{
 		if (*ripplemode == 1)
 			Main_OnCommand(40309, 0);
@@ -54,8 +53,7 @@ void DoToggleRippleOneTrack(COMMAND_T*)
 
 void DoToggleRippleAll(COMMAND_T*)
 {
-	int* ripplemode = (int*)GetConfigVar("projripedit");
-	if (ripplemode)
+	if (const ConfigVar<int> ripplemode = "projripedit")
 	{
 		if (*ripplemode == 2)
 			Main_OnCommand(40309, 0);
@@ -412,16 +410,16 @@ void DoPlayItemsOnce(COMMAND_T*)
 
 void DoMoveCurNextTransMinusFade(COMMAND_T*)
 {
-	int sz=0; double *defFadeLen = (double *)get_config_var("deffadelen",&sz);
+	const double defFadeLen = *ConfigVar<double>("deffadelen");
 	static double prevCurPos = -666.0;
 	double CurPos=GetCursorPosition();
 	if (CurPos==prevCurPos)
 	{
-		CurPos=GetCursorPosition()+*defFadeLen;
+		CurPos=GetCursorPosition()+defFadeLen;
 		SetEditCurPos(CurPos,false,false);
 	}
 	Main_OnCommand(40375,0);
-	CurPos=GetCursorPosition()-*defFadeLen;
+	CurPos=GetCursorPosition()-defFadeLen;
 	SetEditCurPos(CurPos,false,false);
 	prevCurPos=CurPos;
 }
@@ -669,10 +667,7 @@ void DoRenameMarkersWithAscendingNumbers(COMMAND_T* ct)
 
 void DoSetStopAtEndOfTimeSel(int enabled) // -1 toggle 0 unset 1 set
 {
-	// stopendofloop
-	int sz=0;
-	int *stopatend = (int *)get_config_var("stopendofloop",&sz);
-	if (stopatend)
+	if (ConfigVar<int> stopatend = "stopendofloop")
 	{
 		if (enabled==-1)
 		{
@@ -686,7 +681,7 @@ void DoSetStopAtEndOfTimeSel(int enabled) // -1 toggle 0 unset 1 set
 	}
 }
 
-int IsStopAtEndOfTimeSel(COMMAND_T*) { return *(int*)GetConfigVar("stopendofloop") ? true : false; }
+int IsStopAtEndOfTimeSel(COMMAND_T*) { return *ConfigVar<int>("stopendofloop") ? true : false; }
 
 void DoToggleSTopAtEndOfTimeSel(COMMAND_T*)
 {

--- a/Zoom.cpp
+++ b/Zoom.cpp
@@ -126,7 +126,7 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 
 	if (bMinimizeOthers)
 	{
-		*(int*)GetConfigVar("vzoom2") = 0;
+		*ConfigVar<int>("vzoom2") = 0;
 		for (int i = 0; i <= GetNumTracks(); i++)
 			GetSetMediaTrackInfo(CSurf_TrackFromID(i, false), "I_HEIGHTOVERRIDE", &g_i0);
 		Main_OnCommand(40112, 0); // Zoom out vert to minimize envelope lanes too (since vZoom is now 0) (calls refresh)
@@ -261,7 +261,7 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 		// Reset custom track sizes
 		for (int i = 0; i <= GetNumTracks(); i++)
 			GetSetMediaTrackInfo(CSurf_TrackFromID(i, false), "I_HEIGHTOVERRIDE", &g_i0);
-		*(int*)GetConfigVar("vzoom2") = iZoom;
+		*ConfigVar<int>("vzoom2") = iZoom;
 		TrackList_AdjustWindows(false);
 		UpdateTimeline();
 	}
@@ -476,7 +476,7 @@ public:
 		// Vert
 		if (m_bVert)
 		{
-			iVZoom = *(int*)GetConfigVar("vzoom2");
+			iVZoom = *ConfigVar<int>("vzoom2");
 			hbTrackHeights.Resize(GetNumTracks()+1, false);
 			hbTrackVis.Resize(GetNumTracks()+1, false);
 			hbEnvHeights.Resize(0, false);
@@ -521,7 +521,7 @@ public:
 		// Vert zoom
 		if (m_bVert)
 		{
-			*(int*)GetConfigVar("vzoom2") = iVZoom;
+			*ConfigVar<int>("vzoom2") = iVZoom;
 			int iSaved = hbTrackHeights.GetSize();
 			int iEnvPtr = 0;
 			for (int i = 0; i <= GetNumTracks(); i++)
@@ -745,7 +745,7 @@ public:
 			pHeights[i] = *(int*)GetSetMediaTrackInfo(CSurf_TrackFromID(i, false), "I_HEIGHTOVERRIDE", NULL);
 
 		m_dHZoom = GetHZoomLevel();
-		m_iVZoom = *(int*)GetConfigVar("vzoom2");
+		m_iVZoom = *ConfigVar<int>("vzoom2");
 		m_bProjExtents = false;
 	}
 	void ZoomToProject()
@@ -781,7 +781,7 @@ public:
 			return;
 
 		adjustZoom(m_dHZoom, 1, false, -1);
-		*(int*)GetConfigVar("vzoom2") = m_iVZoom;
+		*ConfigVar<int>("vzoom2") = m_iVZoom;
 
 		// Restore track heights, ignoring the fact that tracks could have been added/removed
 		for (int i = 0; i < m_iTrackHeights.GetSize() && i <= GetNumTracks(); i++)

--- a/stdafx.h
+++ b/stdafx.h
@@ -100,6 +100,7 @@
 
 // Headers that are used "enough" to be worth of being precompiled,
 // at the expense of needing recompile of the headers on change
+#include "Utility/configvar.h"
 #include "Utility/SectionLock.h"
 #include "sws_util.h"
 #include "sws_wnd.h"

--- a/sws_util.cpp
+++ b/sws_util.cpp
@@ -275,7 +275,7 @@ int GetTrackVis(MediaTrack* tr) // &1 == mcp, &2 == tcp
 {
 	int iTrack = CSurf_TrackToID(tr, false);
 	if (iTrack == 0)
-		return *(int*)GetConfigVar("showmaintrack") ? 3 : 1; // For now, always return master vis in MCP
+		return *ConfigVar<int>("showmaintrack") ? 3 : 1; // For now, always return master vis in MCP
 	else if (iTrack < 0)
 		return 0;
 
@@ -289,7 +289,7 @@ void SetTrackVis(MediaTrack* tr, int vis) // &1 == mcp, &2 == tcp
 	int iTrack = CSurf_TrackToID(tr, false);
 	if (iTrack == 0)
 	{	// TODO - obey master in mcp
-		if ((vis & 2) != (*(int*)GetConfigVar("showmaintrack") ? 2 : 0))
+		if ((vis & 2) != (*ConfigVar<int>("showmaintrack") ? 2 : 0))
 			Main_OnCommand(40075, 0);
 	}
 	else if (iTrack > 0)
@@ -300,21 +300,6 @@ void SetTrackVis(MediaTrack* tr, int vis) // &1 == mcp, &2 == tcp
 			GetSetMediaTrackInfo(tr, "B_SHOWINMIXER", vis & 1 ? &g_bTrue : &g_bFalse);
 		}
 	}
-}
-
-void* GetConfigVar(const char* cVar)
-{
-	int sztmp;
-	void* p = NULL;
-	if (int iOffset = projectconfig_var_getoffs(cVar, &sztmp))
-	{
-		p = projectconfig_var_addr(EnumProjects(-1, NULL, 0), iOffset);
-	}
-	else
-	{
-		p = get_config_var(cVar, &sztmp);
-	}
-	return p;
 }
 
 HWND GetTrackWnd()

--- a/sws_util.h
+++ b/sws_util.h
@@ -225,7 +225,6 @@ int GetFolderDepth(MediaTrack* tr, int* iType, MediaTrack** nextTr);
 int GetTrackVis(MediaTrack* tr); // &1 == mcp, &2 == tcp
 void SetTrackVis(MediaTrack* tr, int vis); // &1 == mcp, &2 == tcp
 int AboutBoxInit(); // Not worth its own .h
-void* GetConfigVar(const char* cVar);
 HWND GetTrackWnd();
 HWND GetRulerWnd();
 const GUID* TrackToGuid(MediaTrack* tr);

--- a/sws_wnd.cpp
+++ b/sws_wnd.cpp
@@ -416,7 +416,7 @@ INT_PTR SWS_DockWnd::WndProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 					if (*m_tooltip)
 					{
-						if (!(*(int*)GetConfigVar("tooltips")&2)) // obeys the "Tooltip for UI elements" pref
+						if (!(*ConfigVar<int>("tooltips")&2)) // obeys the "Tooltip for UI elements" pref
 						{
 							POINT p = { m_tooltip_pt.x + xo, m_tooltip_pt.y + yo };
 							RECT rr = { r.left+xo,r.top+yo,r.right+xo,r.bottom+yo };

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -7,6 +7,7 @@
  - Make installing the Python ReaScript support optional
  - Fix the install path being initially empty when launching the Windows installer if REAPER is not installed
  - Fix nonworking check for running REAPER processes
++Issue 1131: harden configvar against invalid type interpretation
 
 !v2.10.0 #1 Featured build (February 6, 2019)
 Mega thanks to nofish and cfillion for their many contributions, and X-Raym for doing the tedious work of merging everything into a release.


### PR DESCRIPTION
Fixes #1131. From discussion in #1133. This PR requires C++11, and so I was waiting for the cmake migration to be ready before submitting it.