### PR TITLE
Loudness: Fix potentially invalid max. short-term/momentary measurements

### DIFF
--- a/libebur128/ebur128.cpp
+++ b/libebur128/ebur128.cpp
@@ -311,6 +311,10 @@ ebur128_state* ebur128_init(unsigned int channels,
                                        st->channels *
                                        sizeof(double));
   CHECK_ERROR(!st->d->audio_data, 0, free_true_peak_frame)
+  for (size_t i = 0; i < st->d->audio_data_frames * st->channels; ++i) {
+    st->d->audio_data[i] = 0.0;
+  }
+
   ebur128_init_filter(st);
 
   if (st->d->use_histogram) {
@@ -683,6 +687,9 @@ int ebur128_change_parameters(ebur128_state* st,
                                        st->channels *
                                        sizeof(double));
   CHECK_ERROR(!st->d->audio_data, EBUR128_ERROR_NOMEM, exit)
+  for (size_t i = 0; i < st->d->audio_data_frames * st->channels; ++i) {
+    st->d->audio_data[i] = 0.0;
+  }
 
   /* the first block needs 400ms of audio data */
   st->d->needed_frames = st->d->samples_in_100ms * 4;

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -8,6 +8,9 @@
  - Fix the install path being initially empty when launching the Windows installer if REAPER is not installed
  - Fix nonworking check for running REAPER processes
 
+Fixed:
++Loudness: Fix potentially invalid max. short-term/momentary measurements in high precision mode
+
 !v2.10.0 #1 Featured build (February 6, 2019)
 Mega thanks to nofish and cfillion for their many contributions, and X-Raym for doing the tedious work of merging everything into a release.
 Recommended use of REAPER 5.965.


### PR DESCRIPTION
This is jiixyj/libebur128@383e0a13f34dc735bf4016c982529ae90c14ec34
Backported from libebur128 v1.2.0

> ebur128_loudness_momentary() and ebur128_loudness_shortterm() would read
> unititialized data if the user didn't put in at least 400ms/3000ms worth
> of audio data.

In SWS this caused invalid maximum short-term and maximum momentary measurements
in high precision mode (easily duplicated with Windows debug builds).
