### PR TITLE
Fix media item preview through track when transport is paused

### DIFF
--- a/Breeder/BR_MidiEditor.cpp
+++ b/Breeder/BR_MidiEditor.cpp
@@ -191,9 +191,9 @@ static void MidiTakePreview (int mode, MediaItem_Take* take, MediaTrack* track, 
 				OnPauseButton();
 
 			if (g_ItemPreview.preview_track)
-				g_itemPreviewPlaying = !!PlayTrackPreview2Ex(NULL, &g_ItemPreview, 1, measureSync);
+				g_itemPreviewPlaying = !!PlayTrackPreview2Ex(NULL, &g_ItemPreview, !!measureSync, measureSync);
 			else
-				g_itemPreviewPlaying = !!PlayPreviewEx(&g_ItemPreview, 1, measureSync);
+				g_itemPreviewPlaying = !!PlayPreviewEx(&g_ItemPreview, !!measureSync, measureSync);
 
 			if (g_itemPreviewPlaying)
 			{

--- a/SnM/SnM_Track.cpp
+++ b/SnM/SnM_Track.cpp
@@ -1277,7 +1277,7 @@ bool SNM_PlayTrackPreview(MediaTrack* _tr, PCM_source* _src, bool _pause, bool _
 
 		// go!
 		g_playPreviews.Add(prev);
-		ok = (PlayTrackPreview2Ex(NULL, prev, 1, _msi>0.0? _msi:0.0) != 0);
+		ok = (PlayTrackPreview2Ex(NULL, prev, !!_msi, _msi) != 0);
 	}
 	return ok;
 }

--- a/Xenakios/main.cpp
+++ b/Xenakios/main.cpp
@@ -571,10 +571,10 @@ void ItemPreview(int mode, MediaItem* item, MediaTrack* track, double volume, do
 				if (isMidi)
 					g_itemPreviewSendCC123 = true;
 				g_itemPreviewProject = EnumProjects(-1, NULL, 0);
-				g_itemPreviewPlaying = !!PlayTrackPreview2Ex(g_itemPreviewProject, &g_ItemPreview, 1, measureSync);
+				g_itemPreviewPlaying = !!PlayTrackPreview2Ex(g_itemPreviewProject, &g_ItemPreview, !!measureSync, measureSync);
 			}
 			else
-				g_itemPreviewPlaying = !!PlayPreviewEx(&g_ItemPreview, 1, measureSync);
+				g_itemPreviewPlaying = !!PlayPreviewEx(&g_ItemPreview, !!measureSync, measureSync);
 
 			if (g_itemPreviewPlaying)
 				plugin_register("timer",(void*)ItemPreviewTimer);

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -8,6 +8,9 @@
  - Fix the install path being initially empty when launching the Windows installer if REAPER is not installed
  - Fix nonworking check for running REAPER processes
 
+Fixed:
++Fix media item preview through track when transport is paused (Issue 1189)
+
 !v2.10.0 #1 Featured build (February 6, 2019)
 Mega thanks to nofish and cfillion for their many contributions, and X-Raym for doing the tedious work of merging everything into a release.
 Recommended use of REAPER 5.965.


### PR DESCRIPTION
This reverts commit 67b6f242645246197653df2db52689b58fc1700a. Fixes #1189.

Meaning of bufflag/flags: https://www.askjf.com/index.php?q=1692s

It is unclear why exactly flags=1 makes measure sync work but breaks preview through track when paused and flags=0 breaks measure sync but make it work when paused.