### PR TITLE
padreEnvelopeProcessor: fixes/tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ add_library(sws SHARED
   sws_waitdlg.cpp
   sws_wnd.cpp
   Utility/Base64.cpp
+  Utility/envelope.cpp
   Zoom.cpp
 )
 

--- a/Padre/padreEnvelopeProcessor.cpp
+++ b/Padre/padreEnvelopeProcessor.cpp
@@ -222,10 +222,13 @@ EnvelopeProcessor::ErrorCode EnvelopeProcessor::getTrackEnvelopeMinMax(TrackEnve
 	return eERRORCODE_OK;
 }
 
-void EnvelopeProcessor::writeLfoPoints(string &envState, double dStartTime, double dEndTime, double dValMin, double dValMax, LfoWaveParams &waveParams, double dPrecision, LfoWaveParams* freqModulator)
+void EnvelopeProcessor::writeLfoPoints(MediaItem_Take* take, string &envState, double dStartTime, double dEndTime, double dValMin, double dValMax, LfoWaveParams &waveParams, double dPrecision, LfoWaveParams* freqModulator)
 {
 	double dFreq, dDelay;
 	getFreqDelay(waveParams, dFreq, dDelay);
+
+	if (take) // account for take playrate, #1158
+		dFreq /= GetMediaItemTakeInfo_Value(take, "D_PLAYRATE");
 
 	double dMagnitude = waveParams.strength * (1.0 - fabs(waveParams.offset));
 	double dOff = 0.5*(dValMax+dValMin);
@@ -613,7 +616,7 @@ EnvelopeProcessor::ErrorCode EnvelopeProcessor::generateTrackLfo(TrackEnvelope* 
 		token = strtok(NULL, "\n");
 	}
 
-	writeLfoPoints(newState, dStartPos, dEndPos, dValMin, dValMax, waveParams, dPrecision);
+	writeLfoPoints(nullptr, newState, dStartPos, dEndPos, dValMin, dValMax, waveParams, dPrecision);
 
 	newState.append(token);
 	newState.append("\n");
@@ -748,7 +751,7 @@ EnvelopeProcessor::ErrorCode EnvelopeProcessor::generateTakeLfo(MediaItem_Take* 
 		token = strtok(NULL, "\n");
 	}
 
-	writeLfoPoints(newState, dStartPos, dEndPos, dValMin, dValMax, waveParams, dPrecision);
+	writeLfoPoints(take, newState, dStartPos, dEndPos, dValMin, dValMax, waveParams, dPrecision);
 
 	newState.append(token);
 	newState.append("\n");

--- a/Padre/padreEnvelopeProcessor.cpp
+++ b/Padre/padreEnvelopeProcessor.cpp
@@ -713,9 +713,16 @@ EnvelopeProcessor::ErrorCode EnvelopeProcessor::generateTakeLfo(MediaItem_Take* 
 	//	return eERRORCODE_NULLTIMESELECTION;
 
 	string newState;
-	char* envState = PadresGetEnvelopeState(envelope);
-	if(!envState)
+	string envStateStr;
+	try {
+		envStateStr = envelope::GetEnvelopeStateChunkBig(envelope);
+	}
+	catch (envelope::bad_get_env_chunk_big) {
+
 		return eERRORCODE_NOOBJSTATE;
+	}
+	
+	char* envState = &envStateStr[0];
 	double dTmp[2];
 	int iTmp;
 	char* token = strtok(envState, "\n");
@@ -790,7 +797,6 @@ EnvelopeProcessor::ErrorCode EnvelopeProcessor::generateTakeLfo(MediaItem_Take* 
 writeLfoPoints(newState, dStartPos, dEndPos, dValMin, dValMax, dFreq, dStrength, dOffset, dDelay, tWaveShape, dPrecision);
 	newState.append(">\n");
 */
-	free(envState);
 	if(!newState.size() || !GetSetEnvelopeState(envelope, (char*)newState.c_str(), (int)newState.size()))
 		return eERRORCODE_UNKNOWN;
 
@@ -1085,10 +1091,10 @@ EnvelopeProcessor::ErrorCode EnvelopeProcessor::processTakeEnv(MediaItem_Take* t
 	if(!envelope)
 		return eERRORCODE_NOENVELOPE;
 
-	char* envState = PadresGetEnvelopeState(envelope);
+	string envStateStr = envelope::GetEnvelopeStateChunkBig(envelope);
+	char* envState = &envStateStr[0];
 	string newState;
 	ErrorCode res = processPoints(envState, newState, dStartPos, dEndPos, dValMin, dValMax, envModType, dStrength, dOffset);
-	free(envState);
 
 	if(!newState.size() || !GetSetEnvelopeState(envelope, (char*)newState.c_str(), (int)newState.size()))
 		res = eERRORCODE_UNKNOWN;

--- a/Padre/padreEnvelopeProcessor.h
+++ b/Padre/padreEnvelopeProcessor.h
@@ -135,7 +135,7 @@ ErrorCode processSelectedTakes();
 	protected:
 		static void getFreqDelay(LfoWaveParams &waveParams, double &dFreq, double &dDelay);
 		static ErrorCode getTrackEnvelopeMinMax(TrackEnvelope* envelope, double &dEnvMinVal, double &dEnvMaxVal);
-		static void writeLfoPoints(string &envState, double dStartTime, double dEndTime, double dValMin, double dValMax, LfoWaveParams &waveParams, double dPrecision = 0.1, LfoWaveParams* freqModulator = NULL);
+		static void writeLfoPoints(MediaItem_Take* take, string &envState, double dStartTime, double dEndTime, double dValMin, double dValMax, LfoWaveParams &waveParams, double dPrecision = 0.1, LfoWaveParams* freqModulator = NULL);
 
 		static ErrorCode processPoints(char* envState, string &newState, double dStartPos, double dEndPos, double dValMin, double dValMax, EnvModType envModType, double dStrength = 1.0, double dOffset = 0.0);
 

--- a/Padre/padreUtils.cpp
+++ b/Padre/padreUtils.cpp
@@ -230,34 +230,6 @@ double EnvSignalProcessorFade(double dPos, double dLength, double dStrength, boo
 		return pow(((dLength - dPos)/dLength), dStrength);
 }
 
-char* PadresGetEnvelopeState(TrackEnvelope* envelope)
-{
-	//! \note GetSetObjectState() does not work for take envelopes
-	// While loop shamelessly stolen from SWS! :)
-	if(!envelope)
-		return NULL;
-
-	char* envState = NULL;
-	int iEnvStateMaxSize = 65536;
-	int iEnvStateSize = 256;
-	while(true)
-	{
-		envState = (char*)realloc(envState, iEnvStateSize);
-		envState[0] = 0;
-		bool bRes = GetSetEnvelopeState(envelope, envState, iEnvStateSize);
-		if(bRes && (strlen(envState)!=iEnvStateSize-1))
-			break;
-		if (!bRes || (iEnvStateSize>=iEnvStateMaxSize))
-		{
-			free(envState);
-			return NULL;
-		}
-		iEnvStateSize *= 2;
-	}
-	return envState;
-
-}
-
 void ShowConsoleMsgEx(const char* format, ...)
 {
 	va_list args;

--- a/Padre/padreUtils.h
+++ b/Padre/padreUtils.h
@@ -94,8 +94,6 @@ double WaveformGeneratorRandom(double t, double dFreq, double dDelay);
 
 double EnvSignalProcessorFade(double dPos, double dLength, double dStrength, bool bFadeIn);
 
-char* PadresGetEnvelopeState(TrackEnvelope* envelope);
-
 void ShowConsoleMsgEx(const char* format, ...);
 
 void GetTimeSegmentPositions(TimeSegment timeSegment, double &dStartPos, double &dEndPos, MediaItem* item = NULL);

--- a/Utility/envelope.cpp
+++ b/Utility/envelope.cpp
@@ -1,0 +1,68 @@
+/******************************************************************************
+/ envelope.cpp
+/
+/ Copyright (c) 2019
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#include "stdafx.h"
+#include "../reaper/localize.h"
+#include "envelope.hpp"
+
+
+// wraps GetEnvelopeStateChunk() to make it more save
+// until maybe it gets enhanced one day
+// https://forum.cockos.com/showthread.php?p=2142245#post2142245
+// throws envelope::bad_get_env_chunk_big on failure
+std::string envelope::GetEnvelopeStateChunkBig(TrackEnvelope* envelope, bool isUndo /*= false*/)
+{
+	std::string buffer(1024, '\0');
+
+	while (true) {
+		// can't use std::string::front (C++11) as we're targeting OSX 10.5 (as of September 2019)
+		// though &operator[0] should be ok:
+		// https://github.com/reaper-oss/sws/pull/1202#issuecomment-532476783
+		// if (!GetEnvelopeStateChunk(envelope, &buffer.front(), buffer.size() + 1, isUndo))
+		if (!GetEnvelopeStateChunk(envelope, &buffer[0], buffer.size() + 1, isUndo))
+			break;
+
+		const size_t endpos = buffer.find('\0');
+
+		if (endpos != std::string::npos) {
+			buffer.resize(endpos);
+			return buffer;
+		}
+
+		if (buffer.size() > 100 << 20) { // 100 MiB
+			throw bad_get_env_chunk_big(__LOCALIZE("The envelope chunk size exceeded the 100 MiB limit.", "sws_mbox"));
+		}
+
+		try {
+			buffer.resize(buffer.size() * 2);
+		}
+		catch (const std::bad_alloc) {
+			throw bad_get_env_chunk_big(__LOCALIZE("std::bad_alloc thrown.", "sws_mbox"));
+		}
+	}
+
+	return {};
+}

--- a/Utility/envelope.hpp
+++ b/Utility/envelope.hpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+/ envelope.hpp
+/
+/ Copyright (c) 2019
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#pragma once
+#include <stdexcept>
+
+namespace envelope
+{
+std::string GetEnvelopeStateChunkBig(TrackEnvelope* envelope, bool isUndo = false);
+
+class bad_get_env_chunk_big : public std::runtime_error {
+public:
+	using runtime_error::runtime_error;
+};
+}
+
+

--- a/stdafx.h
+++ b/stdafx.h
@@ -114,6 +114,7 @@
 #include "Padre/padreMidi.h"
 #include "Padre/padreMidiItemProcBase.h"
 #include "Breeder/BR_Timer.h"
+#include "Utility/envelope.hpp"
 
 #ifdef _WIN32
 #  include "Utility/win32-utf8.h"

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -11,6 +11,7 @@
 Fixes:
 PADRE Envelope LFO generator: (Issue #1158)
  - allow for generating more points
+ - account for take playrate
 
 Snapshots:
  - harden getting send envelopes (displays error message in case of failure)

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -8,6 +8,16 @@
  - Fix the install path being initially empty when launching the Windows installer if REAPER is not installed
  - Fix nonworking check for running REAPER processes
 
+Fixes:
+PADRE Envelope LFO generator: (Issue #1158)
+ - allow for generating more points
+
+Snapshots:
+ - harden getting send envelopes (displays error message in case of failure)
+ Reminder from SWS v2.10.0 change log:
+ Send envelops should now be stored/recalled correctly with Snapshots (long standing bug), thogh it hasn't been tested much
+ Since snapshots are based on state chunks, changes within AI envelopes are not stored/recalled currently (https://forum.cockos.com/showthread.php?t=205406|FR|), though AI properties (e.g. position) should be recalled correctly. Also note that when deleting an AI and trying to recall a previously stored snapshot which contains this AI it won't be recalled correctly.
+
 !v2.10.0 #1 Featured build (February 6, 2019)
 Mega thanks to nofish and cfillion for their many contributions, and X-Raym for doing the tedious work of merging everything into a release.
 Recommended use of REAPER 5.965.


### PR DESCRIPTION
take LFO generator:
- allow for generating more envelope points (use _GetEnvelopeStateChunkBig() instead of PadreGetEnvelopeState())
- account for take playrate
fixes #1158

padreUtils:
- remove GetEnvelopeState()

+Snapshots:
- TrackSends: use _GetEnvelopeStateChunkBig() (instead of GetEnvelopeStateChunk())

+add files: envelope.hpp/.cpp (place for contributor independent utility functions), update CMakeLists.txt

**rationale for adding  ~~UtilityFunctions.hpp/.cpp:~~** **envelope.hpp/.cpp**
Currently (general) utility functions are spread in various places in SWS:
sws_util / wol_Util / SnM_Util / XenUtils / ...

I thought I'd rather not add to this by adding my own NF_Util.
So in the past I've added functions to e.g. sws_util, but I don't consider it good style as these are not 'my' files.
UtilityFunctions.hpp/.cpp could serve as a place for collection of all future utility functions in one place (independent of contributor) and it also could be considered condensing some of the existing ones there. 

Wasn't sure about a good function naming convention there.
I've underscored (to differ from Reaper API functions) but not prefixed (e.g. with NF_) because of a possible contributor independent collection (see above), contributor name prefix seems not obligatory imo.

**Open to discussion/suggestions!** 

edit:
I see the builds failed. :(
Well, it does build here, need to investigate..

edit2:
https://travis-ci.com/reaper-oss/sws/jobs/236430802#L542
https://stackoverflow.com/questions/16861535/stdstring-has-no-member-named-front

Confused, I thought we're using C++11(+) now?
The other build errors I have solved I think.






