### PR TITLE
Fix empty columns taking no horizontal space on Linux

### DIFF
--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -373,8 +373,7 @@ void RegionPlaylistView::OnItemClk(SWS_ListItem* item, int iCol, int iKeyState)
 	if (RgnPlaylistItem* pItem = (RgnPlaylistItem*)item)
 	{
 		if (g_optionFlags&2)
-			if (RgnPlaylistItem* pItem = (RgnPlaylistItem*)item)
-				SetEditCurPos2(NULL, pItem->GetPos(), true, false); // move edit curdor, seek done below
+			SetEditCurPos2(NULL, pItem->GetPos(), true, false); // move edit curdor, seek done below
 
 		// do not use PERFORM_MSG here: depends on play state in this case
 		if ((g_optionFlags&1) && GetPlaylist() && (GetPlayState()&1))

--- a/sws_wnd.cpp
+++ b/sws_wnd.cpp
@@ -1256,11 +1256,14 @@ void SWS_ListView::Update()
 				{
 					item.iSubItem = iCol;
 					GetItemText(pItem, k, str, sizeof(str));
-					if (!iCol && !bFound)
+					if (!bFound)
 					{
 						item.mask |= LVIF_PARAM | LVIF_TEXT;
 						item.lParam = (LPARAM)pItem;
-						ListView_InsertItem(m_hwndList, &item);
+						if(iCol == 0)
+							ListView_InsertItem(m_hwndList, &item);
+						else
+							ListView_SetItem(m_hwndList, &item);
 						bResort = true;
 					}
 					else


### PR DESCRIPTION
This was happening because SWELL-generic skips list items with no text attached without updating the drawing coordinates of the next item (WDL patch at <https://github.com/cfillion/WDL/commit/627a0b8ffe571017f4c3bbc108c851c27a05a48a>).

SWS was not setting the LVIF_TEXT mask when populating items beyond the first column thinking it was updating an existing item whose text didn't change.

This patch makes SWS always set LVIF_TEXT when adding items to the list even if the string is empty.