### PR TITLE
Restore TagLib to a mandatory dependency

### DIFF
--- a/Autorender/Autorender.cpp
+++ b/Autorender/Autorender.cpp
@@ -41,10 +41,8 @@
 #include "../Prompt.h"
 #include "WDL/projectcontext.h"
 
-#ifndef NO_TAGLIB
-#  include <taglib/tag.h>
-#  include <taglib/fileref.h>
-#endif
+#include <taglib/tag.h>
+#include <taglib/fileref.h>
 
 int GetCurrentYear(){
 	time_t t = 0;
@@ -699,7 +697,6 @@ void AutorenderRegions(COMMAND_T*)
 		string renderedFilePath = renderedFile->first;
 		RenderRegion renderRegion = renderedFile->second;
 
-#ifndef NO_TAGLIB
 #ifdef _WIN32
 		wchar_t* w_rendered_path = WideCharPlz( renderedFilePath.c_str() );
 		TagLib::FileRef f( w_rendered_path );
@@ -760,7 +757,6 @@ void AutorenderRegions(COMMAND_T*)
 		}
 #ifdef _WIN32
 		delete [] w_rendered_path;
-#endif
 #endif
 	}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 project(sws LANGUAGES C CXX)
 
-option(BUILD_SWS_PYTHON "Generate sws_python(32|64).py (requires Perl)" ON)
-option(SYSTEM_TAGLIB    "Try to use the system-provided TagLib first"   ON)
-option(USE_TAGLIB       "Link with TagLib to enable tagging features"   ON)
+option(BUILD_SWS_PYTHON  "Generate sws_python(32|64).py (requires Perl)" ON)
+option(USE_SYSTEM_TAGLIB "Link against the system-provided TagLib"       OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -157,10 +156,11 @@ target_include_directories(sws PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-find_package(WDL REQUIRED)
-find_package(LICE REQUIRED)
 find_package(JNetLib REQUIRED)
-target_link_libraries(sws JNetLib::JNetLib LICE::LICE WDL::WDL)
+find_package(LICE REQUIRED)
+find_package(TagLib REQUIRED)
+find_package(WDL REQUIRED)
+target_link_libraries(sws JNetLib::JNetLib LICE::LICE TagLib::TagLib WDL::WDL)
 
 find_package(SWELL)
 if(SWELL_FOUND)
@@ -175,16 +175,6 @@ if(SWELL_FOUND)
     DEPENDS ${SWELL_RESGEN}
     MAIN_DEPENDENCY sws_extension.rc
   )
-endif()
-
-if(USE_TAGLIB)
-  find_package(TagLib)
-endif()
-
-if(TagLib_FOUND)
-  target_link_libraries(sws TagLib::TagLib)
-else()
-  target_compile_definitions(sws PRIVATE NO_TAGLIB)
 endif()
 
 if(APPLE)

--- a/SnM/SnM_Misc.cpp
+++ b/SnM/SnM_Misc.cpp
@@ -33,15 +33,12 @@
 #include "SnM_Track.h"
 #include "SnM_Util.h"
 #ifdef _SNM_HOST_AW
-#include "../Misc/Adam.h"
+#  include "../Misc/Adam.h"
 #endif
 #include "../reaper/localize.h"
 
-#ifndef NO_TAGLIB
-#  include <taglib/tag.h>
-#  include <taglib/fileref.h>
-#endif
-
+#include <taglib/tag.h>
+#include <taglib/fileref.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Reascript export, funcs made dumb-proof!
@@ -245,10 +242,6 @@ bool SNM_ReadMediaFileTag(const char *fn, const char* tag, char* tagval, int tag
 {
   if (!fn || !*fn || !tagval || tagval_sz<=0) return false;
   *tagval=0;
-#ifdef NO_TAGLIB
-  return false;
-#else
-
 #ifdef _WIN32
   wchar_t* w_fn = WideCharPlz(fn);
   if (!w_fn) return false;
@@ -280,16 +273,11 @@ bool SNM_ReadMediaFileTag(const char *fn, const char* tag, char* tagval, int tag
   delete [] w_fn;
 #endif
   return !!*tagval;
-#endif
 }
 
 bool SNM_TagMediaFile(const char *fn, const char* tag, const char* tagval)
 {
   if (!fn || !*fn || !tagval || !tag) return false;
-
-#ifdef NO_TAGLIB
-  return false;
-#else
 
 #ifdef _WIN32
   wchar_t* w_fn = WideCharPlz(fn);
@@ -333,7 +321,6 @@ bool SNM_TagMediaFile(const char *fn, const char* tag, const char* tagval)
   delete [] w_fn;
 #endif
   return didsmthg;
-#endif
 }
 
 

--- a/cmake/FindTagLib.cmake
+++ b/cmake/FindTagLib.cmake
@@ -2,18 +2,24 @@ if(TagLib_FOUND)
   return()
 endif()
 
-if(SYSTEM_TAGLIB)
+if(USE_SYSTEM_TAGLIB)
   find_path(TagLib_INCLUDE_DIR NAMES taglib.h PATH_SUFFIXES taglib)
   find_library(TagLib_LIBRARY tag)
   mark_as_advanced(TagLib_INCLUDE_DIR TagLib_LIBRARY)
-endif()
-
-# Build TagLib from source
-if(NOT TagLib_INCLUDE_DIR)
+else()
   set(TagLib_SOURCE_DIR "${CMAKE_SOURCE_DIR}/vendor/taglib")
-endif()
 
-if(TagLib_SOURCE_DIR AND EXISTS "${TagLib_SOURCE_DIR}/CMakeLists.txt")
+  if(NOT EXISTS "${TagLib_SOURCE_DIR}/CMakeLists.txt")
+    message(FATAL_ERROR
+      "TagLib cannnot be found in ${TagLib_SOURCE_DIR}.\n"
+
+      "Run the following command to fetch TagLib and build from source "
+      "or set -DUSE_SYSTEM_TAGLIB=ON to use the system library:\n"
+
+      "git submodule update --init vendor/taglib"
+    )
+  endif()
+
   set(BUILD_BINDINGS OFF CACHE BOOL "Build TagLib C bindings")
 
   # Prevent TagLib from attempting to link against boost (v1.11.1 and older)


### PR DESCRIPTION
It was made optional when SWS was ported to Linux in 1458053c334d4d1de87a91d68849b83c8d3c91ab back when the repository contained prebuilt libraries. libtag.a was compiled for macOS at the time.

Now TagLib is either built from source or SWS uses the system-provided TagLib (controlled by the `USE_SYSTEM_TAGLIB` build option).

Future development efforts (such as reaper-oss/sws#1205) assume TagLib is always available.