### PR TITLE
ReaScript: add NF_ReadAudioFileBitrate() [for after v2.12.0]

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -303,6 +303,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(NF_Win32_GetSystemMetrics), "int", "int", "nIndex", "Equivalent to win32 API GetSystemMetrics().", },
 	{ APIFUNC(NF_GetSWS_RMSoptions), "void", "double*,double*", "targetOut,windowSizeOut", "Get SWS analysis/normalize options. See <a href=\"#NF_SetSWS_RMSoptions\">NF_SetSWS_RMSoptions</a>.", },
 	{ APIFUNC(NF_SetSWS_RMSoptions), "bool", "double,double", "targetLevel,windowSize", "Set SWS analysis/normalize options (same as running action 'SWS: Set RMS analysis/normalize options'). targetLevel: target RMS normalize level (dB), windowSize: window size for peak RMS (sec.)", },
+	{ APIFUNC(NF_ReadAudioFileBitrate), "int", "const char*", "fn", "Returns the bitrate of an audio file in kb/s if available (0 otherwise). For supported filetypes see <a href=\"https://taglib.org/api/classTagLib_1_1AudioProperties.html#ae5b7650b50f8c8f8cc022f25cfee48c5\">TagLib::AudioProperties::bitrate</a>.", },
 	// /*** nofish stuff ***
 
 	{ APIFUNC(SN_FocusMIDIEditor), "void", "", "", "Focuses the active/open MIDI editor.", },

--- a/nofish/NF_ReaScript.cpp
+++ b/nofish/NF_ReaScript.cpp
@@ -39,6 +39,8 @@
 #include "../SnM/SnM_Project.h" // #974
 #include "../SnM/SnM_Chunk.h" // SNM_FXSummaryParser
 
+#include <taglib/fileref.h>
+
 // #781, peak/RMS
 double DoGetMediaItemMaxPeakAndMaxPeakPos(MediaItem* item, double* maxPeakPosOut) // maxPeakPosOut == NULL: peak only
 {
@@ -337,6 +339,34 @@ int NF_Win32_GetSystemMetrics(int nIndex)
 {
 	return GetSystemMetrics(nIndex);
 }
+
+// get taglib audio properties (bitrate only currently)
+enum class TagLibAudioProperties {
+	bitrate = 0
+};
+
+int GetTagLibAudioProperty(const char* fn, TagLibAudioProperties property)
+{
+	if (!fn || !*fn)
+		return 0;
+	TagLib::FileRef f(fn); 
+	if (!f.isNull() && f.audioProperties()) 
+	{
+		switch (property) 
+		{
+			case TagLibAudioProperties::bitrate: 
+				return f.audioProperties()->bitrate();	
+		}		
+	}
+
+	return 0;
+}
+
+int NF_ReadAudioFileBitrate(const char* fn)
+{
+	return GetTagLibAudioProperty(fn, TagLibAudioProperties::bitrate);
+}
+
 
 // #974
 /*

--- a/nofish/NF_ReaScript.h
+++ b/nofish/NF_ReaScript.h
@@ -53,6 +53,7 @@ void           NF_UpdateSWSMarkerRegionSubWindow();
 
 bool           NF_TakeFX_GetFXModuleName(MediaItem* item, int fx, char* nameOut, int nameOutSz);
 int            NF_Win32_GetSystemMetrics(int nIndex);
+int            NF_ReadAudioFileBitrate(const char* fn);
 
 
 // #974


### PR DESCRIPTION
for next release cycle (after v2.11.0)
closes #1134