### PR TITLE
Snapshots: fix 'Prompt on recalling deleted tracks' option

### DIFF
--- a/Snapshots/Snapshots.cpp
+++ b/Snapshots/Snapshots.cpp
@@ -438,7 +438,7 @@ void SWS_SnapshotsWnd::RenameCurrent()
 	m_pLists.Get(0)->EditListItem((SWS_ListItem*)g_ss.Get()->m_snapshots.Get(i), 1);
 }
 
-bool SWS_SnapshotsWnd::GetPromptOnDeleted()
+bool SWS_SnapshotsWnd::GetPromptOnDeletedTracks()
 {
 	return g_bPromptOnDeleted;
 }

--- a/Snapshots/Snapshots.h
+++ b/Snapshots/Snapshots.h
@@ -59,7 +59,7 @@ public:
 	void RenameCurrent();
 	void SetFilterType(int iType) { m_iSelType = iType; }
 	int  GetFilterType() { return m_iSelType; }
-	static bool GetPromptOnDeleted(); // NF: #1073
+	static bool GetPromptOnDeletedTracks(); // NF: #1073
 	
 protected:
 	void OnInitDlg();

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,6 @@
+Snapshots:
+#Fix 'Prompt on recalling deleted tracks' option (report https://github.com/reaper-oss/sws/issues/1073#issuecomment-562705617|here|)
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
fixes https://github.com/reaper-oss/sws/issues/1073#issuecomment-562705617

It actually broke [here](https://github.com/reaper-oss/sws/commit/577b529c9e656974f2e1bdb996c3f8d98b22d87d#diff-0b8713dd67cd3d95cd1b2c1cf7cc1b9fL910-R910) (the check for `prompt` got lost), but I noticed the implementation was (silently) wrong anyway so it's good that it broke and @Poofox reported.
`