### PR TITLE
Fix crash in CF_GetClipboard{,Big} when there is no text data

### DIFF
--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -72,6 +72,11 @@ public:
     m_mem = GetClipboardData(CLIPBOARD_FORMAT);
     m_data = reinterpret_cast<decltype(m_data)>(GlobalLock(m_mem));
 
+    if(!m_data) {
+      m_size = 0;
+      return;
+    }
+
 #ifdef _WIN32
     m_size = WideCharToMultiByte(CP_UTF8, 0, m_data, -1, nullptr, 0, nullptr, nullptr) - 1;
 #else
@@ -87,6 +92,9 @@ public:
       bufSize = m_size;
       buf[m_size] = 0;
     }
+
+    if(!bufSize)
+      return;
 
 #ifdef _WIN32
     WideCharToMultiByte(CP_UTF8, 0, m_data, -1, buf, bufSize, nullptr, nullptr);

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,6 @@
+ReaScript API:
++Fix crash in CF_GetClipboard and CF_GetClipboardBig when the text clipboard does not have data (regression from v2.11.0)
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
Regression from commit 1b02f869cf90c93f2d8d9468f0763a3243b8e63d.