### PR TITLE
Fix 'SWS/S&M: Unselect offscreen items' for items that are vertically offscreen, 'SWS/S&M: Toolbar - Toggle offscreen item selection (top)/(bottom)'

### DIFF
--- a/SnM/SnM_Item.cpp
+++ b/SnM/SnM_Item.cpp
@@ -1314,7 +1314,7 @@ void RefreshOffscreenItems()
 		}
 
 		// up/down item sel.
-		WDL_PtrList<void> trList;
+		WDL_PtrList<MediaTrack> trList;
 		GetVisibleTCPTracks(&trList);
 		bool vertical = (trList.GetSize() > 0);
 
@@ -1351,7 +1351,7 @@ void RefreshOffscreenItems()
 						if (minVis <= maxVis)
 						{
 							MediaTrack* tr = GetMediaItem_Track(item);
-							if (tr && trList.Find((void*)tr) == -1)
+							if (tr && trList.Find(tr) == -1)
 							{
 								int trIdx = CSurf_TrackToID(tr, false);
 								if (trIdx <= minVis)

--- a/SnM/SnM_Window.h
+++ b/SnM/SnM_Window.h
@@ -33,7 +33,7 @@
 bool SNM_IsActiveWindow(HWND _h);
 bool IsChildOf(HWND _hChild, const char* _title);
 HWND GetReaHwndByTitle(const char* _title);
-void GetVisibleTCPTracks(WDL_PtrList<void>* _trList);
+void GetVisibleTCPTracks(WDL_PtrList<MediaTrack>* _trList);
 
 void FocusMainWindow(COMMAND_T*);
 #ifdef _WIN32

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,7 @@
+Miscellaneous:
+Fix 'SWS/S&M: Unselect offscreen items' for items that are vertically offscreen, 'SWS/S&M: Toolbar - Toggle offscreen item selection (top)/(bottom)'  (Issue 1250)
+Note that these work on horizontal track borders, so it may not be totally reliable when track is set to free item positioning mode (not a new issue though)
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
fixes #1250, seems this also broke with the new v6 TCP/MCP architecture
it looks like my fix would be working :hammer: 
(it gets tricky with FIPM where tracks could be party onscreen but the items still invisible, but that isn't accounted for in the original version either, as I gather)

![gif](https://i.imgur.com/Aa0TZ8f.gif)

 

