### PR TITLE
Clean up DockWnd dependency on command Ids

### DIFF
--- a/Breeder/BR_ContextualToolbars.cpp
+++ b/Breeder/BR_ContextualToolbars.cpp
@@ -2032,7 +2032,7 @@ int BR_ContextualToolbarsView::OnItemSort (SWS_ListItem* item1, SWS_ListItem* it
 * Contextual toolbars window                                                  *
 ******************************************************************************/
 BR_ContextualToolbarsWnd::BR_ContextualToolbarsWnd () :
-SWS_DockWnd(IDD_BR_CONTEXTUAL_TOOLBARS, __LOCALIZE("Contextual toolbars","sws_DLG_181"), "", SWSGetCommandID(ContextualToolbarsOptions)),
+SWS_DockWnd(IDD_BR_CONTEXTUAL_TOOLBARS, __LOCALIZE("Contextual toolbars","sws_DLG_181"), ""),
 m_list           (NULL),
 m_currentPreset  (0),
 m_contextMenuCol (0)

--- a/Breeder/BR_Loudness.cpp
+++ b/Breeder/BR_Loudness.cpp
@@ -2234,7 +2234,7 @@ void BR_AnalyzeLoudnessView::OnItemSortEnd ()
 * Analyze loudness window                                                     *
 ******************************************************************************/
 BR_AnalyzeLoudnessWnd::BR_AnalyzeLoudnessWnd () :
-SWS_DockWnd(IDD_BR_LOUDNESS_ANALYZER, __LOCALIZE("Loudness", "sws_DLG_174"), "", SWSGetCommandID(AnalyzeLoudness)),
+SWS_DockWnd(IDD_BR_LOUDNESS_ANALYZER, __LOCALIZE("Loudness", "sws_DLG_174"), ""),
 m_objectsLen        (0),
 m_currentObjectId   (0),
 m_analyzeInProgress (false),

--- a/Color/Autocolor.cpp
+++ b/Color/Autocolor.cpp
@@ -282,7 +282,7 @@ void SWS_AutoColorView::OnEndDrag()
 }
 
 SWS_AutoColorWnd::SWS_AutoColorWnd()
-:SWS_DockWnd(IDD_AUTOCOLOR, __LOCALIZE("Auto Color/Icon/Layout","sws_DLG_115"), "SWSAutoColor", SWSGetCommandID(OpenAutoColor))
+:SWS_DockWnd(IDD_AUTOCOLOR, __LOCALIZE("Auto Color/Icon/Layout","sws_DLG_115"), "SWSAutoColor")
 #ifdef __APPLE__
 	,m_bSettingColor(false)
 #endif

--- a/Console/Console.cpp
+++ b/Console/Console.cpp
@@ -891,7 +891,7 @@ bool LoadConsoleCmds(WDL_PtrList<WDL_FastString>* _outCmds)
 ///////////////////////////////////////////////////////////////////////////////
 
 ReaConsoleWnd::ReaConsoleWnd()
-	: SWS_DockWnd(IDD_CONSOLE, "ReaConsole", "ReaConsole", SWSGetCommandID(ConsoleCommand))
+	: SWS_DockWnd(IDD_CONSOLE, "ReaConsole", "ReaConsole")
 {
 	*m_strCmd = '\0';
 	m_pTrackId = m_strCmd;

--- a/Fingers/GrooveDialog.cpp
+++ b/Fingers/GrooveDialog.cpp
@@ -40,7 +40,7 @@ static const int FNG_REFRESH     = 0xFF01;
 void ShowGrooveDialog(int flags, void *data);
 
 GrooveDialog::GrooveDialog()
-:SWS_DockWnd(IDD_GROOVEDIALOG, __LOCALIZE("Groove","sws_DLG_157"), "FNGGroove", RprCommandManager::getCommandId("FNG_GROOVE_TOOL"))
+:SWS_DockWnd(IDD_GROOVEDIALOG, __LOCALIZE("Groove","sws_DLG_157"), "FNGGroove")
 {
 #ifdef _WIN32
     CoInitializeEx(NULL, 0);

--- a/MarkerList/MarkerList.cpp
+++ b/MarkerList/MarkerList.cpp
@@ -213,7 +213,7 @@ int SWS_MarkerListView::GetItemState(SWS_ListItem* item)
 }
 
 SWS_MarkerListWnd::SWS_MarkerListWnd()
-:SWS_DockWnd(IDD_MARKERLIST, __LOCALIZE("Marker List","sws_DLG_102"), "SWSMarkerList", SWSGetCommandID(OpenMarkerList)), m_dCurPos(DBL_MAX)
+:SWS_DockWnd(IDD_MARKERLIST, __LOCALIZE("Marker List","sws_DLG_102"), "SWSMarkerList"), m_dCurPos(DBL_MAX)
 {
 	// Must call SWS_DockWnd::Init() to restore parameters and open the window if necessary
 	Init();

--- a/Projects/ProjectList.cpp
+++ b/Projects/ProjectList.cpp
@@ -94,7 +94,7 @@ void SWS_ProjectListView::GetItemList(SWS_ListItemList* pList)
 }
 
 SWS_ProjectListWnd::SWS_ProjectListWnd()
-:SWS_DockWnd(IDD_PROJLIST, __LOCALIZE("Project List","sws_DLG_157"), "SWSProjectList", SWSGetCommandID(OpenProjectList))
+:SWS_DockWnd(IDD_PROJLIST, __LOCALIZE("Project List","sws_DLG_157"), "SWSProjectList")
 {
 	// Must call SWS_DockWnd::Init() to restore parameters and open the window if necessary
 	Init();

--- a/SnM/SnM_Cyclactions.cpp
+++ b/SnM/SnM_Cyclactions.cpp
@@ -1898,7 +1898,7 @@ void CommandsView::OnItemSelChanged(SWS_ListItem* item, int iState) {
 // S&M windows lazy init: below's "" prevents registering the SWS' screenset callback
 // (use the S&M one instead - already registered via SNM_WindowManager::Init())
 CyclactionWnd::CyclactionWnd()
-	: SWS_DockWnd(IDD_SNM_CYCLACTION, __LOCALIZE("Cycle Actions","sws_DLG_161"), "", SWSGetCommandID(OpenCyclaction))
+	: SWS_DockWnd(IDD_SNM_CYCLACTION, __LOCALIZE("Cycle Actions","sws_DLG_161"), "")
 {
 	m_id.Set(CA_WND_ID);
 

--- a/SnM/SnM_Find.cpp
+++ b/SnM/SnM_Find.cpp
@@ -134,7 +134,7 @@ bool TrackNotesMatch(MediaTrack* _tr, const char* _searchStr)
 // S&M windows lazy init: below's "" prevents registering the SWS' screenset callback
 // (use the S&M one instead - already registered via SNM_WindowManager::Init())
 FindWnd::FindWnd()
-	: SWS_DockWnd(IDD_SNM_FIND, __LOCALIZE("Find","sws_DLG_154"), "", SWSGetCommandID(OpenFind))
+	: SWS_DockWnd(IDD_SNM_FIND, __LOCALIZE("Find","sws_DLG_154"), "")
 {
 	m_id.Set(FIND_WND_ID);
 	m_type = 0;

--- a/SnM/SnM_LiveConfigs.cpp
+++ b/SnM/SnM_LiveConfigs.cpp
@@ -789,7 +789,7 @@ void LiveConfigView::OnItemDblClk(SWS_ListItem* item, int iCol)
 // S&M windows lazy init: below's "" prevents registering the SWS' screenset callback
 // (use the S&M one instead - already registered via SNM_WindowManager::Init())
 LiveConfigsWnd::LiveConfigsWnd()
-	: SWS_DockWnd(IDD_SNM_LIVE_CONFIGS, __LOCALIZE("Live Configs","sws_DLG_155"), "", SWSGetCommandID(OpenLiveConfig))
+	: SWS_DockWnd(IDD_SNM_LIVE_CONFIGS, __LOCALIZE("Live Configs","sws_DLG_155"), "")
 {
 	m_id.Set(LIVECFG_WND_ID);
 	// Must call SWS_DockWnd::Init() to restore parameters and open the window if necessary
@@ -2768,7 +2768,6 @@ LiveConfigMonitorWnd::LiveConfigMonitorWnd(int _cfgId)
 	m_iResource=IDD_SNM_LIVE_CONFIG_MON;
 	m_wndTitle.Set(title);
 	m_id.Set(dockId);
-	m_iCmdID = SWSGetCommandID(OpenLiveConfigMonitorWnd, (INT_PTR)m_cfgId);
 
 	// screensets: already registered via SNM_WindowManager::Init()
 

--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -134,7 +134,7 @@ bool g_internalMkrRgnChange = false;
 // S&M windows lazy init: below's "" prevents registering the SWS' screenset callback
 // (use the S&M one instead - already registered via SNM_WindowManager::Init())
 NotesWnd::NotesWnd()
-	: SWS_DockWnd(IDD_SNM_NOTES, __LOCALIZE("Notes","sws_DLG_152"), "", SWSGetCommandID(OpenNotes))
+	: SWS_DockWnd(IDD_SNM_NOTES, __LOCALIZE("Notes","sws_DLG_152"), "")
 {
 	m_id.Set(NOTES_WND_ID);
 	// must call SWS_DockWnd::Init() to restore parameters and open the window if necessary

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -529,7 +529,7 @@ void GetMonitoringInfo(WDL_FastString* _curNum, WDL_FastString* _cur,
 // S&M windows lazy init: below's "" prevents registering the SWS' screenset callback
 // (use the S&M one instead - already registered via SNM_WindowManager::Init())
 RegionPlaylistWnd::RegionPlaylistWnd()
-	: SWS_DockWnd(IDD_SNM_RGNPLAYLIST, __LOCALIZE("Region Playlist","sws_DLG_165"), "", SWSGetCommandID(OpenRegionPlaylist))
+	: SWS_DockWnd(IDD_SNM_RGNPLAYLIST, __LOCALIZE("Region Playlist","sws_DLG_165"), "")
 {
 	m_id.Set(RGNPL_WND_ID);
 	// must call SWS_DockWnd::Init() to restore parameters and open the window if necessary

--- a/SnM/SnM_Resources.cpp
+++ b/SnM/SnM_Resources.cpp
@@ -1004,7 +1004,7 @@ done:
 // S&M windows lazy init: below's "" prevents registering the SWS' screenset callback
 // (use the S&M one instead - already registered via SNM_WindowManager::Init())
 ResourcesWnd::ResourcesWnd()
-	: SWS_DockWnd(IDD_SNM_RESOURCES, __LOCALIZE("Resources","sws_DLG_150"), "", SWSGetCommandID(OpenResources))
+	: SWS_DockWnd(IDD_SNM_RESOURCES, __LOCALIZE("Resources","sws_DLG_150"), "")
 {
 	m_id.Set(RES_WND_ID);
 	// Must call SWS_DockWnd::Init() to restore parameters and open the window if necessary
@@ -3428,7 +3428,7 @@ SNM_WindowManager<ImageWnd> g_imgWndMgr(IMG_WND_ID);
 // S&M windows lazy init: below's "" prevents registering the SWS' screenset callback
 // (use the S&M one instead - already registered via SNM_WindowManager::Init())
 ImageWnd::ImageWnd()
-	: SWS_DockWnd(IDD_SNM_IMAGE, __LOCALIZE("Image","sws_DLG_162"), "", SWSGetCommandID(OpenImageWnd))
+	: SWS_DockWnd(IDD_SNM_IMAGE, __LOCALIZE("Image","sws_DLG_162"), "")
 {
 	m_id.Set(IMG_WND_ID);
 	m_stretch = g_stretchPref;

--- a/Snapshots/Snapshots.cpp
+++ b/Snapshots/Snapshots.cpp
@@ -357,7 +357,7 @@ int SWS_SnapshotsView::GetItemState(SWS_ListItem* item)
 }
 
 SWS_SnapshotsWnd::SWS_SnapshotsWnd()
-:SWS_DockWnd(IDD_SNAPS, __LOCALIZE("Snapshots","sws_DLG_101"), "SWSSnapshots", SWSGetCommandID(OpenSnapshotsDialog)),m_iSelType(0)
+:SWS_DockWnd(IDD_SNAPS, __LOCALIZE("Snapshots","sws_DLG_101"), "SWSSnapshots"),m_iSelType(0)
 {
 	// Restore state
 	char str[32];

--- a/TrackList/Tracklist.cpp
+++ b/TrackList/Tracklist.cpp
@@ -197,7 +197,7 @@ int SWS_TrackListView::GetItemState(SWS_ListItem* item)
 }
 
 SWS_TrackListWnd::SWS_TrackListWnd()
-:SWS_DockWnd(IDD_TRACKLIST, __LOCALIZE("Track List","sws_DLG_108"), "SWSTrackList", SWSGetCommandID(OpenTrackList)),m_bUpdate(false),
+:SWS_DockWnd(IDD_TRACKLIST, __LOCALIZE("Track List","sws_DLG_108"), "SWSTrackList"),m_bUpdate(false),
 m_trLastTouched(NULL),m_bHideFiltered(false),m_bLink(false),m_cOptionsKey("Track List Options")
 {
 	// Restore state

--- a/sws_wnd.cpp
+++ b/sws_wnd.cpp
@@ -52,8 +52,8 @@
 #define TOOLTIP_TIMEOUT		350
 
 
-SWS_DockWnd::SWS_DockWnd(int iResource, const char* cWndTitle, const char* cId, int iCmdID)
-:m_hwnd(NULL), m_iResource(iResource), m_wndTitle(cWndTitle), m_id(cId), m_bUserClosed(false), m_iCmdID(iCmdID), m_bSaveStateOnDestroy(true)
+SWS_DockWnd::SWS_DockWnd(int iResource, const char* cWndTitle, const char* cId)
+		: m_hwnd(NULL), m_iResource(iResource), m_wndTitle(cWndTitle), m_id(cId), m_bUserClosed(false), m_bSaveStateOnDestroy(true)
 {
 	if (cId && *cId) // e.g. default constructor
 	{

--- a/sws_wnd.h
+++ b/sws_wnd.h
@@ -175,8 +175,8 @@ typedef struct SWS_DockWnd_State // Converted to little endian on store
 class SWS_DockWnd
 {
 public:
-	// Unless you need the default contructor (new SWS_DockWnd()), you must provide all parameters
-	SWS_DockWnd(int iResource=0, const char* cWndTitle="", const char* cId="", int iCmdID=0);
+	// Unless you need the default constructor (new SWS_DockWnd()), you must provide all parameters
+	explicit SWS_DockWnd(int iResource=0, const char* cWndTitle="", const char* cId="");
 	virtual ~SWS_DockWnd();
 
 	virtual bool IsActive(bool bWantEdit = false);
@@ -229,7 +229,6 @@ protected:
 	virtual void KillTooltip(bool doRefresh=false);
 
 	HWND m_hwnd;
-	int m_iCmdID;
 	int m_iResource;
 	WDL_FastString m_wndTitle;
 	WDL_FastString m_id;


### PR DESCRIPTION
I'm working on implementing a new module and found that the dependency between action function pointers and the `SWS_DockWnd` constructor made it difficult to avoid a lot of awkward global variables.

As far as I can tell it seems that `m_iCmdID` isn't really used in any useful way so this change seems safe to me. Please let me know if there is something I'm missing! 