### PR TITLE
Allow using scripts with a toggle state in cycle action conditions

### DIFF
--- a/SnM/SnM_Cyclactions.cpp
+++ b/SnM/SnM_Cyclactions.cpp
@@ -728,23 +728,26 @@ bool CheckToggle(int _section, Cyclaction* _a, int _cmdIdx)
 	const char* nextCmd = _a ? _a->GetCmd(_cmdIdx) : "";
 	if (*nextCmd)
 	{
+		const auto actionType = GetActionType(nextCmd, false);
+
 		if (strstr(nextCmd, "_CYCLACTION"))
 		{
 			if (Cyclaction* nextAction = GetCAFromCustomId(_section, nextCmd))
 				tglOk = (nextAction->IsToggle() >= 0);
 		}
-		else if (IsMacroOrScript(nextCmd, false) || strstr(nextCmd, "_SWSCONSOLE_CUST"))
+		else if (actionType == ActionType::Custom || strstr(nextCmd, "_SWSCONSOLE_CUST"))
 		{
-			// script, macros & console cmds do not report any toggle state
+			// macros & console cmds do not report any toggle state
 		}
 		else
 		{
-			if (!_section)
+			if (!_section && actionType != ActionType::ReaScript)
 			{
 				KbdSectionInfo* kbdSec = SNM_GetActionSection(_section);
 				tglOk = (GetToggleCommandState2(kbdSec, SNM_NamedCommandLookup(nextCmd, kbdSec)) >= 0);
 			}
 			// for other sections the toggle state can depend on focus, etc..
+			// script set their toggle state at runtime...
 			// => in doubt, we authorize it
 			else
 				tglOk = true;

--- a/SnM/SnM_Util.h
+++ b/SnM/SnM_Util.h
@@ -80,6 +80,8 @@ int SNM_NamedCommandLookup(const char* _custId, KbdSectionInfo* _section = NULL,
 const char* SNM_GetTextFromCmd(int _cmdId, KbdSectionInfo* _section);
 bool LoadKbIni(WDL_PtrList<WDL_FastString>* _out);
 int GetMacroOrScript(const char* _customId, int _sectionUniqueId, WDL_PtrList<WDL_FastString>* _inMacroScripts, WDL_PtrList<WDL_FastString>* _outCmds, WDL_FastString* _outName = NULL);
+enum class ActionType { Unknown, Custom, ReaScript };
+ActionType GetActionType(const char* _cmd, bool _cmdIsName = true);
 bool IsMacroOrScript(const char* _cmd, bool _cmdIsName = true);
 int CheckSwsMacroScriptNumCustomId(const char* _custId, int _secIdx = 0);
 

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,6 @@
+Cycle actions:
++Allow using scripts with a toggle state in conditions (Note: the toggle state is not refreshed while the cycle action is running)
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
This also disables checking whether Main Section scripts have a toggle state set. This is because scripts cannot have a toggle state until they are run. Leaving the check enabled would prevent these cycle actions from being registered when starting up REAPER.