### PR TITLE
Fix reference track defaulting to the master track

### DIFF
--- a/Xenakios/MixerActions.cpp
+++ b/Xenakios/MixerActions.cpp
@@ -922,7 +922,8 @@ typedef struct
 MediaTrack* g_ReferenceTrack=0;
 bool g_ReferenceTrackSolo=false;
 double g_RefMasterVolume=1.0;
-GUID g_RefTrackGUID={}; // Set to invalid GUID
+// Set to invalid GUID (not zero because GuidToTrack would return the master track instead of NULL)
+GUID g_RefTrackGUID { ~0u };
 vector<t_track_solostate> g_RefTrackSolostates;
 
 void DoSetSelTrackAsRefTrack(COMMAND_T*)

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,6 @@
+Miscellaneous:
++Fix reference track defaulting to the master track (v2.11 regression, report https://forum.cockos.com/showthread.php?p=2233601|here|)
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
Regression from the C++11 migration in commit f60ac4cfb15a3e20589ebbc8ed72a4dc3fa98388.

Report at https://forum.cockos.com/showthread.php?p=2233601.