### PR TITLE
ReaConsole: Fix corrupted track colors

### DIFF
--- a/Console/Console.cpp
+++ b/Console/Console.cpp
@@ -567,10 +567,10 @@ void ProcessCommand(CONSOLE_COMMAND command, const char* args)
 					i = RGB(255, 128, 0);
 				else if (_stricmp(args, __LOCALIZE("magenta","sws_DLG_100")) == 0)
 					i = RGB(255, 0, 128);
-				else if (strstr(args, "0x"))
+				else if (strstr(args, "0x") == args)
 				{
-					unsigned int newcol = strtol(args, NULL, 16);
-					i = (newcol & 0xFF0000) >> 16 | (newcol & 0xFF00) | newcol << 16;
+					const long color = strtol(args, NULL, 16);
+					i = RGB((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 				}
 				else
 				{

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,7 @@
+ReaConsole:
++Fix corrupted track colors when the green channel is higher than 127 (report https://forum.cockos.com/showthread.php?p=2225496|here|)
++Fix inverted red and blue channels when coloring tracks on Linux and macOS
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
There were two ways ReaConsole could set `I_CUSTOMCOLOR` to a negative 32-bit signed integer value:

- A green channel higher than 127 (`0x008000 << 16` == MSB set = negative value)
- A color code longer than 6 hex digits (users could set any bit including the MSB and color enable flag)

The stock REAPER v5 theme does not handle negative color values well (as shown in the [report post](https://forum.cockos.com/showthread.php?p=2225496)).

Furthermore, the red and blue channels were inverted on Linux and macOS.

(Not 100% sure whether that last one should be fixed vs preserving compatibility with old configs. I think it makes sense to have ReaConsole behave consistently on all systems and the same way as Auto Color.)