### PR TITLE
Theme helper: add support for REAPER v6

### DIFF
--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,7 @@
+Theme helper:
++Add support for REAPER v6 (report https://forum.cockos.com/showthread.php?t=230558|here|)
++Fix master track showing empty track name instead of "[MASTER]" in REAPER v5 implementation
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
report (and confirmed here): https://forum.cockos.com/showthread.php?t=230558

alternative way to get TCP width (than reading ftom .ini, as it's not in the API obviously) would be:
```
#include "Breeder/BR_Util.h" // GetTcpWnd()
bool isContainer;
HWND tcpWnd = GetTcpWnd(isContainer);
RECT r;	GetClientRect(tcpWnd, &r);
int tcpwWdth = r.right - r.left;
```

but from my (and [Edgemeal's](https://forum.cockos.com/showpost.php?p=2238757&postcount=5)) test both give same result, so not sure which one is better.

It loops through the tracks two times, could have been optimized probably, but I wanted to keep the previous output structure (all TCPs first, then MCPs) and this way it was easier to do. :)

edit:
I left the old code in currently. `I_TCPH` was added in [v5.981+dev0803](https://forum.cockos.com/showthread.php?p=2166101), but I couldn't find when `I_MCPH/I_MCPW` were added. If before/at v5.982 (next SWS required min. REAPER version) the legacy code could theoretically be removed.
 