### PR TITLE
Remove g_runningReaVer (it was unused)

### DIFF
--- a/SnM/SnM_Project.cpp
+++ b/SnM/SnM_Project.cpp
@@ -235,7 +235,6 @@ void ProjectStartupActionTimer()
 	}
 }
 
-double g_runningReaVer;
 // global action timer armed via SNM_Init()/OnInitTimer()
 void GlobalStartupActionTimer()
 {
@@ -248,7 +247,6 @@ void GlobalStartupActionTimer()
 		OutputDebugString("'\n");
 #endif
 	}
-	g_runningReaVer = atof(GetAppVersion());
 }
 
 int PromptClearStartupAction(int _type, bool _clear)

--- a/sws_util.cpp
+++ b/sws_util.cpp
@@ -39,7 +39,6 @@ int  g_i2 = 2;
 bool g_bTrue  = true;
 bool g_bFalse = false;
 MTRand g_MTRand;
-extern double g_runningReaVer; // SnM_Project.cpp/GlobalStartupActionTimer()
 #ifndef _WIN32
 const GUID GUID_NULL = { 0, 0, 0, "\0\0\0\0\0\0\0" };
 #endif


### PR DESCRIPTION
I added this when (trying to) working on AI support for `BR_Env` for avoiding calling` GetAppVersion()` repeatedly (as there were API bugs back then) but it was probably a stupid idea (i.e. premature optimization) anyway.