### PR TITLE
Expose SelectTrackFX to ReaScripts

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -313,6 +313,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetTakeFXChain), "FxChain*", "MediaItem_Take*", "take", "Return a handle to the given take FX chain window. HACK: This temporarily renames the take in order to disambiguate the take FX chain window from similarily named takes.", },
 	{ APIFUNC(CF_GetFocusedFXChain), "FxChain*", "", "", "Return a handle to the currently focused FX chain window.", },
 	{ APIFUNC(CF_EnumSelectedFX), "int", "FxChain*,int", "hwnd,index", "Return the index of the next selected effect in the given FX chain. Start index should be -1. Returns -1 if there are no more selected effects.", },
+	{ APIFUNC(CF_SelectTrackFX), "bool", "MediaTrack*,int", "track,index", "Set which track effect is active in the track's FX chain. The FX chain window does not have to be open.", },
 
 	{ APIFUNC(CF_GetSWSVersion), "void", "char*,int", "buf,buf_sz", "Return the current SWS version number.", },
 

--- a/SnM/SnM_FX.h
+++ b/SnM/SnM_FX.h
@@ -61,6 +61,7 @@ void ToggleAllFXsBypassSelItems(COMMAND_T*);
 void UpdateAllFXsBypassSelItems(COMMAND_T*);
 
 void SelectTrackFX(COMMAND_T*);
+bool SelectTrackFX(MediaTrack* _tr, int _fx);
 int GetSelectedTrackFX(MediaTrack* _tr);
 int GetSelectedTakeFX(MediaItem_Take* _take);
 

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -29,6 +29,7 @@
 #include "cfillion.hpp"
 
 #include "reaper/localize.h"
+#include "SnM/SnM_FX.h"
 #include "version.h"
 
 #ifdef _WIN32
@@ -267,6 +268,12 @@ int CF_EnumSelectedFX(HWND fxChain, const int index)
 {
   const HWND list = GetDlgItem(fxChain, 1076);
   return ListView_GetNextItem(list, index, LVNI_SELECTED);
+}
+
+bool CF_SelectTrackFX(MediaTrack *track, const int index)
+{
+  // track and index are validated in SelectTrackFX
+  return SelectTrackFX(track, index);
 }
 
 int CF_GetMediaSourceBitDepth(PCM_source *source)

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -45,6 +45,7 @@ HWND CF_GetFocusedFXChain();
 HWND CF_GetTrackFXChain(MediaTrack *);
 HWND CF_GetTakeFXChain(MediaItem_Take *);
 int CF_EnumSelectedFX(HWND chain, int index = -1);
+bool CF_SelectTrackFX(MediaTrack *, int index);
 
 int CF_GetMediaSourceBitDepth(PCM_source *);
 bool CF_GetMediaSourceOnline(PCM_source *);

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,6 @@
+ReaScript API:
++Add CF_SelectTrackFX
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
I needed this for my "Select track FX by name" script. While I ended up writing a simplified version of `SelectTrackFX`'s logic in Lua, SWS's chunk parsing implementation is more robust and easier to reuse.