### PR TITLE
Convert SWSSNAPSHOT_GET and SWSSNAPSHOT_SAVE to dynamic actions

### DIFF
--- a/SnM/SnM.h
+++ b/SnM/SnM.h
@@ -224,6 +224,8 @@ typedef struct DYN_COMMAND_T {
 	int (*getEnabled)(COMMAND_T*);
 	int uniqueSectionId;
 	void(*onAction)(COMMAND_T*, int, int, int, HWND);
+
+	bool Register(const int slot) const;
 } DYN_COMMAND_T;
 
 typedef struct SECTION_INFO_T {
@@ -367,6 +369,8 @@ void SNM_Exit();
 
 bool SNM_GetActionName(const char* _custId, WDL_FastString* _nameOut, int _slot = -1);
 int GetFakeToggleState(COMMAND_T*);
+
+DYN_COMMAND_T *FindDynamicAction(void (*doCommand)(COMMAND_T*));
 
 static void freecharptr(char* _p) { FREE_NULL(_p); }
 static void deleteintptr(int* _p) { DELETE_NULL(_p); }

--- a/Snapshots/SnapshotClass.cpp
+++ b/Snapshots/SnapshotClass.cpp
@@ -703,7 +703,7 @@ Snapshot::Snapshot(int slot, int mask, bool bSelOnly, const char* name, const ch
 	char undoStr[128];
 	snprintf(undoStr, sizeof(undoStr), __LOCALIZE_VERFMT("Save snapshot %d","sws_undo"), slot);
 	Undo_OnStateChangeEx(undoStr, UNDO_STATE_MISCCFG, -1);
-	RegisterGetCommand(slot);
+	RegisterSnapshotSlot(slot);
 }
 
 // Build a snapshot from an XML/RPP chunk from the clipboard/RPP/undo/etc
@@ -838,7 +838,7 @@ Snapshot::Snapshot(const char* chunk)
 			else if (ts->ProcessEnv(chunk, line, 4096, &pos, "<MUTEENV", &ts->m_sMuteEnv)) {}
 		}
 	}
-	RegisterGetCommand(m_iSlot);
+	RegisterSnapshotSlot(m_iSlot);
 }
 
 Snapshot::~Snapshot()
@@ -1059,20 +1059,6 @@ int Snapshot::Find(MediaTrack* tr)
 		if (tr == GuidToTrack(&m_tracks.Get(i)->m_guid))
 			return i;
 	return -1;
-}
-
-void Snapshot::RegisterGetCommand(int iSlot) // Slot is 1-based index.
-{
-	static int iLastRegistered = 0;
-	if (iSlot > iLastRegistered)
-	{
-		char cID[BUFFER_SIZE];
-		char cDesc[BUFFER_SIZE];
-		snprintf(cID, BUFFER_SIZE, "SWSSNAPSHOT_GET%d", iSlot);
-		snprintf(cDesc, BUFFER_SIZE, __LOCALIZE_VERFMT("SWS: Recall snapshot %d","sws_actions"), iSlot);
-		SWSRegisterCommandExt(GetSnapshot, cID, cDesc, iSlot, false);
-		iLastRegistered = iSlot;
-	}
 }
 
 char* Snapshot::GetTimeString(char* str, int iStrMax, bool bDate)

--- a/Snapshots/SnapshotClass.h
+++ b/Snapshots/SnapshotClass.h
@@ -131,7 +131,6 @@ public:
 	void DelSelTracks();
 	void SelectTracks();
 	int Find(MediaTrack* tr);
-	static void RegisterGetCommand(int iSlot);
 	char* GetTimeString(char* str, int iStrMax, bool bDate);
 	void GetChunk(WDL_FastString* chunk);
 	void GetDetails(WDL_FastString* details);

--- a/Snapshots/Snapshots.cpp
+++ b/Snapshots/Snapshots.cpp
@@ -32,7 +32,7 @@
 #include "../Prompt.h"
 #include "../reaper/localize.h"
 #include "WDL/projectcontext.h"
-
+#include "SnM/SnM.h" // dynamic actions
 
 #define SNAP_OPTIONS_KEY "Snapshot Options"
 #define RENAME_MSG	0x10001
@@ -1024,11 +1024,11 @@ void SelSnapshotTracks(COMMAND_T*)
 }
 
 void SaveCurSnapshot(COMMAND_T*) { if (g_ss.Get()->m_pCurSnapshot) SaveSnapshot(g_ss.Get()->m_pCurSnapshot->m_iSlot); }
-void SaveSnapshot(COMMAND_T* ct) { SaveSnapshot((int)ct->user); }
+void SaveSnapshot(COMMAND_T* ct) { SaveSnapshot((int)ct->user + 1); }
 void GetCurSnapshot(COMMAND_T*)	 { if (g_ss.Get()->m_pCurSnapshot) GetSnapshot(g_ss.Get()->m_pCurSnapshot->m_iSlot, ALL_MASK, false); }
 void GetPreviousSnapshot(COMMAND_T*) { if ((g_ss.Get()->m_pCurSnapshot) && (g_ss.Get()->m_pCurSnapshot)->m_iSlot >= 0) GetSnapshot(((g_ss.Get()->m_pCurSnapshot->m_iSlot) - 1), ALL_MASK, false); }
 void GetNextSnapshot(COMMAND_T*)	 { if (g_ss.Get()->m_pCurSnapshot) GetSnapshot(((g_ss.Get()->m_pCurSnapshot->m_iSlot) + 1), ALL_MASK, false); }
-void GetSnapshot(COMMAND_T* ct)	 { GetSnapshot((int)ct->user, ALL_MASK, false); }
+void GetSnapshot(COMMAND_T* ct)	 { GetSnapshot((int)ct->user + 1, ALL_MASK, false); }
 void SetSnapType(COMMAND_T* ct)
 {
 	int type=(int)ct->user;
@@ -1184,18 +1184,6 @@ static COMMAND_T g_commandTable[] =
 	{ { DEFACCEL, "SWS: New snapshot and edit name" },						"SWSSNAPSHOT_NEWEDIT",   NewSnapshotEdit,	   NULL, 1 },
 	{ { DEFACCEL, "SWS: Delete current snapshot" },						"SWSSNAPSHOT_DELCUR",   DeleteCurSnapshot },
 	{ { DEFACCEL, "SWS: Delete all snapshots" },							"SWSSNAPSHOT_DELALL",   DeleteAllSnapshots, "Delete all snapshots" },
-	{ { DEFACCEL, "SWS: Save as snapshot 1" },								"SWSSNAPSHOT_SAVE1",	 SaveSnapshot,         NULL, 1 },
-	{ { DEFACCEL, "SWS: Save as snapshot 2" },								"SWSSNAPSHOT_SAVE2",	 SaveSnapshot,         NULL, 2 },
-	{ { DEFACCEL, "SWS: Save as snapshot 3" },								"SWSSNAPSHOT_SAVE3",	 SaveSnapshot,         NULL, 3 },
-	{ { DEFACCEL, "SWS: Save as snapshot 4" },								"SWSSNAPSHOT_SAVE4",	 SaveSnapshot,         NULL, 4 },
-	{ { DEFACCEL, "SWS: Save as snapshot 5" },								"SWSSNAPSHOT_SAVE5",	 SaveSnapshot,         NULL, 5 },
-	{ { DEFACCEL, "SWS: Save as snapshot 6" },								"SWSSNAPSHOT_SAVE6",	 SaveSnapshot,         NULL, 6 },
-	{ { DEFACCEL, "SWS: Save as snapshot 7" },								"SWSSNAPSHOT_SAVE7",	 SaveSnapshot,         NULL, 7 },
-	{ { DEFACCEL, "SWS: Save as snapshot 8" },								"SWSSNAPSHOT_SAVE8",	 SaveSnapshot,         NULL, 8 },
-	{ { DEFACCEL, "SWS: Save as snapshot 9" },								"SWSSNAPSHOT_SAVE9",	 SaveSnapshot,         NULL, 9 },
-	{ { DEFACCEL, "SWS: Save as snapshot 10" },								"SWSSNAPSHOT_SAVE10",	 SaveSnapshot,         NULL, 10 },
-	{ { DEFACCEL, "SWS: Save as snapshot 11" },								"SWSSNAPSHOT_SAVE11",	 SaveSnapshot,         NULL, 11 },
-	{ { DEFACCEL, "SWS: Save as snapshot 12" },								"SWSSNAPSHOT_SAVE12",	 SaveSnapshot,         NULL, 12 },
 
 	{ { DEFACCEL, "SWS: Set snapshots to 'mix' mode" },						"SWSSNAPSHOT_MIXMODE",   SetSnapType,    NULL, 0 },
 	{ { DEFACCEL, "SWS: Set snapshots to 'visibility' mode" },				"SWSSNAPSHOT_VISMODE",   SetSnapType,    NULL, 1 },
@@ -1264,8 +1252,6 @@ static void menuhook(const char* menustr, HMENU hMenu, int flag)
 	}
 }
 
-int g_nbRecallPref = 12;
-
 int SnapshotsInit()
 {
 	if (!plugin_register("projectconfig",&g_projectconfig))
@@ -1273,17 +1259,32 @@ int SnapshotsInit()
 
 	SWSRegisterCommands(g_commandTable);
 
-	// Add gets by default, more actions are added dynamically as needed
-	g_nbRecallPref = GetPrivateProfileInt(SWS_INI, "DefaultNbSnapsRecall", 12, get_ini_file());
-	for (int i = 0; i < g_nbRecallPref; i++)
-		Snapshot::RegisterGetCommand(i+1);
-
 	if (!plugin_register("hookcustommenu", (void*)menuhook))
 		return 0;
+
+	// DEPRECATED: DefaultNbSnapsRecall is replaced by [NbOfActions] in S&M.ini
+	// This migrates the old setting to the new one (SNM_Init is called later)
+	const int nbrecall = GetPrivateProfileInt(SWS_INI, "DefaultNbSnapsRecall", -1, get_ini_file());
+	if (nbrecall >= 0)
+		FindDynamicAction(GetSnapshot)->count = nbrecall;
 
 	g_pSSWnd = new SWS_SnapshotsWnd;
 
 	return 1;
+}
+
+void RegisterSnapshotSlot(const int slot) // slot is a 1-based index
+{
+	static int lastRegistered = 0;
+	static const DYN_COMMAND_T *cmd = FindDynamicAction(GetSnapshot);
+
+	if (slot <= lastRegistered)
+		return;
+
+	if (slot > cmd->count) // only register new slots above the configured amount
+		cmd->Register(slot - 1);
+
+	lastRegistered = slot;
 }
 
 void SnapshotsExit()
@@ -1291,9 +1292,8 @@ void SnapshotsExit()
 	plugin_register("-projectconfig",&g_projectconfig);
 	plugin_register("-hookcustommenu", (void*)menuhook);
 
-	char buf[64];
-	sprintf(buf, "%d", g_nbRecallPref);
-	WritePrivateProfileString(SWS_INI, "DefaultNbSnapsRecall", buf, get_ini_file());
+	// deletes the old setting key (see SnapshotsInit)
+	WritePrivateProfileString(SWS_INI, "DefaultNbSnapsRecall", nullptr, get_ini_file());
 
 	delete g_pSSWnd;
 }

--- a/Snapshots/Snapshots.h
+++ b/Snapshots/Snapshots.h
@@ -83,13 +83,16 @@ private:
 #endif
 };
 
+class Snapshot;
 
 int SnapshotsInit();
+void RegisterSnapshotSlot(int);
 void SnapshotsExit();
 void OpenSnapshotsDialog(COMMAND_T* = NULL);
 void NewSnapshot(int iMask, bool bSelOnly);
 void NewSnapshot(COMMAND_T* = NULL);
 Snapshot* GetSnapshotPtr(int i);
-void GetSnapshot(COMMAND_T* ct);
+void GetSnapshot(COMMAND_T*);
 void GetSnapshot(int slot, int iMask, bool bSelOnly);
+void SaveSnapshot(COMMAND_T*);
 void UpdateSnapshotsDialog(bool bSelChange = false);

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -1213,7 +1213,7 @@ error:
 			ERR_RETURN("ReaConsole init error.")
 		if (!FreezeInit())
 			ERR_RETURN("Freeze init error.")
-		if (!SnapshotsInit())
+		if (!SnapshotsInit()) // must be called before SNM_Init registers dynamic actions
 			ERR_RETURN("Snapshots init error.")
 		if (!TrackListInit())
 			ERR_RETURN("Tracklist init error.")

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,7 @@
+Snapshots:
++Allow customizing the amount of "Save as snapshot n" actions via [NbOfActions]/SWSSNAPSHOT_SAVE in S&M.ini (Issue 1310)
++Replace the setting [SWS]/DefaultNbSnapsRecall in reaper.ini by [NbOfActions]/SWSSNAPSHOT_GET in S&M.ini
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
- Makes the quantity of `SWSSNAPSHOT_SAVE` actions user-configurable
- Prevents possible weird bugs due to the old `DefaultNbSnapsRecall` setting being unbounded and command IDs being limited to 16-bit (+ fairly slow to register in big amounts)
- `reaper.ini/SWS/DefaultNbSnapsRecall` is automatically migrated to `S&M.ini/NbOfActions/SWSSNAPSHOT_GET` and deleted