### PR TITLE
Enable the whatsnew build target on macOS and Linux

### DIFF
--- a/BuildUtils/CMakeLists.txt
+++ b/BuildUtils/CMakeLists.txt
@@ -19,20 +19,18 @@ add_custom_command(
 add_custom_target(langpack DEPENDS ${LANGPACK_OUTPUT})
 add_dependencies(langpack buildlangpack)
 
-if(WIN32)
-  set(WHATSNEW_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/whatsnew.html)
-  set(WHATSNEW_SOURCE ${CMAKE_SOURCE_DIR}/whatsnew.txt)
+set(WHATSNEW_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/whatsnew.html)
+set(WHATSNEW_SOURCE ${CMAKE_SOURCE_DIR}/whatsnew.txt)
 
-  add_executable(makewhatsnew EXCLUDE_FROM_ALL MakeWhatsNew.cpp)
-  target_include_directories(makewhatsnew PRIVATE ${WDL_INCLUDE_DIR})
+add_executable(makewhatsnew EXCLUDE_FROM_ALL MakeWhatsNew.cpp)
+target_include_directories(makewhatsnew PRIVATE ${WDL_INCLUDE_DIR})
 
-  add_custom_command(
-    OUTPUT ${WHATSNEW_OUTPUT}
-    COMMAND $<TARGET_FILE:makewhatsnew> -h ${WHATSNEW_SOURCE} ${WHATSNEW_OUTPUT}
-    DEPENDS ${WHATSNEW_SOURCE}
-    COMMAND_EXPAND_LISTS
-  )
+add_custom_command(
+  OUTPUT ${WHATSNEW_OUTPUT}
+  COMMAND $<TARGET_FILE:makewhatsnew> -h ${WHATSNEW_SOURCE} ${WHATSNEW_OUTPUT}
+  DEPENDS ${WHATSNEW_SOURCE}
+  COMMAND_EXPAND_LISTS
+)
 
-  add_custom_target(whatsnew DEPENDS ${WHATSNEW_OUTPUT})
-  add_dependencies(whatsnew makewhatsnew)
-endif()
+add_custom_target(whatsnew DEPENDS ${WHATSNEW_OUTPUT})
+add_dependencies(whatsnew makewhatsnew)

--- a/BuildUtils/MakeWhatsNew.cpp
+++ b/BuildUtils/MakeWhatsNew.cpp
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <WDL/ptrlist.h>
+#include <WDL/wdlcstring.h>
 #include <WDL/wdlstring.h>
 
 class IntStack
@@ -185,11 +186,7 @@ int GenHtmlWhatsNew(const char* fnIn, const char* fnOut, bool bFullHTML, const c
 				url.SetLen(0);
 			}
 
-#ifdef _WIN32
-			if (_strnicmp(&cBuf[iPos], "issue ", 6) == 0)
-#else
-			if (strncasecmp(&cBuf[iPos], "issue ", 6) == 0)
-#endif
+			if (strnicmp(&cBuf[iPos], "issue ", 6) == 0)
 			{
 				int iIssue = atol(&cBuf[iPos+6]);
 				if (iIssue != 0)
@@ -279,12 +276,12 @@ int GenHtmlWhatsNew(const char* fnIn, const char* fnOut, bool bFullHTML, const c
 			}
 		}
 		// Special cases for <strong></strong>
-		else if (_strnicmp(&cBuf[iPos], "<strong>", 8) == 0)
+		else if (strnicmp(&cBuf[iPos], "<strong>", 8) == 0)
 		{
 			fputs("<strong>", pOut);
 			iPos += 7;
 		}
-		else if (_strnicmp(&cBuf[iPos], "</strong>", 9) == 0)
+		else if (strnicmp(&cBuf[iPos], "</strong>", 9) == 0)
 		{
 			fputs("</strong>", pOut);
 			iPos += 8;
@@ -322,7 +319,6 @@ int GenHtmlWhatsNew(const char* fnIn, const char* fnOut, bool bFullHTML, const c
 	return 0;
 }
 
-#ifdef _WIN32
 int main(int argc, char* argv[])
 {
 	if (argc < 2)
@@ -341,12 +337,11 @@ int main(int argc, char* argv[])
 	}
 
 	char fnIn[2048]="", fnOut[2048]="";
-	lstrcpyn(fnIn, argv[iNextArg], sizeof(fnIn));
+	lstrcpyn_safe(fnIn, argv[iNextArg], sizeof(fnIn));
 	iNextArg++;
 
 	if (argc == iNextArg + 1)
-		lstrcpyn(fnOut, argv[iNextArg], sizeof(fnOut));
+		lstrcpyn_safe(fnOut, argv[iNextArg], sizeof(fnOut));
 
 	return GenHtmlWhatsNew(fnIn, fnOut, bFullHTML, NULL);
 }
-#endif

--- a/BuildUtils/MakeWhatsNew.cpp
+++ b/BuildUtils/MakeWhatsNew.cpp
@@ -68,7 +68,7 @@ int GenHtmlWhatsNew(const char* fnIn, const char* fnOut, bool bFullHTML, const c
 	if (*fnOut)
 	{
 #ifdef _WIN32
-		fopen_s(&pOut, fnOut, "w");
+		fopen_s(&pOut, fnOut, "wb");
 #else
 		pOut = fopen(fnOut, "w");
 #endif


### PR DESCRIPTION
MakeWhatsNew.cpp was using functions that were only available on Windows.