### PR TITLE
Disable thread-safe initialization of local static variables on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ if(MSVC)
 
     # Remove unreferenced COMDAT
     $<$<NOT:$<CONFIG:Debug>>:/Zc:inline>
+
+    # Disable thread-safe initialization of local static variables for XP compatibility
+    # https://web.archive.org/web/20151123133638/https://connect.microsoft.com/VisualStudio/feedback/details/1789709/visual-c-2015-runtime-broken-on-windows-server-2003-c-11-magic-statics
+    /Zc:threadSafeInit-
   )
 else()
   add_compile_options(-fstack-protector-strong -fdiagnostics-color)

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,5 @@
++Fix various crashes occuring on Windows XP since v2.10.0 (issue 1332)
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
This is required for compatibility with Windows XP

https://web.archive.org/web/20151123133638/https://connect.microsoft.com/VisualStudio/feedback/details/1789709/visual-c-2015-runtime-broken-on-windows-server-2003-c-11-magic-statics