### PR TITLE
Loudness: fix momentary calculation

### DIFF
--- a/Breeder/BR_Loudness.cpp
+++ b/Breeder/BR_Loudness.cpp
@@ -1153,7 +1153,7 @@ unsigned WINAPI BR_LoudnessObject::AnalyzeData (void* loudnessObject)
 			}
 
 			// Momentary buffer (400 ms) filled
-			if (i % 2 && momentaryFilled && doMomentary)
+			if ((i % 2 > 0) == momentaryFilled && doMomentary)
 			{
 				double momentary;
 				ebur128_loudness_momentary(loudnessState, &momentary);

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,5 @@
+Loudness: fix momentary calculation (regression from v2.11.0)
+
 !v2.11.0 pre-release build
 <strong>Reminder: this new SWS version requires REAPER v5.979+!</strong>
 


### PR DESCRIPTION
Came across this when looking into https://github.com/reaper-oss/sws/issues/1335.
current line 
`if (i % 2 && momentaryFilled && doMomentary)` (momentaryFilled is bool)
can evaluate differently than Breeder's original line
`if (i % 2 == momentaryFilled && doMomentary)` (momentaryFilled is int)
e.g. when i = 0; momentaryFilled = false/0 ; doMomentary = true -> 1st line == false, 2nd line == true

With the cast to int the "unsafe conversion from bool to int" warning (https://github.com/reaper-oss/sws/pull/1215#issuecomment-545528589) could be avoided but then it could be thought if maybe better that momentaryFilled stays an int rather than casting every time.

@cfillion 
What do you think?





`