### PR TITLE
Fix _SWS_MOVECURSAMPLEFT and _SWS_MOVECURSAMPRIGHT

### DIFF
--- a/Misc/EditCursor.cpp
+++ b/Misc/EditCursor.cpp
@@ -99,14 +99,15 @@ void MoveCursorSample(COMMAND_T* ct)
 	if (!projsrate)
 		return;
 
-	INT64 iCurSample = (INT64)(dPos * *projsrate + 0.5);
-	if (ct->user == -1 && (dPos == (double)(iCurSample / *projsrate)))
+	const double dSrate = *projsrate;
+	int64_t iCurSample = static_cast<int64_t>(dPos * dSrate + 0.5);
+
+	if (ct->user == -1 && (dPos == iCurSample / dSrate))
 		iCurSample--;
 	else if (ct->user == 1)
 		iCurSample++;
 
-	double dNewPos = (double)(iCurSample / *projsrate);
-
+	const double dNewPos = iCurSample / dSrate;
 	SetEditCurPos(dNewPos, true, false);
 }
 


### PR DESCRIPTION
Another regression from v2.11.0: it broke in c06f8cfa0d64607c4544a733ae780af21a9d2439 by doing integer division instead of floating point division.

Reported at https://forum.cockos.com/showpost.php?p=2282414.