### PR TITLE
slightly clean up BR_EnvelopeUtil.h/.cpp

### DIFF
--- a/Breeder/BR_EnvelopeUtil.cpp
+++ b/Breeder/BR_EnvelopeUtil.cpp
@@ -1793,7 +1793,7 @@ bool BR_Envelope::FillProperties () const
 					lp.parse(token);
 					m_properties.visible    = lp.gettoken_int(1);
 					m_properties.lane       = lp.gettoken_int(2);
-					// 3rd field is a deprecated value, always 1.0, see p=2198426&postcount=118
+					// 3rd field is a deprecated value, always 1.0, see p=2198426
 				}
 				else if (!strncmp(token, "LANEHEIGHT ", sizeof("LANEHEIGHT ")-1))
 				{
@@ -1810,8 +1810,10 @@ bool BR_Envelope::FillProperties () const
 				{
 					lp.parse(token);
 					m_properties.shape         = lp.gettoken_int(1);
-					m_properties.shapeUnknown1 = lp.gettoken_int(2);
-					m_properties.shapeUnknown2 = lp.gettoken_int(3);
+					// 2nd and 3rd fields are pitch env range/snap settings, -1 = global default, 
+					// otherwise these are the LSBand MSB of the "pitchenvrange" config variable, see p=2198426
+					m_properties.pitchEnvRange = lp.gettoken_int(2);
+					m_properties.pitchEnvSnap  = lp.gettoken_int(3);
 				}
 				else if (!strncmp(token, "VOLTYPE ", sizeof("VOLTYPE ")-1))
 				{
@@ -1908,10 +1910,10 @@ WDL_FastString BR_Envelope::GetProperties ()
 		properties.Append(m_properties.paramType.Get());
 		properties.Append("\n");
 		properties.AppendFormatted(256, "ACT %d %d\n", m_properties.active, m_properties.AIoptions);
-		properties.AppendFormatted(256, "VIS %d %d %d\n", m_properties.visible, m_properties.lane, 1.0);
+		properties.AppendFormatted(256, "VIS %d %d 1\n", m_properties.visible, m_properties.lane);
 		properties.AppendFormatted(256, "LANEHEIGHT %d %d\n", m_properties.height, m_properties.heightUnknown);
 		properties.AppendFormatted(256, "ARM %d\n", m_properties.armed);
-		properties.AppendFormatted(256, "DEFSHAPE %d %d %d\n", m_properties.shape, m_properties.shapeUnknown1, m_properties.shapeUnknown2);
+		properties.AppendFormatted(256, "DEFSHAPE %d %d %d\n", m_properties.shape, m_properties.pitchEnvRange, m_properties.pitchEnvSnap);
 		for (int i = 0; i < (int)m_properties.automationItems.size(); ++i)
 		{
 			properties.Append(m_properties.automationItems[i].Get());
@@ -1943,8 +1945,8 @@ height        (0),
 heightUnknown (0),
 armed         (0),
 shape         (0),
-shapeUnknown1 (0),
-shapeUnknown2 (0),
+pitchEnvRange (0),
+pitchEnvSnap  (0),
 faderMode     (0),
 type          (UNKNOWN),
 minValue      (0),
@@ -1966,8 +1968,8 @@ height          (properties.height),
 heightUnknown   (properties.heightUnknown),
 armed           (properties.armed),
 shape           (properties.shape),
-shapeUnknown1   (properties.shapeUnknown1),
-shapeUnknown2   (properties.shapeUnknown2),
+pitchEnvRange   (properties.pitchEnvRange),
+pitchEnvSnap    (properties.pitchEnvSnap),
 faderMode       (properties.faderMode),
 type            (properties.type),
 minValue        (properties.minValue),
@@ -1996,8 +1998,8 @@ BR_Envelope::EnvProperties& BR_Envelope::EnvProperties::operator= (const EnvProp
 	heightUnknown   = properties.heightUnknown;
 	armed           = properties.armed;
 	shape           = properties.shape;
-	shapeUnknown1   = properties.shapeUnknown1;
-	shapeUnknown2   = properties.shapeUnknown2;
+	pitchEnvRange   = properties.pitchEnvRange;
+	pitchEnvSnap    = properties.pitchEnvSnap;
 	faderMode       = properties.faderMode;
 	type            = properties.type;
 	minValue        = properties.minValue;

--- a/Breeder/BR_EnvelopeUtil.cpp
+++ b/Breeder/BR_EnvelopeUtil.cpp
@@ -1793,7 +1793,7 @@ bool BR_Envelope::FillProperties () const
 					lp.parse(token);
 					m_properties.visible    = lp.gettoken_int(1);
 					m_properties.lane       = lp.gettoken_int(2);
-					m_properties.visUnknown = lp.gettoken_int(3);
+					// 3rd field is a deprecated value, always 1.0, see p=2198426&postcount=118
 				}
 				else if (!strncmp(token, "LANEHEIGHT ", sizeof("LANEHEIGHT ")-1))
 				{
@@ -1908,7 +1908,7 @@ WDL_FastString BR_Envelope::GetProperties ()
 		properties.Append(m_properties.paramType.Get());
 		properties.Append("\n");
 		properties.AppendFormatted(256, "ACT %d %d\n", m_properties.active, m_properties.AIoptions);
-		properties.AppendFormatted(256, "VIS %d %d %d\n", m_properties.visible, m_properties.lane, m_properties.visUnknown);
+		properties.AppendFormatted(256, "VIS %d %d %d\n", m_properties.visible, m_properties.lane, 1.0);
 		properties.AppendFormatted(256, "LANEHEIGHT %d %d\n", m_properties.height, m_properties.heightUnknown);
 		properties.AppendFormatted(256, "ARM %d\n", m_properties.armed);
 		properties.AppendFormatted(256, "DEFSHAPE %d %d %d\n", m_properties.shape, m_properties.shapeUnknown1, m_properties.shapeUnknown2);
@@ -1939,7 +1939,6 @@ active        (0),
 AIoptions     (-1),
 visible       (0),
 lane          (0),
-visUnknown    (0),
 height        (0),
 heightUnknown (0),
 armed         (0),
@@ -1963,7 +1962,6 @@ active          (properties.active),
 AIoptions       (-1),
 visible         (properties.visible),
 lane            (properties.lane),
-visUnknown      (properties.visUnknown),
 height          (properties.height),
 heightUnknown   (properties.heightUnknown),
 armed           (properties.armed),
@@ -1994,7 +1992,6 @@ BR_Envelope::EnvProperties& BR_Envelope::EnvProperties::operator= (const EnvProp
 	visible         = properties.visible;
 
 	lane            = properties.lane;
-	visUnknown      = properties.visUnknown;
 	height          = properties.height;
 	heightUnknown   = properties.heightUnknown;
 	armed           = properties.armed;

--- a/Breeder/BR_EnvelopeUtil.h
+++ b/Breeder/BR_EnvelopeUtil.h
@@ -173,7 +173,7 @@ private:
 	struct EnvProperties
 	{
 		int active, AIoptions; // automation items options, second ACT token in track env. chunk
-		int visible, lane, visUnknown;
+		int visible, lane;
 		int height, heightUnknown;
 		int armed;
 		int shape, shapeUnknown1, shapeUnknown2;

--- a/Breeder/BR_EnvelopeUtil.h
+++ b/Breeder/BR_EnvelopeUtil.h
@@ -176,7 +176,7 @@ private:
 		int visible, lane;
 		int height, heightUnknown;
 		int armed;
-		int shape, shapeUnknown1, shapeUnknown2;
+		int shape, pitchEnvRange, pitchEnvSnap;
 		int faderMode;
 		BR_EnvType type;
 		double minValue, maxValue, centerValue;


### PR DESCRIPTION
slight refactor/clean up of `BR_EnvelopeUtil.h/.cpp` according to schwa's info:
https://forum.cockos.com/showthread.php?p=2198426&postcount=118

- deprecate/remove m_properties.visUnknown (is always 1.0)
- rename m_properties.shapeUnknown1/2 to m_properties.pitchEnvRange/pitchEnvSnap (only used class internal, so should be backwards compatibel)