### PR TITLE
Sort files alphabetically when switching to prev/next in folder

### DIFF
--- a/Xenakios/MoreItemCommands.cpp
+++ b/Xenakios/MoreItemCommands.cpp
@@ -1104,6 +1104,8 @@ void ReplaceItemSourceFileFromFolder(bool askforFolder,int mode,int param,bool o
 		SplitFileNameComponents(srcfn,fncompns);
 		foundfiles.clear();
 		SearchDirectory(foundfiles, fncompns[0].c_str(), onlyRPP ? "RPP" : NULL, false);
+		if (mode==0) // sequential mode
+			std::sort(foundfiles.begin(), foundfiles.end());
 		int j;
 		// find index take's source file in the found files
 		int fileindx=-1;


### PR DESCRIPTION
Affected actions:

- Xenakios/SWS: Switch item source file to next in folder
- Xenakios/SWS: Switch item source file to previous in folder