### PR TITLE
Fix disappearing notes when using multiple project tabs

### DIFF
--- a/SnM/SnM_Find.cpp
+++ b/SnM/SnM_Find.cpp
@@ -118,7 +118,7 @@ bool TrackNotesMatch(MediaTrack* _tr, const char* _searchStr)
 		{
 			if (g_SNM_TrackNotes.Get()->Get(i)->GetTrack() == _tr)
 			{
-				match = (stristr(g_SNM_TrackNotes.Get()->Get(i)->m_notes.Get(), _searchStr) != NULL);
+				match = stristr(g_SNM_TrackNotes.Get()->Get(i)->GetNotes(), _searchStr) != NULL;
 				break;
 			}
 		}

--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -822,7 +822,7 @@ void NotesWnd::SaveCurrentMkrRgnNameOrSub(int _type, bool _wantUndo)
 				}
 			}
 			if (!found)
-				g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(g_lastMarkerRegionId, g_lastText));
+				g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(nullptr, g_lastMarkerRegionId, g_lastText));
 			if (_wantUndo)
 				Undo_OnStateChangeEx2(NULL, IsRegion(g_lastMarkerRegionId) ? __LOCALIZE("Edit region subtitle","sws_undo") : __LOCALIZE("Edit marker subtitle","sws_undo"), UNDO_STATE_MISCCFG, -1);
 			else
@@ -1045,7 +1045,7 @@ int NotesWnd::UpdateMkrRgnNameOrSub(int _type)
 							SetText(g_pRegionSubs.Get()->Get(i)->m_notes.Get());
 							return REQUEST_REFRESH;
 						}
-					g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(id, ""));
+					g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(nullptr, id, ""));
 					SetText("");
 				}
 				refreshType = REQUEST_REFRESH;
@@ -1310,7 +1310,7 @@ bool ImportSubRipFile(const char* _fn)
 
 						int id = MakeMarkerRegionId(num, true);
 						if (id > 0) // add the sub, no duplicate mgmt..
-							g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(id, notes.Get()));
+							g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(nullptr, id, notes.Get()));
 					}
 				}
 				else
@@ -1467,14 +1467,14 @@ static bool ProcessExtensionLine(const char *line, ProjectStateContext *ctx, boo
 	}
 	else if (!strcmp(lp.gettoken_str(0), "<S&M_SUBTITLE"))
 	{
-		if (GetMarkerRegionIndexFromId(NULL, lp.gettoken_int(1)) >= 0) // still exists?
+		if (GetMarkerRegionIndexFromId(p, lp.gettoken_int(1)) >= 0) // still exists?
 		{
 			WDL_FastString notes;
 			ExtensionConfigToString(&notes, ctx);
 
 			char buf[MAX_HELP_LENGTH] = "";
 			if (GetStringFromNotesChunk(&notes, buf, MAX_HELP_LENGTH))
-				g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(lp.gettoken_int(1), buf));
+				g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(p, lp.gettoken_int(1), buf));
 			return true;
 		}
 	}
@@ -1525,7 +1525,7 @@ static void SaveExtensionConfig(ProjectStateContext *ctx, bool isUndo, struct pr
 	{
 		if (SNM_RegionSubtitle* sub = g_pRegionSubs.Get()->Get(i))
 		{
-			if (sub->m_notes.GetLength() && GetMarkerRegionIndexFromId(NULL, sub->m_id) >= 0) // valid mkr/rgn?
+			if (sub->m_notes.GetLength() && GetMarkerRegionIndexFromId(sub->m_project, sub->m_id) >= 0) // valid mkr/rgn?
 			{
 				if (snprintfStrict(line, sizeof(line), "<S&M_SUBTITLE %d\n|", sub->m_id) > 0)
 					if (GetNotesChunkFromString(sub->m_notes.Get(), &formatedNotes, line))
@@ -1764,7 +1764,7 @@ bool NFDoSetSWSMarkerRegionSub(const char* mkrRgnSubIn, int mkrRgnIdxNumberIn)
 			// mkrRgn sub doesn't exist but marker/region is present in project, add new mkrRgn sub
 			if (mkrRgnExists)
 			{
-				g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(mkrRgnId, mkrRgnSubIn));
+				g_pRegionSubs.Get()->Add(new SNM_RegionSubtitle(nullptr, mkrRgnId, mkrRgnSubIn));
 				return true;
 			}
 			else // mkrRgn isn't present in project

--- a/SnM/SnM_Notes.h
+++ b/SnM/SnM_Notes.h
@@ -56,7 +56,7 @@ enum {
 class SNM_TrackNotes {
 public:
 	SNM_TrackNotes(ReaProject* project, const GUID* guid, const char* notes)
-		: m_project(project), m_guid(*guid), m_notes(notes)
+		: m_project{project}, m_guid{*guid}, m_notes{notes}
 	{
 		// The current project (project == NULL) doen't always match
 		// the notes' project when saving in SaveExtensionConfig [#1141]
@@ -75,8 +75,14 @@ public:
 
 class SNM_RegionSubtitle {
 public:
-	SNM_RegionSubtitle(int _id, const char* _notes) 
-		: m_id(_id),m_notes(_notes ? _notes : "") {}
+	SNM_RegionSubtitle(ReaProject* project, const int id, const char* notes)
+		: m_project{project}, m_id{id}, m_notes{notes}
+	{
+		if (!project) // see SNM_TrackNotes's constructor
+			m_project = EnumProjects(-1, nullptr, 0);
+	}
+
+	ReaProject *m_project;
 	int m_id;
 	WDL_FastString m_notes;
 };

--- a/SnM/SnM_Notes.h
+++ b/SnM/SnM_Notes.h
@@ -67,7 +67,11 @@ public:
 
 	MediaTrack* GetTrack() { return GuidToTrack(m_project, &m_guid); }
 	const GUID* GetGUID() { return &m_guid; }
+	const char *GetNotes() const { return m_notes.Get(); }
+	int GetNotesLength() const { return m_notes.GetLength(); }
+	void SetNotes(const char *notes) { m_notes.Set(notes); }
 
+private:
 	ReaProject *m_project;
 	GUID m_guid;
 	WDL_FastString m_notes;
@@ -82,6 +86,13 @@ public:
 			m_project = EnumProjects(-1, nullptr, 0);
 	}
 
+	int GetId() const { return m_id; }
+	bool IsValid() const { return GetMarkerRegionIndexFromId(m_project, m_id) >= 0; }
+	const char *GetNotes() const { return m_notes.Get(); }
+	int GetNotesLength() const { return m_notes.GetLength(); }
+	void SetNotes(const char *notes) { m_notes.Set(notes); }
+
+private:
 	ReaProject *m_project;
 	int m_id;
 	WDL_FastString m_notes;

--- a/SnM/SnM_Notes.h
+++ b/SnM/SnM_Notes.h
@@ -55,12 +55,20 @@ enum {
 
 class SNM_TrackNotes {
 public:
-	SNM_TrackNotes(const GUID* _guid, const char* _notes) {
-		if (_guid) memcpy(&m_guid, _guid, sizeof(GUID));
-		m_notes.Set(_notes ? _notes : "");
+	SNM_TrackNotes(ReaProject* project, const GUID* guid, const char* notes)
+		: m_project(project), m_guid(*guid), m_notes(notes)
+	{
+		// The current project (project == NULL) doen't always match
+		// the notes' project when saving in SaveExtensionConfig [#1141]
+
+		if (!project)
+			m_project = EnumProjects(-1, nullptr, 0);
 	}
-	MediaTrack* GetTrack() { return GuidToTrack(&m_guid); }
+
+	MediaTrack* GetTrack() { return GuidToTrack(m_project, &m_guid); }
 	const GUID* GetGUID() { return &m_guid; }
+
+	ReaProject *m_project;
 	GUID m_guid;
 	WDL_FastString m_notes;
 };

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -1124,6 +1124,7 @@ error:
 		IMPAPI(UpdateItemInProject);
 		IMPAPI(UpdateTimeline);
 		IMPAPI(ValidatePtr);
+		IMPAPI(ValidatePtr2); // v5.12
 
 		if (errcnt)
 		{

--- a/sws_util.h
+++ b/sws_util.h
@@ -225,10 +225,13 @@ void SetTrackVis(MediaTrack* tr, int vis); // &1 == mcp, &2 == tcp
 int AboutBoxInit(); // Not worth its own .h
 HWND GetTrackWnd();
 HWND GetRulerWnd();
-const GUID* TrackToGuid(MediaTrack* tr);
-MediaTrack* GuidToTrack(const GUID* guid);
+const GUID* TrackToGuid(ReaProject*, MediaTrack*);
+inline const GUID* TrackToGuid(MediaTrack* tr) { return TrackToGuid(nullptr, tr); }
+MediaTrack* GuidToTrack(ReaProject*, const GUID*);
+inline MediaTrack* GuidToTrack(const GUID* guid) { return GuidToTrack(nullptr, guid); }
 bool GuidsEqual(const GUID* g1, const GUID* g2);
-bool TrackMatchesGuid(MediaTrack* tr, const GUID* g);
+bool TrackMatchesGuid(ReaProject*, MediaTrack*, const GUID*);
+inline bool TrackMatchesGuid(MediaTrack* tr, const GUID* g) { return TrackMatchesGuid(nullptr, tr, g); }
 const char *stristr(const char* a, const char* b);
 
 // NF: fix / workaround for setting take start offset doesn't work if containing stretch markers


### PR DESCRIPTION

<details>
<summary>Reproduction script</summary>

```lua
local projs = {}

-- close all
--reaper.Main_OnCommand(40886, 0)

if not reaper.EnumProjects(2) then
  for i = 1, 6 do
    reaper.Main_OnCommand(40859, 0) -- new tab
    reaper.InsertTrackAtIndex(0, false)
    local track = reaper.GetTrack(nil, 0)
    reaper.SetTrackSelected(track, true)
    reaper.AddProjectMarker(0, false, 2, 0, 'marker', i)
    reaper.NF_SetSWSTrackNotes(track, i)
    reaper.NF_SetSWSMarkerRegionSub(i, 0)
  end
end

local i = 1
while true do
  local p = reaper.EnumProjects(i)
  i = i + 1
  if p then
    table.insert(projs, p)
  else
    break
  end
end

i = 0

function nextProject()
  local projId = (i%#projs)+1
  reaper.SelectProjectInstance(projs[projId])
  i = i + 1
  
  local track = reaper.GetTrack(nil, 0)
  local notes = reaper.NF_GetSWSTrackNotes(track)
  if notes ~= tostring(projId) then
    reaper.ShowConsoleMsg(string.format("TRACK BUG!!! (got '%s' expected '%s')\n", notes, projId))
    return
  end
  
  if i % 2 == 1 then
    local subs = reaper.NF_GetSWSMarkerRegionSub(0)
    if subs ~= tostring(projId) then
      reaper.ShowConsoleMsg(string.format("SUB BUG!!! (got '%s' expected '%s')\n", subs, projId))
      return
    end
  end

  if i < 100 then
    reaper.defer(nextProject)
  end
end

nextProject()
```
</details>