### PR TITLE
Fix a potential crash occuring after saving window screensets

### DIFF
--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -134,7 +134,8 @@ bool g_internalMkrRgnChange = false;
 // S&M windows lazy init: below's "" prevents registering the SWS' screenset callback
 // (use the S&M one instead - already registered via SNM_WindowManager::Init())
 NotesWnd::NotesWnd()
-	: SWS_DockWnd(IDD_SNM_NOTES, __LOCALIZE("Notes","sws_DLG_152"), "")
+	: SWS_DockWnd(IDD_SNM_NOTES, __LOCALIZE("Notes","sws_DLG_152"), ""),
+	m_edit{nullptr} // NotesWnd may be constructed without being open
 {
 	m_id.Set(NOTES_WND_ID);
 	// must call SWS_DockWnd::Init() to restore parameters and open the window if necessary


### PR DESCRIPTION
Saving a window screenset constructs and leaves `NotesWnd` in memory (via `SNM_WindowManager::SNM_ScreensetCallback`) but does not open it (`OnInitDlg` is not called).

When the track list is updated, through `CSurf_SetTrackListChange`, `NotesUpdateJob` thinks the Notes window is fully opened and asks it to update itself. `m_edit` is uninitialized at this point, leading to the reported crash.

The previous implementation was relying on `m_hwnd` being initialized to null by `SWS_DockWnd`'s constructor. This commit does the same for `m_edit`.

A better solution might be to delete unused/closed windows from memory, or to check whether the window is actually open before calling `NotesWnd::Update`.