### PR TITLE
"SWS/S&M: Pan active takes of selected items ...": update take waveform immediately

### DIFF
--- a/SnM/SnM_Item.cpp
+++ b/SnM/SnM_Item.cpp
@@ -1525,7 +1525,10 @@ void SetPan(COMMAND_T* _ct)
 		}
 	}
 	if (updated)
+	{
 		Undo_OnStateChangeEx2(NULL, SWS_CMD_SHORTNAME(_ct), UNDO_STATE_ALL, -1);
+		UpdateTimeline();
+	}	
 }
 
 void OpenMediaPathInExplorerFinder(COMMAND_T*)

--- a/Xenakios/ItemTakeCommands.cpp
+++ b/Xenakios/ItemTakeCommands.cpp
@@ -916,13 +916,13 @@ void DoPanTakesOfItemSymmetrically()
 			}
 		}
 	}
+	UpdateTimeline();
 }
 
 void DoPanTakesSymmetricallyWithUndo(COMMAND_T* ct)
 {
 	DoPanTakesOfItemSymmetrically();
 	Undo_OnStateChangeEx(SWS_CMD_SHORTNAME(ct),4,-1);
-	UpdateTimeline();
 }
 
 
@@ -933,7 +933,6 @@ void DoImplodeTakesSetPlaySetSymPans(COMMAND_T* ct)
 	DoSetAllTakesPlay();
 	DoPanTakesOfItemSymmetrically();
 	Undo_EndBlock(SWS_CMD_SHORTNAME(ct),0);
-	//UpdateTimeline();
 }
 
 double g_lastTailLen;


### PR DESCRIPTION
same for "Xenakios/SWS: Implode items to takes and pan symmetrically"
closes #1369