### PR TITLE
Enable UTF-8 in the property interpolator window

### DIFF
--- a/Xenakios/PropertyInterpolator.cpp
+++ b/Xenakios/PropertyInterpolator.cpp
@@ -648,6 +648,9 @@ WDL_DLGRET ItemInterpDlgProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPar
 
 			HWND hList = GetDlgItem(hwnd,IDC_IIACTPARLIST);
 			ListView_SetExtendedListViewStyleEx(hList, LVS_EX_FULLROWSELECT, LVS_EX_FULLROWSELECT);
+#ifdef _WIN32
+			WDL_UTF8_HookListView(hList);
+#endif
 			LVCOLUMN col;
 			col.mask=LVCF_TEXT|LVCF_WIDTH;
 			col.cx=15;


### PR DESCRIPTION
Item property interpolator:
+Fix the enabled indicator being wrongly displayed on Windows

(Original report at https://forum.cockos.com/showthread.php?p=2275857)