### PR TITLE
fix BR_EnvSetProperties() erasing <EXT> envelope subchunk

### DIFF
--- a/Breeder/BR_EnvelopeUtil.cpp
+++ b/Breeder/BR_EnvelopeUtil.cpp
@@ -1887,6 +1887,21 @@ bool BR_Envelope::FillProperties () const
 				{
 					m_properties.automationItems.push_back(WDL_FastString(token));
 				}
+				else if (strstr(token, "<EXT"))
+				{
+					int subchunks = 0; // <BIN, https://github.com/reaper-oss/sws/pull/1387#issuecomment-705651041
+
+					do
+					{
+						if (*token == '<')
+							++subchunks;
+						else if (!strcmp(token, ">"))
+							--subchunks;
+					
+						AppendLine(m_properties.EXT, token);
+						token = strtok(NULL, "\n");
+					} while (token && subchunks > 0);
+				}
 
 				token = strtok(NULL, "\n");
 			}
@@ -1918,6 +1933,8 @@ WDL_FastString BR_Envelope::GetProperties ()
 			properties.Append("\n");
 		}
 		if (m_properties.faderMode != 0) properties.AppendFormatted(256, "VOLTYPE %d\n", 1);
+		if (m_properties.EXT.GetLength())
+			properties.Append(m_properties.EXT.Get());
 		return properties;
 	}
 	else

--- a/Breeder/BR_EnvelopeUtil.h
+++ b/Breeder/BR_EnvelopeUtil.h
@@ -178,6 +178,7 @@ private:
 		int armed;
 		int shape, shapeUnknown1, shapeUnknown2;
 		int faderMode;
+		WDL_FastString EXT; // extension-specific persistent data, since REAPER v5.975
 		BR_EnvType type;
 		double minValue, maxValue, centerValue;
 		int paramId, fxId;


### PR DESCRIPTION
fixes #1385 
It seems to work so far. :)

With the test script from #1385 it seemingly only failed for the first run because on the consecutive runs  the envelope properties didn't change anymore (because the properties were already set so from the first run) so  the below was skipped in `BR_Envelope::Commit()` and so the `EXT` subchunk wasn't erased anymore.
https://github.com/reaper-oss/sws/blob/master/Breeder/BR_EnvelopeUtil.cpp#L1468-L1477
