### PR TITLE
Per-Monitor v2 DPI awareness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(sws SHARED
   sws_wnd.cpp
   Utility/Base64.cpp
   Utility/envelope.cpp
+  Utility/hidpi.cpp
   Zoom.cpp
 )
 

--- a/Utility/hidpi.cpp
+++ b/Utility/hidpi.cpp
@@ -1,0 +1,66 @@
+/******************************************************************************
+/ hidpi.cpp
+/
+/ Copyright (c) 2020 Christian Fillion
+/ https://cfillion.ca
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#include "stdafx.h"
+
+#ifdef _WIN32
+#include <ShellScalingApi.h> // GetDpiForMonitor
+#include "win32-import.h"
+#endif // _WIN32
+
+unsigned int hidpi::GetDpiForPoint(const POINT &point)
+{
+#ifdef _WIN32
+  // not linking against shcore.dll for compatibility with Windows older than 8.1
+  static win32::import<decltype(GetDpiForMonitor)> _GetDpiForMonitor
+    {"SHCore.dll", "GetDpiForMonitor"};
+
+  // using MONITOR_DEFAULTTONEAREST to match GetMonitorRectFromPoint from BR_Util
+  HMONITOR monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
+
+  if (_GetDpiForMonitor && monitor) {
+    unsigned int dpiX, dpiY;
+    if (S_OK == _GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY))
+      return (dpiX * 256) / 96; // same scaling as WDL_WndSizer::calc_dpi
+    else
+      return 256;
+  }
+#endif
+
+  return 0;
+}
+
+unsigned int hidpi::GetDpiForWindow(HWND window)
+{
+  // returns 0 if Per-Monitor v2 DPI awareness is disabled for the thread
+  return WDL_WndSizer::calc_dpi(window);
+}
+
+bool hidpi::IsDifferentDpi(const unsigned int a, const unsigned int b)
+{
+  return a && b && a != b;
+}

--- a/Utility/hidpi.h
+++ b/Utility/hidpi.h
@@ -1,0 +1,34 @@
+/******************************************************************************
+/ hidpi.h
+/
+/ Copyright (c) 2020 Christian Fillion
+/ https://cfillion.ca
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#pragma once
+
+namespace hidpi {
+  unsigned int GetDpiForPoint(const POINT &);
+  unsigned int GetDpiForWindow(HWND);
+  bool IsDifferentDpi(unsigned int originDpi, unsigned int targetDpi);
+}

--- a/Utility/win32-import.h
+++ b/Utility/win32-import.h
@@ -1,0 +1,61 @@
+/******************************************************************************
+/ win32-import.h
+/
+/ Copyright (c) 2020 Christian Fillion
+/ https://cfillion.ca
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#pragma once
+
+#ifndef _WIN32
+#  error This file should not be included on non-Windows systems.
+#endif
+
+namespace win32 {
+  template<typename Proc, typename = std::enable_if_t<std::is_function_v<Proc>>>
+  class import {
+  public:
+    import(const char *dll, const char *func)
+    {
+      if (m_lib = LoadLibrary(dll))
+        m_proc = reinterpret_cast<Proc *>(GetProcAddress(m_lib, func));
+      else
+        m_proc = nullptr;
+    }
+
+    ~import()
+    {
+      if (m_lib)
+        FreeLibrary(m_lib);
+    }
+
+    operator bool() const { return m_proc != nullptr; }
+
+    template<typename... Args>
+    auto operator()(Args&&... args) const { return m_proc(std::forward<Args>(args)...); }
+
+  private:
+    HINSTANCE m_lib;
+    Proc *m_proc;
+  };
+}

--- a/stdafx.h
+++ b/stdafx.h
@@ -113,4 +113,5 @@
 #include "Padre/padreMidiItemProcBase.h"
 #include "Breeder/BR_Timer.h"
 #include "Utility/envelope.hpp"
+#include "Utility/hidpi.h"
 #include "Utility/win32-utf8.h"

--- a/sws_util.cpp
+++ b/sws_util.cpp
@@ -43,40 +43,6 @@ MTRand g_MTRand;
 const GUID GUID_NULL = { 0, 0, 0, "\0\0\0\0\0\0\0" };
 #endif
 
-BOOL IsCommCtrlVersion6()
-{
-#ifndef _WIN32
-	return true;
-#else
-    static BOOL isCommCtrlVersion6 = -1;
-    if (isCommCtrlVersion6 != -1)
-        return isCommCtrlVersion6;
-    
-    //The default value
-    isCommCtrlVersion6 = FALSE;
-    
-    HINSTANCE commCtrlDll = LoadLibrary("comctl32.dll");
-    if (commCtrlDll)
-    {
-        DLLGETVERSIONPROC pDllGetVersion;
-        pDllGetVersion = (DLLGETVERSIONPROC)GetProcAddress(commCtrlDll, "DllGetVersion");
-        
-        if (pDllGetVersion)
-        {
-            DLLVERSIONINFO dvi = {0};
-            dvi.cbSize = sizeof(DLLVERSIONINFO);
-            (*pDllGetVersion)(&dvi);
-            
-            isCommCtrlVersion6 = (dvi.dwMajorVersion == 6);
-        }
-        
-        FreeLibrary(commCtrlDll);
-    }
-    
-    return isCommCtrlVersion6;
-#endif
-}
-
 void SaveWindowPos(HWND hwnd, const char* cKey)
 {
 	// Remember the dialog position

--- a/sws_util.h
+++ b/sws_util.h
@@ -209,7 +209,6 @@ int IsSwsAction(const char* _actionName);
 HMENU SWSCreateMenuFromCommandTable(COMMAND_T pCommands[], HMENU hMenu = NULL, int* iIndex = NULL);;
 
 // Utility functions, sws_util.cpp
-BOOL IsCommCtrlVersion6();
 void SaveWindowPos(HWND hwnd, const char* cKey);
 void RestoreWindowPos(HWND hwnd, const char* cKey, bool bRestoreSize = true);
 void SetWindowPosAtMouse(HWND hwnd);


### PR DESCRIPTION
**Note:** This PR should be merged before #1368 (which updates WDL to a newer commit).

Adds support for Windows 10 Creators Update (1703)'s new Per-Monitor v2 DPI awareness mode (REAPER v6.04+ only).

Fixes #1264.