### PR TITLE
deprecate "Xenakios/SWS: Insert media file from clipboard"

### DIFF
--- a/Xenakios/CommandRegistering.cpp
+++ b/Xenakios/CommandRegistering.cpp
@@ -201,7 +201,7 @@ COMMAND_T g_XenCommandTable[] =
 	{ { DEFACCEL, "Xenakios/SWS: Render item to new take with tail..." }, "XENAKIOS_RENDERITEMNEWTAKEWITHTAIL", DoRenderItemsWithTail,NULL, },
 	{ { DEFACCEL, "Xenakios/SWS: Open associated REAPER project of item" }, "XENAKIOS_OPENASSOCIATED_RPP", DoOpenAssociatedRPP,	NULL, },
 	{ { DEFACCEL, "Xenakios/SWS: Take mixer..." }, "XENAKIOS_SHOWTAKEMIXERDLG", DoShowTakeMixerDlg,	NULL, },
-	{ { DEFACCEL, "Xenakios/SWS: Insert media file from clipboard" }, "XENAKIOS_INSERTMEDIAFROMCLIPBOARD", DoInsertMediaFromClipBoard,NULL, },
+	{ { DEFACCEL, "Xenakios/SWS: Insert media file from clipboard (deprecated)" }, "XENAKIOS_INSERTMEDIAFROMCLIPBOARD", DoInsertMediaFromClipBoard,NULL, },
 
 	{ { DEFACCEL, "Xenakios/SWS: Erase from item (time based)" }, "XENAKIOS_HOLDKEYTEST1", DoHoldKeyTest1,NULL, },
 	{ { DEFACCEL, "Xenakios/SWS: Erase from item (beat based)" }, "XENAKIOS_HOLDKEYTEST2", DoHoldKeyTest2,NULL, },

--- a/Xenakios/ExoticCommands.cpp
+++ b/Xenakios/ExoticCommands.cpp
@@ -1092,7 +1092,7 @@ void DoInsertMediaFromClipBoard(COMMAND_T*)
 		CloseClipboard();
 	}
 #else
-	MessageBox(g_hwndParent, __LOCALIZE("Not supported on OSX, sorry!", "sws_mbox"), __LOCALIZE("SWS - Error", "sws_mbox"), MB_OK);
+	MessageBox(g_hwndParent, __LOCALIZE("Not supported on OSX and Linux, sorry!", "sws_mbox"), __LOCALIZE("SWS - Error", "sws_mbox"), MB_OK);
 #endif
 }
 

--- a/Xenakios/ItemTakeCommands.cpp
+++ b/Xenakios/ItemTakeCommands.cpp
@@ -498,7 +498,7 @@ bool DoLaunchExternalTool(const char *ExeFilename)
 	free(cFile);
 	return bRet;
 #else
-	MessageBox(g_hwndParent, __LOCALIZE("Not supported on OSX, sorry!", "sws_mbox"), __LOCALIZE("SWS - Error", "sws_mbox"), MB_OK);
+	MessageBox(g_hwndParent, __LOCALIZE("Not supported on OSX and Linux, sorry!", "sws_mbox"), __LOCALIZE("SWS - Error", "sws_mbox"), MB_OK);
 	return false;
 #endif
 }

--- a/Xenakios/MediaDialog.cpp
+++ b/Xenakios/MediaDialog.cpp
@@ -628,7 +628,7 @@ void SendSelectedProjFolFilesToRecycleBin()
 	}
 	UpdateProjFolderList(GetDlgItem(g_hMediaDlg,IDC_PROJFOLMEDLIST), IsDlgButtonChecked(g_hMediaDlg,IDC_SHOWUNUS) == BST_CHECKED);
 #else
-	MessageBox(g_hwndParent, __LOCALIZE("Not supported on OSX, sorry!", "sws_mbox"), __LOCALIZE("SWS - Error", "sws_mbox"), MB_OK);
+	MessageBox(g_hwndParent, __LOCALIZE("Not supported on OSX and Linux, sorry!", "sws_mbox"), __LOCALIZE("SWS - Error", "sws_mbox"), MB_OK);
 #endif
 }
 


### PR DESCRIPTION
REAPER v6.13+ supports pasting media files from clipboard natively (and this action only works on Windows OS)