### PR TITLE
Cycle action: make prevent UI refresh optional

### DIFF
--- a/SnM/SnM_Cyclactions.h
+++ b/SnM/SnM_Cyclactions.h
@@ -113,6 +113,7 @@ protected:
 
 	WDL_VirtualComboBox m_cbSection;
 	WDL_VirtualIconButton m_btnUndo;
+	WDL_VirtualIconButton m_btnPreventUIRefresh;
 	WDL_VirtualStaticText m_txtSection;
 	SNM_ToolbarButton m_btnApply, m_btnCancel, m_btnImpExp, m_btnActionList;
 	SNM_TwoTinyButtons m_tinyLRbtns;


### PR DESCRIPTION
Some actions require a UI refresh to update REAPER's internal state.

Fixes #1395