### PR TITLE
Always immediately refresh offscreen items when running actions

### DIFF
--- a/SnM/SnM_Item.cpp
+++ b/SnM/SnM_Item.cpp
@@ -1418,12 +1418,10 @@ void ToggleOffscreenSelItems(COMMAND_T* _ct)
 {
 	int dir = (int)_ct->user;
 
-	// force refresh if not auto
-	if (!g_SNM_ToolbarRefresh) 
-		RefreshOffscreenItems();
+	RefreshOffscreenItems();
 
 	PreventUIRefresh(1);
-	bool updated = (ToggleOffscreenSelItems(dir));
+	bool updated = ToggleOffscreenSelItems(dir);
 	PreventUIRefresh(-1);
   
 	if (updated)
@@ -1456,9 +1454,7 @@ int HasOffscreenSelItems(COMMAND_T* _ct)
 // deselects offscreen items
 void UnselectOffscreenItems(COMMAND_T* _ct)
 {
-	// force refresh if not auto
-	if (!g_SNM_ToolbarRefresh) 
-		RefreshOffscreenItems();
+	RefreshOffscreenItems();
 
 	bool updated = false;
 	PreventUIRefresh(1);


### PR DESCRIPTION
- SWS/S&M: Unselect offscreen items
- SWS/S&M: Toolbar - Toggle offscreen item selection

It previously required "SWS/S&M: Toggle toolbars auto refresh enable" to be disabled for the offscreen items to be refreshed synchronously.

Otherwise the refresh would be done through the global toolbar refresh timer. This made the above actions potentially use out-of-date data when used as part of a custom action or a script.

Fixes #1325.