### PR TITLE
Fix a buffer overflow in GetUsedNamedNotes

### DIFF
--- a/Breeder/BR_MidiUtil.cpp
+++ b/Breeder/BR_MidiUtil.cpp
@@ -705,15 +705,15 @@ vector<int> GetUsedNamedNotes (HWND midiEditor, MediaItem_Take* take, bool used,
 	/* Not really reliable, user could have changed default draw channel  *
 	*  but without resetting note view settings, view won't get updated   */
 
-	vector<int> allNotesStatus(127, 0);
-	MediaItem_Take* midiTake = (midiEditor) ? MIDIEditor_GetTake(midiEditor) : take;
+	vector<bool> allNotesStatus(128, false);
+	MediaItem_Take* midiTake = midiEditor ? MIDIEditor_GetTake(midiEditor) : take;
 
 	if (named)
 	{
 		MediaTrack* track = GetMediaItemTake_Track(midiTake);
-		for (int i = 0; i < 128; ++i)
-			if (GetTrackMIDINoteNameEx(NULL, track, i, channelForNames))
-				allNotesStatus[i] = 1;
+		for (size_t i = 0; i < allNotesStatus.size(); ++i)
+			if (GetTrackMIDINoteNameEx(NULL, track, static_cast<int>(i), channelForNames))
+				allNotesStatus[i] = true;
 	}
 
 	if (used)
@@ -725,16 +725,16 @@ vector<int> GetUsedNamedNotes (HWND midiEditor, MediaItem_Take* take, bool used,
 			{
 				int pitch;
 				MIDI_GetNote(midiTake, i, NULL, NULL, NULL, NULL, NULL, &pitch, NULL);
-				allNotesStatus[pitch] = 1;
+				allNotesStatus[pitch] = true;
 			}
 		}
 	}
 
 	vector<int> notes;
-	notes.reserve(128);
-	for (int i = 0; i < 128; ++i)
+	notes.reserve(allNotesStatus.size());
+	for (size_t i = 0; i < allNotesStatus.size(); ++i)
 	{
-		if (allNotesStatus[i] == 1)
+		if (allNotesStatus[i])
 			notes.push_back(i);
 	}
 


### PR DESCRIPTION
The size of `allNotesStatus` was off by one. `GetUsedNamedNotes` is called when the BR mouse context detection code is used in the all or midi editor modes. It would cause memory corruption, crashes or dragons.