### PR TITLE
Preserve R6 CC shapes and don't duplicate subsequent events

### DIFF
--- a/Fingers/RprMidiEvent.cpp
+++ b/Fingers/RprMidiEvent.cpp
@@ -118,6 +118,11 @@ const std::vector<unsigned char>& RprMidiEvent::getMidiMessage()
     return mMidiMessage;
 }
 
+void RprMidiEvent::addPropertyNode(const RprNode *node)
+{
+    mPropertyLines.push_back(node->getValue());
+}
+
 unsigned char RprMidiEvent::getValue1() const
 {
     return mMidiMessage[1];
@@ -233,6 +238,10 @@ RprNode *RprMidiEvent::toReaper()
             oss << " " << mQuantizeOffset;
         }
     }
+
+    for(const std::string &propertyLine : mPropertyLines)
+        oss << '\n' << propertyLine;
+
     std::auto_ptr<RprNode> node(new RprPropertyNode(oss.str()));
     return node.release();
 }

--- a/Fingers/RprMidiEvent.h
+++ b/Fingers/RprMidiEvent.h
@@ -41,7 +41,7 @@ public:
     void setMidiMessage(const std::vector<unsigned char> message);
     const std::vector<unsigned char>& getMidiMessage();
 
-    const std::string& getExtendedData() const;
+    void addPropertyNode(const RprNode *);
 
     virtual RprNode *toReaper();
 
@@ -57,10 +57,10 @@ public:
     };
 
 private:
-
     std::vector<unsigned char> mMidiMessage;
-    int mQuantizeOffset;
+    std::list<std::string> mPropertyLines;
 
+    int mQuantizeOffset;
     int mDelta;
     int mOffset;
     bool mMuted;

--- a/Fingers/RprNode.cpp
+++ b/Fingers/RprNode.cpp
@@ -23,7 +23,7 @@ RprNode* RprPropertyNode::getChild(int index)
     return NULL;
 }
 
-const std::string& RprNode::getValue()
+const std::string& RprNode::getValue() const
 {
     return mValue;
 }

--- a/Fingers/RprNode.h
+++ b/Fingers/RprNode.h
@@ -3,7 +3,7 @@
 
 class RprNode {
 public:
-    const std::string &getValue();
+    const std::string &getValue() const;
 
     RprNode *getParent();
     void setParent(RprNode *parent);


### PR DESCRIPTION
Changes RprMidiTake to preserve R6+ CC shapes when constructed in write mode. Fixes all MIDI events following a CC shape "event" (ENV line) being duplicated beyond the end of the item.

This was affecting some FNG actions (including the Groove tool).

Fixes #1307
Originally reported at https://forum.cockos.com/showpost.php?p=2242119.