### PR TITLE
Keep notation settings when applying a groove

### DIFF
--- a/Fingers/RprMidiEvent.cpp
+++ b/Fingers/RprMidiEvent.cpp
@@ -54,6 +54,9 @@ int RprMidiEvent::getOffset() const
 void RprMidiEvent::setOffset(int offset)
 {
     mOffset = offset;
+
+    for(RprMidiEvent *attachedEvent : mAttachedEvents)
+        attachedEvent->setOffset(offset);
 }
 
 RprMidiEvent::RprMidiException::RprMidiException(const char *message) : mMessage(message)
@@ -116,6 +119,23 @@ void RprMidiEvent::setMidiMessage(const std::vector<unsigned char> message)
 const std::vector<unsigned char>& RprMidiEvent::getMidiMessage()
 {
     return mMidiMessage;
+}
+
+bool RprMidiEvent::isAttachableTo(const RprMidiEvent *targetEvent) const
+{
+    // Notations Events are Text Events occuring right after a Note On.
+    // Normal Text Events occur before any Note On at the same time position.
+    // Therefore, this only matches Notation Events attached to a Note On.
+
+    return
+        getOffset() == targetEvent->getOffset() && // same absolute position
+        getMessageType() == NotationEvent &&
+        targetEvent->getMessageType() == RprMidiEvent::NoteOn;
+}
+
+void RprMidiEvent::addAttachedEvent(RprMidiEvent *attachedEvent)
+{
+    mAttachedEvents.push_back(attachedEvent);
 }
 
 unsigned char RprMidiEvent::getValue1() const

--- a/Fingers/RprMidiEvent.h
+++ b/Fingers/RprMidiEvent.h
@@ -8,7 +8,7 @@ class RprNode;
 class RprMidiEvent {
 public:
     enum MessageType { NoteOff, NoteOn, KeyPressure, CC, ProgramChange, ChannelPressure, PitchBend,
-                       Sysex, TextEvent, Unknown };
+                       Sysex, TextEvent, NotationEvent = TextEvent, Unknown };
     RprMidiEvent();
 
     bool isSelected() const;
@@ -41,7 +41,8 @@ public:
     void setMidiMessage(const std::vector<unsigned char> message);
     const std::vector<unsigned char>& getMidiMessage();
 
-    const std::string& getExtendedData() const;
+    bool isAttachableTo(const RprMidiEvent *) const;
+    void addAttachedEvent(RprMidiEvent *);
 
     virtual RprNode *toReaper();
 
@@ -57,10 +58,10 @@ public:
     };
 
 private:
-
     std::vector<unsigned char> mMidiMessage;
-    int mQuantizeOffset;
+    std::list<RprMidiEvent *> mAttachedEvents;
 
+    int mQuantizeOffset;
     int mDelta;
     int mOffset;
     bool mMuted;

--- a/Fingers/RprMidiTake.cpp
+++ b/Fingers/RprMidiTake.cpp
@@ -566,6 +566,10 @@ static void getMidiEvents(RprNode *midiNode, RprMidiEvents &midiEvents)
         RprMidiEvent *midiEvent = creator.collectEvent();
         offset += midiEvent->getDelta();
         midiEvent->setOffset(offset);
+
+        if(!midiEvents.empty() && midiEvent->isAttachableTo(midiEvents.back()))
+            midiEvents.back()->addAttachedEvent(midiEvent);
+
         midiEvents.push_back(midiEvent);
     }
 }


### PR DESCRIPTION
Note notation settings (articulations, accidentals...) were detached (effectively lost) from the note after applying a groove. The offset of the Notation Event message was not updated to match the new position of the Note On.