### PR TITLE
Fix FNG MIDI actions skipping too much in REAPER v6

### DIFF
--- a/Fingers/RprMidiTake.cpp
+++ b/Fingers/RprMidiTake.cpp
@@ -463,9 +463,8 @@ RprMidiCC::~RprMidiCC()
 
 static int getQNValue(RprNode *midiNode)
 {
-    const std::string &qnString = midiNode->getChild(0)->getValue();
-    StringVector tokens(qnString);
-    return ::atoi(tokens.at(2));
+    const std::string &hasdata = midiNode->findChildByToken("HASDATA")->getValue();
+    return ::atoi(StringVector{hasdata}.at(2));
 }
 
 static bool sortMidiBase(const RprMidiEvent *lhs, const RprMidiEvent *rhs)
@@ -1085,6 +1084,6 @@ bool RprMidiTake::hasEventType(RprMidiEvent::MessageType messageType)
 
 std::string RprMidiTake::poolGuid() const
 {
-    const std::string &pooledevts = getMidiSourceNode()->getChild(1)->getValue();
+    const std::string &pooledevts = getMidiSourceNode()->findChildByToken("POOLEDEVTS")->getValue();
     return StringVector{pooledevts}.at(1);
 }

--- a/Fingers/RprNode.cpp
+++ b/Fingers/RprNode.cpp
@@ -3,24 +3,11 @@
 
 #include "RprNode.h"
 
-int RprPropertyNode::childCount()
-{
-    return 0;
-}
-
-void RprPropertyNode::addChild(RprNode *node)
-{}
-
 void RprPropertyNode::toReaper(std::ostringstream &oss, int indent)
 {
     std::string strIndent(indent, ' ');
     oss << strIndent.c_str() << getValue().c_str();
     oss << std::endl;
-}
-
-RprNode* RprPropertyNode::getChild(int index)
-{
-    return NULL;
 }
 
 const std::string& RprNode::getValue() const
@@ -57,7 +44,7 @@ RprParentNode::RprParentNode(const char *value)
     setValue(value);
 }
 
-RprNode *RprParentNode::getChild(int index)
+RprNode *RprParentNode::getChild(int index) const
 {
     return mChildren.at(index);
 }
@@ -74,7 +61,7 @@ void RprParentNode::addChild(RprNode *node, int index)
     mChildren.insert(mChildren.begin() + index, node);
 }
 
-int RprParentNode::childCount()
+int RprParentNode::childCount() const
 {
     return (int)mChildren.size();
 }
@@ -131,9 +118,6 @@ RprPropertyNode::RprPropertyNode(const std::string &value)
 {
     setValue(value);
 }
-
-void RprPropertyNode::removeChild(int index)
-{}
 
 RprNode *RprParentNode::createItemStateTree(const char *itemState)
 {

--- a/Fingers/RprNode.cpp
+++ b/Fingers/RprNode.cpp
@@ -49,6 +49,17 @@ RprNode *RprParentNode::getChild(int index) const
     return mChildren.at(index);
 }
 
+RprNode *RprParentNode::findChildByToken(const std::string &token) const
+{
+    for(RprNode *child : mChildren) {
+        const std::string &value = child->getValue();
+        if(value.rfind(token, 0) == 0 && value[token.size()] == '\x20')
+            return child;
+    }
+
+    return nullptr;
+}
+
 void RprParentNode::addChild(RprNode *node)
 {
     node->setParent(this);

--- a/Fingers/RprNode.h
+++ b/Fingers/RprNode.h
@@ -13,6 +13,7 @@ public:
 
     virtual int childCount() const = 0;
     virtual RprNode *getChild(int index) const = 0;
+    virtual RprNode *findChildByToken(const std::string &) const = 0;
     virtual void addChild(RprNode *node) = 0;
     virtual void addChild(RprNode *node, int index) {}
     virtual void removeChild(int index) = 0;
@@ -32,6 +33,7 @@ public:
 
     int childCount() const override { return 0; }
     RprNode *getChild(int index) const override { return nullptr; }
+    RprNode *findChildByToken(const std::string &) const override { return nullptr; }
     void addChild(RprNode *node) override {}
     void removeChild(int index) override {}
 
@@ -49,6 +51,7 @@ public:
 
     int childCount() const override;
     RprNode *getChild(int index) const override;
+    RprNode *findChildByToken(const std::string &) const override;
     void addChild(RprNode *node) override;
     void addChild(RprNode *node, int index) override;
     void removeChild(int index) override;

--- a/Fingers/RprNode.h
+++ b/Fingers/RprNode.h
@@ -3,7 +3,7 @@
 
 class RprNode {
 public:
-    const std::string &getValue() const;
+    virtual ~RprNode() {}
 
     RprNode *getParent();
     void setParent(RprNode *parent);
@@ -11,14 +11,14 @@ public:
     std::string toReaper();
     virtual void toReaper(std::ostringstream &oss, int indent) = 0;
 
-    virtual int childCount() = 0;
-    virtual RprNode *getChild(int index) = 0;
+    virtual int childCount() const = 0;
+    virtual RprNode *getChild(int index) const = 0;
     virtual void addChild(RprNode *node) = 0;
     virtual void addChild(RprNode *node, int index) {}
     virtual void removeChild(int index) = 0;
-    virtual ~RprNode() {}
 
     void setValue(const std::string &value);
+    const std::string &getValue() const;
 
 private:
     std::string mValue;
@@ -28,13 +28,15 @@ private:
 class RprPropertyNode : public RprNode {
 public:
     RprPropertyNode(const std::string &value);
-    int childCount();
-    RprNode *getChild(int index);
-    void addChild(RprNode *node);
-    void removeChild(int index);
     ~RprPropertyNode() {}
+
+    int childCount() const override { return 0; }
+    RprNode *getChild(int index) const override { return nullptr; }
+    void addChild(RprNode *node) override {}
+    void removeChild(int index) override {}
+
 private:
-    void toReaper(std::ostringstream &oss, int indent);
+    void toReaper(std::ostringstream &oss, int indent) override;
 };
 
 class RprParentNode : public RprNode {
@@ -42,18 +44,18 @@ public:
     static RprNode *createItemStateTree(const char *itemState);
 
     RprParentNode(const char *value);
-    int childCount();
-    RprNode *getChild(int index);
-    void addChild(RprNode *node);
-    void addChild(RprNode *node, int index);
-    void removeChild(int index);
+    RprParentNode(const RprNode&) = delete;
     ~RprParentNode();
-private:
-    RprParentNode();
-    RprParentNode(const RprNode&);
-    RprParentNode& operator=(const RprNode&);
 
-    void toReaper(std::ostringstream &oss, int indent);
+    int childCount() const override;
+    RprNode *getChild(int index) const override;
+    void addChild(RprNode *node) override;
+    void addChild(RprNode *node, int index) override;
+    void removeChild(int index) override;
+
+private:
+    RprParentNode& operator=(const RprNode&);
+    void toReaper(std::ostringstream &oss, int indent) override;
 
     std::vector<RprNode *> mChildren;
 };


### PR DESCRIPTION
SWS/FNG: Increase/Decrease selected MIDI items velocity by x
SWS/FNG: Transpose selected MIDI items...

Regression from 30bd5b8a8edef9d64c2841913e812ee015f08afd, reported at https://forum.cockos.com/showpost.php?p=2354538.

This also hardens the old `getQNValue` with the same fix, just in case it also moves in future RPPs.