### PR TITLE
Allow start and/or end to be ignored in TrimItem_UseNativeTrimActions

### DIFF
--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -1078,17 +1078,25 @@ bool TrimItem_UseNativeTrimActions(MediaItem* item, double start, double end, bo
 	if (!item)
 		return false;
 
+	// Fetch the current start and length for the item
+	double itemPos = GetMediaItemInfo_Value(item, "D_POSITION");
+	double itemLen = GetMediaItemInfo_Value(item, "D_LENGTH");
+
+	// If start is negative then keep the current start position
+	if (start < 0)
+		start = itemPos;
+
+	// If end is negative then keep the current end position
+	if (end < 0)
+		end = itemPos + itemLen;
+
 	if (start > end)
 		swap(start, end);
-	if (start < 0)
-		start = 0;
 
 	double newLen = end - start;
 	if (newLen <= 0)
 		return false;
 
-	double itemPos = GetMediaItemInfo_Value(item, "D_POSITION");
-	double itemLen = GetMediaItemInfo_Value(item, "D_LENGTH");
 
 	if (force || start != itemPos || newLen != itemLen) {
 		// NF: ugly code ahead for fixing


### PR DESCRIPTION
If either the 'start' or 'end' parameters are less than zero the original start/end value is kept.

Co-authored-by: Christian Fillion <cfillion@users.noreply.github.com>

closes #1114