### PR TITLE
Fix data loss bugs with many/large cycle actions

### DIFF
--- a/SnM/SnM_Cyclactions.cpp
+++ b/SnM/SnM_Cyclactions.cpp
@@ -1219,9 +1219,7 @@ void SaveCyclactions(WDL_PtrList<Cyclaction>* _cyclactions = NULL, int _section 
 			iniSection << "Nb_Actions=" << maxId << '\0';
 			iniSection << "Version=" << CA_VERSION << '\0';
 
-			const char *iniSectionName = GetCAIniSection(sec);
-			WritePrivateProfileStruct(iniSectionName, nullptr, nullptr, 0, _iniFn); // flush section
-			WritePrivateProfileSection(iniSectionName, iniSection.str().c_str(), _iniFn);
+			SaveIniSection(GetCAIniSection(sec), iniSection.str(), _iniFn);
 		}
 	}
 }

--- a/SnM/SnM_Cyclactions.cpp
+++ b/SnM/SnM_Cyclactions.cpp
@@ -1180,7 +1180,7 @@ void SaveCyclactions(WDL_PtrList<Cyclaction>* _cyclactions = NULL, int _section 
 		{
 			WDL_PtrList_DeleteOnDestroy<int> freeCycleIds;
 			std::ostringstream iniSection;
-			iniSection << "; Do not tweak by hand! Use the Cycle Action editor instead" << '\0'; // no localization for ini files..
+			iniSection << "; Do not tweak by hand! Use the Cycle Action editor instead ===" << '\0'; // no localization for ini files..
 
 			// prepare ids "compression" (i.e. will re-assign ids of new actions for the next load)
 			for (int j=0; j < _cyclactions[sec].GetSize(); j++)

--- a/SnM/SnM_Util.cpp
+++ b/SnM/SnM_Util.cpp
@@ -521,20 +521,13 @@ void ExtensionConfigToString(WDL_FastString* _str, ProjectStateContext* _ctx)
 // write a full ini file section in one go
 // "the data in the buffer pointed to by the lpString parameter consists 
 // of one or more null-terminated strings, followed by a final null character"
-void SaveIniSection(const char* _iniSectionName, WDL_FastString* _iniSection, const char* _iniFn)
+bool SaveIniSection(const char* _iniSectionName, const std::string& _iniSection, const char* _iniFn)
 {
-	if (_iniSectionName && _iniSection && _iniFn)
-	{
-		if (char* buf = (char*)calloc(_iniSection->GetLength()+1, sizeof(char)))  // +1 for dbl-null termination
-		{
-			memcpy(buf, _iniSection->Get(), _iniSection->GetLength());
-			for (int j=0; j < _iniSection->GetLength(); j++)
-				if (buf[j] == '\n') buf[j] = '\0';
-			WritePrivateProfileStruct(_iniSectionName, NULL, NULL, 0, _iniFn); // flush section
-			WritePrivateProfileSection(_iniSectionName, buf, _iniFn);
-			free(buf);
-		}
-	}
+	if (!_iniSectionName || !_iniFn)
+		return false;
+
+	WritePrivateProfileStruct(_iniSectionName, nullptr, nullptr, 0, _iniFn); // flush section
+	return WritePrivateProfileSection(_iniSectionName, _iniSection.c_str(), _iniFn);
 }
 
 void UpdatePrivateProfileSection(const char* _oldAppName, const char* _newAppName, const char* _iniFn, const char* _newIniFn)

--- a/SnM/SnM_Util.h
+++ b/SnM/SnM_Util.h
@@ -60,7 +60,7 @@ void ScanFiles(WDL_PtrList<WDL_String>* _files, const char* _initDir, const char
 void StringToExtensionConfig(WDL_FastString* _str, ProjectStateContext* _ctx);
 void ExtensionConfigToString(WDL_FastString* _str, ProjectStateContext* _ctx);
 
-void SaveIniSection(const char* _iniSectionName, WDL_FastString* _iniSection, const char* _iniFn);
+bool SaveIniSection(const char* _iniSectionName, const std::string& _iniSection, const char* _iniFn);
 void UpdatePrivateProfileSection(const char* _oldAppName, const char* _newAppName, const char* _iniFn, const char* _newIniFn = NULL);
 void UpdatePrivateProfileString(const char* _appName, const char* _oldKey, const char* _newKey, const char* _iniFn, const char* _newIniFn = NULL);
 void SNM_UpgradeIniFiles(int _iniVersion);


### PR DESCRIPTION
- Fixes S&M_Cycleaction.ini corruption when writing lines longer than 8191 bytes
- Fixes data loss when saving cycle action sections larger than around 1MB on Windows