### PR TITLE
Fix generation of sws_python64.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL "8")
   set(CPUBITS "64")
-  set(REASCRIPT_PYTHON_FLAGS, "-x64")
+  set(REASCRIPT_PYTHON_FLAGS "-x64")
 elseif(CMAKE_SIZEOF_VOID_P EQUAL "4")
   set(CPUBITS "32")
 else()


### PR DESCRIPTION
The 32-bit version was included in the 64-bit installers since 2.11 because of that typo.