### PR TITLE
Fix dragging cycle action commands or region playlists when scrolled

### DIFF
--- a/SnM/SnM_Cyclactions.cpp
+++ b/SnM/SnM_Cyclactions.cpp
@@ -1890,8 +1890,7 @@ void CommandsView::OnDrag()
 				g_editedAction->InsertCmd(iNewPriority, draggedItems.Get(i));
 			}
 
-			ListView_DeleteAllItems(m_hwndList); // because of the special sort criteria ("not sortable" somehow)
-			Update();
+			Update(true);
 
 			for (int i=0; i < draggedItems.GetSize(); i++)
 				SelectByItem((SWS_ListItem*)draggedItems.Get(i), i==0, i==0);

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -438,8 +438,7 @@ void RegionPlaylistView::OnDrag()
 			pl->Insert(iNewPriority, m_draggedItems.Get(i));
 		}
 
-		ListView_DeleteAllItems(m_hwndList); // because of the special sort criteria ("not sortable" somehow)
-		Update(); // no UpdateCompact() here, it would crash! see OnEndDrag()
+		Update(true); // no UpdateCompact() here, it would crash! see OnEndDrag()
 
 		for (int i=0; i < m_draggedItems.GetSize(); i++)
 			SelectByItem((SWS_ListItem*)m_draggedItems.Get(i), i==0, i==0);

--- a/sws_wnd.cpp
+++ b/sws_wnd.cpp
@@ -1170,7 +1170,7 @@ int SWS_ListView::LVKeyHandler(MSG* msg, int iKeyState)
 	return 0;
 }
 
-void SWS_ListView::Update()
+void SWS_ListView::Update(const bool reassign)
 {
 	// Fill in the data by pulling it from the derived class
 	if (m_iEditingItem == -1 && !m_bDisableUpdates)
@@ -1251,6 +1251,13 @@ void SWS_ListView::Update()
 			item.iItem = bFound ? i : newIndex++;
 			item.pszText = str;
 
+			if (reassign) {
+				// update list view item/internal data item association
+				// (eg. after reordering the internal list on drag/drop)
+				item.mask |= LVIF_PARAM;
+				item.lParam = reinterpret_cast<LPARAM>(pItem);
+			}
+
 			int iCol = 0;
 			for (int k = 0; k < m_iCols; k++)
 				if (m_pCols[k].iPos != -1)
@@ -1261,7 +1268,7 @@ void SWS_ListView::Update()
 					{
 						item.mask |= LVIF_TEXT;
 						if(iCol == 0) {
-							item.mask |= LVIF_PARAM | LVIF_TEXT;
+							item.mask |= LVIF_PARAM;
 							item.lParam = reinterpret_cast<LPARAM>(pItem);
 							ListView_InsertItem(m_hwndList, &item);
 						}

--- a/sws_wnd.h
+++ b/sws_wnd.h
@@ -86,7 +86,7 @@ public:
 	virtual void OnEndDrag() {}
 	int EditingKeyHandler(MSG *msg);
 	int LVKeyHandler(MSG *msg, int iKeyState);
-	virtual void Update();
+	void Update(bool reassign = false);
 	bool DoColumnMenu(int x, int y);
 	bool HeaderHitTest(const POINT &) const;
 	SWS_ListItem* GetHitItem(int x, int y, int* iCol);


### PR DESCRIPTION
The list was always scrolled to the top after clearing & rebuilding the entire list (+ an extra redraw causing flickering).

Fixes #1456