### PR TITLE
Support OSARA's shortcut help mode in cycle, continuous and MIDI editor actions

### DIFF
--- a/reaper/sws_rpf_wrapper.h
+++ b/reaper/sws_rpf_wrapper.h
@@ -50,6 +50,9 @@ REAPER_EXTRA_API_DECL bool (*OnColorThemeOpenFile)(const char*);
 // https://forum.cockos.com/showthread.php?t=227910
 REAPER_EXTRA_API_DECL bool (*ListView_HeaderHitTest)(HWND, POINT);
 
+// jcsteh/osara#359
+REAPER_EXTRA_API_DECL bool (*osara_isShortcutHelpEnabled)();
+
 // Avoid VWnd collisions
 #define WDL_VirtualWnd_ScaledBlitBG WDL_VirtualWnd_ScaledBlitBG_fptr
 #define WDL_VirtualWnd_BGCfg WDL_VirtualWnd_BGCfg_stub


### PR DESCRIPTION
Inhibit execution of cycle, continuous and MIDI editor actions when OSARA's shortcut help mode is enabled and OSARA was loaded after SWS.

See jcsteh/osara#359.