### PR TITLE
Preserve CC shapes in REAPER v6 when using BR_MidiItemTimePos::Restore 

### DIFF
--- a/Breeder/BR_MidiUtil.h
+++ b/Breeder/BR_MidiUtil.h
@@ -183,8 +183,8 @@ private:
 			CCEvent (MediaItem_Take* take, int id);
 			void InsertEvent (MediaItem_Take* take, double offset);
 			bool selected, muted;
-			double pos;
-			int chanMsg, chan, msg2, msg3;
+			double pos, beztension;
+			int chanMsg, chan, msg2, msg3, shape;
 		};
 		struct SysEvent
 		{

--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -970,14 +970,7 @@ bool SetIgnoreTempo (MediaItem* item, bool ignoreTempo, double bpm, int num, int
 			LineParser lp(false);
 			lp.parse(token);
 
-			bool replaceLine = true;
-			if (skipItemsWithSameIgnoreState)
-			{
-				if ((ignoreTempo && !!lp.gettoken_int(1) == true) || (!ignoreTempo && !!lp.gettoken_int(1) == false))
-					replaceLine = false;
-			}
-
-			if (replaceLine)
+			if (!skipItemsWithSameIgnoreState || !!lp.gettoken_int(1) != ignoreTempo)
 			{
 				for (int i = 0; i < lp.getnumtokens(); ++i)
 				{

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -942,6 +942,7 @@ error:
 		IMPAPI(MIDI_eventlist_Create);
 		IMPAPI(MIDI_eventlist_Destroy);
 		IMPAPI(MIDI_GetCC);
+		IMPAP_OPT(MIDI_GetCCShape); // v6.0
 		IMPAPI(MIDI_GetEvt);
 		IMPAPI(MIDI_GetGrid)
 		IMPAPI(MIDI_GetNote);
@@ -955,6 +956,7 @@ error:
 		IMPAPI(MIDI_InsertNote);
 		IMPAPI(MIDI_InsertTextSysexEvt);
 		IMPAPI(MIDI_SetCC);
+		IMPAP_OPT(MIDI_SetCCShape); // v6.0
 		IMPAPI(MIDI_SetEvt);
 		IMPAPI(MIDI_SetItemExtents); // v5.0pre (no data on exact build in whatsnew, but I'm pretty sure I never saw this in v4)
 		IMPAPI(MIDI_SetNote);


### PR DESCRIPTION
Fixes CC shape loss after running the following actions (R6+ only):

- SWS/BR: Delete tempo marker and preserve position and length of items (including MIDI events)
- SWS/BR: Delete tempo marker and preserve position and length of selected items (including MIDI events)
- SWS/BR: Enable "Ignore project tempo" for selected MIDI items preserving time position of MIDI events (use tempo at item's start)

Reported at https://forum.cockos.com/showpost.php?p=2368423