### PR TITLE
Region Playlist: accessibility improvements

### DIFF
--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -500,6 +500,12 @@ static COMMAND_T s_cmdTable[] =
 	{{ DEFACCEL, "SWS/S&M: Region Playlist - Options/Enable shuffle (only in Region Playlist)" }, "S&M_PLAYLIST_OPT_SHUFFLE_ON", SetPlaylistOptionShuffle, NULL, 0},
 	{ { DEFACCEL, "SWS/S&M: Region Playlist - Options/Disable shuffle (only in Region Playlist)" }, "S&M_PLAYLIST_OPT_SHUFFLE_OFF", SetPlaylistOptionShuffle, NULL, 1},
 	{ { DEFACCEL, "SWS/S&M: Region Playlist - Options/Toggle shuffle (only in Region Playlist)" }, "S&M_PLAYLIST_OPT_TGL_SHUFFLE", SetPlaylistOptionShuffle, NULL, -1, IsPlaylistOptionShuffle},
+	// Accessibility
+	{ { DEFACCEL, "SWS/S&M: Region Playlist - Add playlist (Accessibility)" }, "S&M_PLAYLIST_ADD_PLAYLIST", AddPlaylist, NULL, -1 },
+	{ { DEFACCEL, "SWS/S&M: Region Playlist - Add all regions (Accessibility)" }, "S&M_PLAYLIST_ADD_ALL_RGNS", AddAllRegions, NULL, -1 },
+	{ { DEFACCEL, "SWS/S&M: Region Playlist - Set name of selected region (Accessibility)" }, "S&M_PLAYLIST_SET_NAME_SEL_RGN", SetNameOfSelectedRegion, NULL, -1 },
+	{ { DEFACCEL, "SWS/S&M: Region Playlist - Set loop count of selected region (Accessibility)" }, "S&M_PLAYLIST_SET_LOOP_COUNT_SEL_RGN", SetLoopCountOfSelectedRegion, NULL, -1 },
+	{ { DEFACCEL, "SWS/S&M: Region Playlist - Display context menu (Accessibility)" }, "S&M_PLAYLIST_DISPLAY_CONTEXT_MENU", DisplayContextMenu, NULL, -1 },
 
 	// Markers & regions ------------------------------------------------------
 	{ { DEFACCEL, "SWS/S&M: Insert marker at edit cursor" }, "S&M_INS_MARKER_EDIT", InsertMarker, NULL, 0},

--- a/SnM/SnM_RegionPlaylist.h
+++ b/SnM/SnM_RegionPlaylist.h
@@ -170,4 +170,10 @@ int IsRegionPlaylistDisplayed(COMMAND_T*);
 void ToggleRegionPlaylistLock(COMMAND_T*);
 int IsRegionPlaylistMonitoring(COMMAND_T*);
 
+// Accessibility
+void AddPlaylist(COMMAND_T*);
+void AddAllRegions(COMMAND_T*);
+void SetNameOfSelectedRegion(COMMAND_T*);
+void SetLoopCountOfSelectedRegion(COMMAND_T*);
+void DisplayContextMenu(COMMAND_T*);
 #endif


### PR DESCRIPTION
As per the conversation in #1404:

new actions (displaying error messages if necessary conditions not met):
- SWS/S&M: Region Playlist - Add playlist (Accessibilty)
- SWS/S&M: Region Playlist - Add all regions (Accessibilty)
- SWS/S&M: Region Playlist - Set name of selected region (Accessibilty)
- SWS/S&M: Region Playlist - Set loop count of selected region (Accessibility)
- SWS/S&M: Region Playlist - Display context menu (Accessibility) [not implemented]

new functionality:
- TAB selects first region (if present)

TODO:
- implement 'Display context menu' action
- remove '(Accessibilty)'  in action name?

I could use help with implementing the 'show context menu' (at mouse cursor) action.
I've added '(Accessibility)' to the new actions names for easier filtering/testing during development stage, could be removed for release.