### PR TITLE
S&M track groups actions: support groups 33 to 64

### DIFF
--- a/SnM/SnM.h
+++ b/SnM/SnM.h
@@ -143,7 +143,7 @@
 #define SNM_MAX_HW_OUTS            8
 #define SNM_MAX_CC_LANE_ID         167 // v5pre11
 #define SNM_MAX_CC_LANES_LEN       4096
-#define SNM_MAX_TRACK_GROUPS       32
+#define SNM_MAX_TRACK_GROUPS       64
 #define SNM_MAX_CUE_BUSS_CONFS     8
 //#define SNM_MAX_TAKES              1024
 #define SNM_MAX_FX                 128


### PR DESCRIPTION
- S&M Set selected tracks to {first unused group,group n}: support groups 33 to 64

- S&M {Copy,Cut,Paste,Remove} track grouping: support groups 33 to 64
fixes #1470








