### PR TITLE
ReaScript: remove NF_ReadID3v2Tag()

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -300,7 +300,6 @@ APIdef g_apidefs[] =
 	{ APIFUNC(NF_UpdateSWSMarkerRegionSubWindow), "void", "", "", "Redraw the Notes window (call if you've changed a subtitle via <a href=\"NF_SetSWSMarkerRegionSub\">NF_SetSWSMarkerRegionSub</a> which is currently displayed in the Notes window and you want to appear the new subtitle immediately.)", },
 
 	{ APIFUNC(NF_TakeFX_GetFXModuleName), "bool", "MediaItem*,int,char*,int", "item,fx,nameOut,nameOut_sz", "See BR_TrackFX_GetFXModuleName. fx: counted consecutively across all takes (zero-based).", },
-	{ APIFUNC(NF_ReadID3v2Tag), "bool", "const char*,const char*,char*,int", "fn,tag,tagvalOut,tagvalOut_sz", "Reads an ID3v2 tag ('text information frame'), works with mp3 only. Supported tags e.g.: \"TBPM\" (BPM), \"TCOP\" (Copyright). For other possibly supported tags see <a href=\"http://id3.org/id3v2.4.0-frames\">id3v2.4.0-frames.txt</a> Returns false if tag was not found.", },
 	{ APIFUNC(NF_Win32_GetSystemMetrics), "int", "int", "nIndex", "Equivalent to win32 API GetSystemMetrics().", },
 	{ APIFUNC(NF_GetSWS_RMSoptions), "void", "double*,double*", "targetOut,windowSizeOut", "Get SWS analysis/normalize options. See <a href=\"#NF_SetSWS_RMSoptions\">NF_SetSWS_RMSoptions</a>.", },
 	{ APIFUNC(NF_SetSWS_RMSoptions), "bool", "double,double", "targetLevel,windowSize", "Set SWS analysis/normalize options (same as running action 'SWS: Set RMS analysis/normalize options'). targetLevel: target RMS normalize level (dB), windowSize: window size for peak RMS (sec.)", },

--- a/nofish/NF_ReaScript.cpp
+++ b/nofish/NF_ReaScript.cpp
@@ -39,14 +39,6 @@
 #include "../SnM/SnM_Project.h" // #974
 #include "../SnM/SnM_Chunk.h" // SNM_FXSummaryParser
 
-#ifdef USE_SYSTEM_TAGLIB
-#  include <taglib/id3v2tag.h>
-#  include <taglib/mpegfile.h>
-#else
-#  include <taglib/mpeg/id3v2/id3v2tag.h>
-#  include <taglib/mpeg/mpegfile.h>
-#endif
-
 // #781, peak/RMS
 double DoGetMediaItemMaxPeakAndMaxPeakPos(MediaItem* item, double* maxPeakPosOut) // maxPeakPosOut == NULL: peak only
 {
@@ -339,32 +331,6 @@ bool NF_TakeFX_GetFXModuleName(MediaItem * item, int fx, char * nameOut, int nam
 
 	snprintf(nameOut, nameOutSz, "%s", module.Get());
 	return found;
-}
-
-bool NF_ReadID3v2Tag(const char* fn, const char* tag, char* tagval, int tagval_sz)
-{
-	if (!fn || !*fn || !tagval || tagval_sz <= 0) return false;
-	if (stricmp(strrchr(fn, '\0') - 4, ".mp3")) return false;
-	*tagval = 0;
-
-	TagLib::MPEG::File f(win32::widen(fn).c_str(), false);
-
-	if (f.isValid() && !f.ID3v2Tag()->isEmpty())
-	{
-		TagLib::String s;
-		TagLib::ID3v2::FrameList l = f.ID3v2Tag()->frameListMap()[tag];
-		if (!l.isEmpty())
-			s = l.front()->toString();
-		
-		if (s.length())
-		{
-			const char* p = s.toCString(true);
-			lstrcpyn(tagval, p, tagval_sz);
-			tagval[tagval_sz - 1] = '\0'; // null-terminate in case of buffer overflow (probably unlikely)
-		}
-	}
-
-	return !!*tagval;
 }
 
 int NF_Win32_GetSystemMetrics(int nIndex)

--- a/nofish/NF_ReaScript.h
+++ b/nofish/NF_ReaScript.h
@@ -52,7 +52,6 @@ bool           NF_SetSWSMarkerRegionSub(const char* mkrRgnSub, int mkrRgnIdx);
 void           NF_UpdateSWSMarkerRegionSubWindow();
 
 bool           NF_TakeFX_GetFXModuleName(MediaItem* item, int fx, char* nameOut, int nameOutSz);
-bool           NF_ReadID3v2Tag(const char* fn, const char* tag, char* tagval, int tagval_sz);
 int            NF_Win32_GetSystemMetrics(int nIndex);
 
 


### PR DESCRIPTION
[REAPER v6.17+dev1130](https://forum.cockos.com/showthread.php?t=245662)  adds native API function GetMediaFileMetadata()

(NF_ReadID3v2Tag() was added in SWS v2.11.0 pre-release, so never appeared in an official release.)