### PR TITLE
Remove redundant inverse checks in conditions

### DIFF
--- a/Breeder/BR_EnvelopeUtil.cpp
+++ b/Breeder/BR_EnvelopeUtil.cpp
@@ -952,10 +952,8 @@ bool BR_Envelope::VisibleInArrange (int* envHeight, int* yOffset, bool cacheValu
 
 	if (this->IsTakeEnvelope())
 	{
-		if (!cacheValues || (cacheValues && m_height == -1))
-		{
+		if (!cacheValues || m_height == -1)
 			m_height = GetTakeEnvHeight(m_take, &m_yOffset);
-		}
 
 		WritePtr(envHeight, m_height);
 		WritePtr(yOffset,   m_yOffset);
@@ -978,10 +976,8 @@ bool BR_Envelope::VisibleInArrange (int* envHeight, int* yOffset, bool cacheValu
 	}
 	else
 	{
-		if (!cacheValues || (cacheValues && m_height == -1))
-		{
+		if (!cacheValues || m_height == -1)
 			m_height = GetTrackEnvHeight(m_envelope, &m_yOffset, true, this->GetParent());
-		}
 
 		WritePtr(envHeight, m_height);
 		WritePtr(yOffset,   m_yOffset);
@@ -1904,7 +1900,7 @@ bool BR_Envelope::FillProperties () const
 							++subchunks;
 						else if (!strcmp(token, ">"))
 							--subchunks;
-					
+
 						AppendLine(m_properties.EXT, token);
 						token = strtok(NULL, "\n");
 					} while (token && subchunks > 0);
@@ -2458,11 +2454,11 @@ bool ToggleShowSendEnvelope (MediaTrack* track, int sendId, BR_EnvType type)
 						if ((type & PAN)    && !panEnv.GetLength())  {panEnv  = ConstructReceiveEnv(PAN,    trim ? sendPan : 0,    hwSend); stateUpdated = true;}
 						if ((type & MUTE)   && !muteEnv.GetLength()) {muteEnv = ConstructReceiveEnv(MUTE,   sendMute,              hwSend); stateUpdated = true;}
 
-						if (volEnv.GetLength()  && (!(type & VOLUME) || (!envelopeHidden || (envelopeHidden && pointCount >= 2))))
+						if (volEnv.GetLength()  && (!(type & VOLUME) || (!envelopeHidden || pointCount >= 2)))
 							newState.Append(volEnv.Get());
-						if (panEnv.GetLength()  && (!(type & PAN)    || (!envelopeHidden || (envelopeHidden && pointCount >= 2))))
+						if (panEnv.GetLength()  && (!(type & PAN)    || (!envelopeHidden || pointCount >= 2)))
 							newState.Append(panEnv.Get());
-						if (muteEnv.GetLength() && (!(type & MUTE)   || (!envelopeHidden || (envelopeHidden && pointCount >= 2))))
+						if (muteEnv.GetLength() && (!(type & MUTE)   || (!envelopeHidden || pointCount >= 2)))
 							newState.Append(muteEnv.Get());
 					}
 					else

--- a/Breeder/BR_MidiUtil.cpp
+++ b/Breeder/BR_MidiUtil.cpp
@@ -910,7 +910,7 @@ set<int> GetUsedCCLanes (HWND midiEditor, int detect14bit, bool selectedEventsOn
 		{
 			bool selected; int chan;
 			MIDI_GetNote(take, i, &selected, NULL, NULL, NULL, &chan, NULL, NULL);
-			if (editor.IsChannelVisible(chan) && (!selectedEventsOnly || (selectedEventsOnly && selected)))
+			if (editor.IsChannelVisible(chan) && (!selectedEventsOnly || selected))
 			{
 				usedCC.insert(-1);
 				break;
@@ -926,7 +926,7 @@ set<int> GetUsedCCLanes (HWND midiEditor, int detect14bit, bool selectedEventsOn
 
 			if (type == -1)
 			{
-				if (!foundSys && (!selectedEventsOnly || (selectedEventsOnly && selected)))
+				if (!foundSys && (!selectedEventsOnly || selected))
 				{
 					usedCC.insert(CC_SYSEX);
 					foundSys = true;
@@ -936,7 +936,7 @@ set<int> GetUsedCCLanes (HWND midiEditor, int detect14bit, bool selectedEventsOn
 			}
 			else
 			{
-				if (!foundText && (!selectedEventsOnly || (selectedEventsOnly && selected)))
+				if (!foundText && (!selectedEventsOnly || selected))
 				{
 					usedCC.insert(CC_TEXT_EVENTS);
 					foundText = true;
@@ -1477,7 +1477,7 @@ bool DeleteEventsInLane (MediaItem_Take* take, int lane, bool selectedOnly, doub
 
 			if ((!doRange || CheckBounds(position, startRangePpq, endRangePpq)) && ((lane == CC_SYSEX && type == -1) || (lane == CC_TEXT_EVENTS && CheckBounds(type, 1, 7))))
 			{
-				if (!selectedOnly || (selectedOnly && selected))
+				if (!selectedOnly || selected)
 				{
 					MIDI_DeleteTextSysexEvt(take, i);
 					--i;
@@ -1502,7 +1502,7 @@ bool DeleteEventsInLane (MediaItem_Take* take, int lane, bool selectedOnly, doub
 
 			if ((!doRange || CheckBounds(position, startRangePpq, endRangePpq)) && chanMsg == eventType && (eventType != STATUS_CC || (lane1 == msg2 || lane2 == msg2)))
 			{
-				if (!selectedOnly || (selectedOnly && selected))
+				if (!selectedOnly || selected)
 				{
 					MIDI_DeleteCC(take, i);
 					--i;

--- a/Breeder/BR_ProjState.cpp
+++ b/Breeder/BR_ProjState.cpp
@@ -830,7 +830,7 @@ bool BR_ItemMuteState::Restore (bool selectedOnly)
 	{
 		if (MediaItem* item = GuidToItem(&m_items[i].guid))
 		{
-			if (!selectedOnly || (selectedOnly && GetMediaItemInfo_Value(item, "B_UISEL") != 0))
+			if (!selectedOnly || GetMediaItemInfo_Value(item, "B_UISEL"))
 			{
 				SetMediaItemInfo_Value(item, "B_MUTE", m_items[i].mute);
 				update = true;
@@ -917,7 +917,7 @@ bool BR_TrackSoloMuteState::Restore (bool selectedOnly)
 	{
 		if (MediaTrack* track = GuidToTrack(&m_tracks[i].guid))
 		{
-			if (!selectedOnly || (selectedOnly && GetMediaTrackInfo_Value(track, "I_SELECTED") != 0))
+			if (!selectedOnly || GetMediaTrackInfo_Value(track, "I_SELECTED"))
 			{
 				SetMediaTrackInfo_Value(track, "I_SOLO", m_tracks[i].solo);
 				SetMediaTrackInfo_Value(track, "B_MUTE", m_tracks[i].mute);

--- a/Breeder/BR_ReaScript.cpp
+++ b/Breeder/BR_ReaScript.cpp
@@ -707,7 +707,7 @@ void BR_SetMediaItemImageResource (MediaItem* item, const char* imageIn, int ima
 
 		bool didImage      = !imageIn;
 		bool didImageFlags = false;
-		bool doImageFlags  = (!imageIn || (imageIn && strcmp(imageIn, "")));
+		bool doImageFlags  = !imageIn || strcmp(imageIn, "");
 		bool commitTwice   = false; // in case image path is the same as one already set in the item, reaper will remove it in case we supply chunk with the same path (and sometimes we just want to change the flag)
 		bool skipCommit    = false;
 

--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -1638,7 +1638,7 @@ bool InsertStretchMarkersInAllItems (const vector<double>& stretchMarkers, bool 
 {
 	bool updated = true;
 
-	if (!IsLocked(ITEM_FULL) && !IsLocked(STRETCH_MARKERS) && (!obeySwsOptions || (obeySwsOptions && IsSetAutoStretchMarkersOn(NULL))))
+	if (!IsLocked(ITEM_FULL) && !IsLocked(STRETCH_MARKERS) && (!obeySwsOptions || IsSetAutoStretchMarkersOn(nullptr)))
 	{
 		const int itemCount = CountMediaItems(NULL);
 		for (int i = 0; i < itemCount; ++i)
@@ -2424,7 +2424,7 @@ static HWND SearchChildren (const char* name, HWND hwnd, HWND startHwnd = NULL, 
 				GetWindowText(hwnd, wndName, sizeof(wndName));
 				if (!strcmp(wndName, name))
 				{
-					if (!windowHasNoChildren || (windowHasNoChildren && !GetWindow(hwnd, GW_CHILD)))
+					if (!windowHasNoChildren || !GetWindow(hwnd, GW_CHILD))
 						returnHwnd = hwnd;
 				}
 			}
@@ -2439,7 +2439,7 @@ static HWND SearchChildren (const char* name, HWND hwnd, HWND startHwnd = NULL, 
 			while (true)
 			{
 				returnHwnd = FindWindowEx(hwnd, returnHwnd, NULL, name);
-				if (!returnHwnd || !windowHasNoChildren || (windowHasNoChildren && !GetWindow(returnHwnd, GW_CHILD)))
+				if (!returnHwnd || !windowHasNoChildren || !GetWindow(returnHwnd, GW_CHILD))
 					return returnHwnd;
 			}
 		}
@@ -2503,8 +2503,8 @@ static HWND FindFloating (const char* name, bool checkForNoCaption = false, bool
 	{
 		if (GetParent(hwnd) == g_hwndParent)
 		{
-			if ((!checkForNoCaption   || (checkForNoCaption   && !(GetWindowLongPtr(hwnd, GWL_STYLE) & WS_CAPTION))) &&
-				(!windowHasNoChildren || (windowHasNoChildren && !GetWindow(hwnd, GW_CHILD)))
+			if ((!checkForNoCaption || !(GetWindowLongPtr(hwnd, GWL_STYLE) & WS_CAPTION)) &&
+				(!windowHasNoChildren || !GetWindow(hwnd, GW_CHILD))
 			)
 				return hwnd;
 		}

--- a/SnM/SnM_ChunkParserPatcher.h
+++ b/SnM/SnM_ChunkParserPatcher.h
@@ -1019,8 +1019,8 @@ static int RemoveChunkLines(char* _chunk, const char* _searchStr, bool _checkBOL
 		while (*bol && bol > _chunk && *bol != '\n') bol--;
 		if (eol && bol && (*bol == '\n' || bol == _chunk) &&
 			// additional optional checks (safety)
-			(!_checkEOLChar || (_checkEOLChar && *((char*)(eol-1)) == _checkEOLChar)) &&
-			(!_checkBOL || (_checkBOL && idStr == (char*)(bol + ((bol == _chunk ? 0 : 1))))))
+			(!_checkEOLChar || *((char*)(eol-1)) == _checkEOLChar) &&
+			(!_checkBOL || idStr == (char*)(bol + ((bol == _chunk ? 0 : 1)))))
 		{
 			updates++;
 			if (bol != _chunk) bol++;

--- a/SnM/SnM_Dlg.cpp
+++ b/SnM/SnM_Dlg.cpp
@@ -66,13 +66,13 @@ bool g_SNM_ClearType = true;
 
 ColorTheme* SNM_GetColorTheme(bool _checkForSize) {
 	int sz; ColorTheme* ct = (ColorTheme*)GetColorThemeStruct(&sz);
-	if (ct && (!_checkForSize || (_checkForSize && sz >= sizeof(ColorTheme)))) return ct;
+	if (ct && (!_checkForSize || sz >= sizeof(ColorTheme))) return ct;
 	return NULL;
 }
 
 IconTheme* SNM_GetIconTheme(bool _checkForSize) {
 	int sz; IconTheme* it = (IconTheme*)GetIconThemeStruct(&sz);
-	if (it && (!_checkForSize || (_checkForSize && sz >= sizeof(IconTheme)))) return it;
+	if (it && (!_checkForSize || sz >= sizeof(IconTheme))) return it;
 	return NULL;
 }
 

--- a/SnM/SnM_Find.cpp
+++ b/SnM/SnM_Find.cpp
@@ -490,7 +490,7 @@ bool FindWnd::FindMediaItem(int _dir, bool _allTakes, bool (*jobTake)(MediaItem_
 						for (int k=0; item && k < nbTakes; k++)
 						{
 							MediaItem_Take* tk = GetMediaItemTake(item, k);
-							if (tk && (_allTakes || (!_allTakes && tk == GetActiveTake(item))))
+							if (tk && (_allTakes || tk == GetActiveTake(item)))
 							{
 								if (jobTake(tk, g_searchStr))
 								{

--- a/SnM/SnM_Item.cpp
+++ b/SnM/SnM_Item.cpp
@@ -106,7 +106,7 @@ void SNM_GetSelectedItems(ReaProject* _proj, WDL_PtrList<MediaItem>* _items, boo
 	int count = _items ? CountTracks(_proj) : 0;
 	for (int i=1; i <= count; i++) // skip master
 		if (MediaTrack* tr = SNM_GetTrack(_proj, i))
-			if (!_onSelTracks || (_onSelTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL)))
+			if (!_onSelTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED"))
 				for (int j=0; j < GetTrackNumMediaItems(tr); j++)
 					if (MediaItem* item = GetTrackMediaItem(tr,j))
 						if (*(bool*)GetSetMediaItemInfo(item, "B_UISEL", NULL))
@@ -119,7 +119,7 @@ bool SNM_SetSelectedItems(ReaProject* _proj, WDL_PtrList<MediaItem>* _items, boo
 	int count = _items && _items->GetSize() ? CountTracks(_proj) : 0;
 	for (int i=1; i <= count; i++) // skip master
 		if (MediaTrack* tr = SNM_GetTrack(_proj, i))
-			if (!_onSelTracks || (_onSelTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL)))
+			if (!_onSelTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED"))
 				for (int j=0; j < GetTrackNumMediaItems(tr); j++)
 					if (MediaItem* item = GetTrackMediaItem(tr, j))
 						for (int k=0; k < _items->GetSize(); k++)
@@ -137,7 +137,7 @@ bool SNM_ClearSelectedItems(ReaProject* _proj, bool _onSelTracks) // primitive f
 	int count = CountTracks(_proj);
 	for (int i=1; i <= count; i++) // skip master
 		if (MediaTrack* tr = SNM_GetTrack(_proj, i))
-			if (!_onSelTracks || (_onSelTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL)))
+			if (!_onSelTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED"))
 				for (int j=0; j < GetTrackNumMediaItems(tr); j++)
 					if (MediaItem* item = GetTrackMediaItem(tr, j))
 						if (*(bool*)GetSetMediaItemInfo(item, "B_UISEL", NULL)) {
@@ -409,7 +409,7 @@ bool SplitSelectItemsInInterval(const char* _undoTitle, double _pos1, double _po
 	PreventUIRefresh(1);
 	for (int i=1; i <= GetNumTracks(); i++) // skip master
 		if (MediaTrack* tr = CSurf_TrackFromID(i, false))
-			if (!_selTracks || (_selTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL)))
+			if (!_selTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED"))
 				updated |= SplitSelectItemsInInterval(tr, _pos1, _pos2, _newItemsOut);
 	PreventUIRefresh(-1);
 
@@ -549,7 +549,7 @@ int BuildLanes(const char* _undoTitle, int _mode)
 	for (int i = 1; i <= GetNumTracks(); i++) // skip master
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
-		if (tr && (_mode || (!_mode && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+		if (tr && (_mode || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 		{
 			WDL_PtrList<void> items;
 			WDL_IntKeyedArray<int> recPassColors; 
@@ -560,7 +560,7 @@ int BuildLanes(const char* _undoTitle, int _mode)
 			for (int j = 0; tr && j < GetTrackNumMediaItems(tr); j++)
 			{
 				MediaItem* item = GetTrackMediaItem(tr,j);
-				if (item && (!_mode || (_mode && *(bool*)GetSetMediaItemInfo(item,"B_UISEL",NULL))))
+				if (item && (!_mode || GetMediaItemInfo_Value(item,"B_UISEL")))
 				{
 					int* recPasses = new int[SNM_RECPASSPARSER_MAX_TAKES];
 					int takeColors[SNM_RECPASSPARSER_MAX_TAKES];
@@ -661,10 +661,10 @@ bool RemoveEmptyTakes(MediaTrack* _tr, bool _empty, bool _midiEmpty, bool _trSel
 	bool updated = false;
 	for (int j = 0; _tr && j < GetTrackNumMediaItems(_tr); j++)
 	{
-		if (!_trSel || (_trSel && *(int*)GetSetMediaTrackInfo(_tr, "I_SELECTED", NULL)))
+		if (!_trSel || GetMediaTrackInfo_Value(_tr, "I_SELECTED"))
 		{
 			MediaItem* item = GetTrackMediaItem(_tr,j);
-			if (item && (!_itemSel || (_itemSel && *(bool*)GetSetMediaItemInfo(item,"B_UISEL",NULL))))
+			if (item && (!_itemSel || GetMediaItemInfo_Value(item,"B_UISEL")))
 			{
 				SNM_TakeParserPatcher p(item, CountTakes(item));
 				int k=0, kOriginal=0;

--- a/SnM/SnM_LiveConfigs.cpp
+++ b/SnM/SnM_LiveConfigs.cpp
@@ -360,7 +360,7 @@ bool LiveConfigItem::IsDefault(bool _ignoreComment)
 { 
 	return (
 		!m_track &&
-		(_ignoreComment || (!_ignoreComment && !m_desc.GetLength())) &&
+		(_ignoreComment || !m_desc.GetLength()) &&
 		!m_trTemplate.GetLength() &&
 		!m_fxChain.GetLength() &&
 		!m_presets.GetLength() && 
@@ -386,7 +386,7 @@ bool LiveConfigItem::Equals(LiveConfigItem* _item, bool _ignoreComment)
 {
 	return (_item &&
 		m_track == _item->m_track &&
-		(_ignoreComment || (!_ignoreComment && !strcmp(m_desc.Get(), _item->m_desc.Get()))) &&
+		(_ignoreComment || !strcmp(m_desc.Get(), _item->m_desc.Get())) &&
 		!strcmp(m_trTemplate.Get(), _item->m_trTemplate.Get()) &&
 		!strcmp(m_fxChain.Get(), _item->m_fxChain.Get()) &&
 		!strcmp(m_presets.Get(), _item->m_presets.Get()) &&

--- a/SnM/SnM_Marker.cpp
+++ b/SnM/SnM_Marker.cpp
@@ -63,7 +63,7 @@ int UpdateMarkerRegionCache()
 	while ((x = EnumProjectMarkers3(NULL, x, &isRgn, &pos, &rgnend, &name, &num, &col)))
 	{
 		MarkerRegion* m = g_mkrRgnCache.Get(i);
-		if (!m || (m && !m->Compare(isRgn, pos, rgnend, name, num, col)))
+		if (!m || !m->Compare(isRgn, pos, rgnend, name, num, col))
 		{
 			if (m) g_mkrRgnCache.Delete(i, true);
 			g_mkrRgnCache.Insert(i, new MarkerRegion(isRgn, pos, rgnend, name, num, col));

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1024,7 +1024,7 @@ void RegionPlaylistWnd::DrawControls(LICE_IBitmap* _bm, const RECT* _r, int* _to
 						m_txtPlaylist.SetText(hasPlaylists ? __LOCALIZE("Playlist #","sws_DLG_165") : __LOCALIZE("Playlist: None","sws_DLG_165"));
 						if (SNM_AutoVWndPosition(DT_LEFT, &m_txtPlaylist, NULL, _r, &x0, _r->top, h, hasPlaylists?4:SNM_DEF_VWND_X_STEP))
 						{
-							if (!hasPlaylists || (hasPlaylists && SNM_AutoVWndPosition(DT_LEFT, &m_cbPlaylist, &m_txtPlaylist, _r, &x0, _r->top, h, 4)))
+							if (!hasPlaylists || SNM_AutoVWndPosition(DT_LEFT, &m_cbPlaylist, &m_txtPlaylist, _r, &x0, _r->top, h, 4))
 							{
 								m_btnDel.SetEnabled(hasPlaylists);
 								if (SNM_AutoVWndPosition(DT_LEFT, &m_btnsAddDel, NULL, _r, &x0, _r->top, h))
@@ -1409,7 +1409,7 @@ void PlaylistRun()
 		{
 			// a bunch of calls end here when looping!!
 
-			if (!g_plLoop || (g_plLoop && (g_unsync || pos<g_lastRunPos)))
+			if (!g_plLoop || g_unsync || pos<g_lastRunPos)
 			{
 				g_plLoop = false;
 
@@ -2126,7 +2126,7 @@ static void SaveExtensionConfig(ProjectStateContext *ctx, bool isUndo, struct pr
 				confStr.AppendFormatted(128,"%d %d\n", item->m_rgnId, item->m_cnt);
 
 		// ignore empty playlists when saving but always take them into account for undo
-		if (isUndo || (!isUndo && confStr.GetLength() > iHeaderLen)) {
+		if (isUndo || confStr.GetLength() > iHeaderLen) {
 			confStr.Append(">\n");
 			StringToExtensionConfig(&confStr, ctx);
 		}

--- a/SnM/SnM_Resources.cpp
+++ b/SnM/SnM_Resources.cpp
@@ -323,7 +323,7 @@ void TieResFileToProject(const char* _fn, int _bookmarkType, bool _checkDup = fa
 
 	if (_bookmarkType>=SNM_NUM_DEFAULT_SLOTS && g_tiedProjects.Get(_bookmarkType)->GetLength())
 		if (ResourceList* fl = g_SNM_ResSlots.Get(_bookmarkType))
-			if (!_checkDup || (_checkDup && fl->FindByPath(_fn)<0))
+			if (!_checkDup || fl->FindByPath(_fn)<0)
 			{
 				int i=0;
 				char path[SNM_MAX_PATH] = "";
@@ -347,7 +347,7 @@ void UntieResFileFromProject(const char* _fn, int _bookmarkType, bool _checkDup 
 
 	if (_bookmarkType>=SNM_NUM_DEFAULT_SLOTS && g_tiedProjects.Get(_bookmarkType)->GetLength())
 		if (ResourceList* fl = g_SNM_ResSlots.Get(_bookmarkType))
-			if (!_checkDup || (_checkDup && fl->FindByPath(_fn)<0))
+			if (!_checkDup || fl->FindByPath(_fn)<0)
 				TieResFileToProject(_fn, _bookmarkType, false, false);
 }
 

--- a/SnM/SnM_Routing.cpp
+++ b/SnM/SnM_Routing.cpp
@@ -72,7 +72,7 @@ void CopySendsReceives(bool _noIntra, WDL_PtrList<MediaTrack>* _trs,
 				MediaTrack* dest = (MediaTrack*)GetSetTrackSendInfo(tr, 0, idx, "P_DESTTRACK", NULL);
 				while (dest)
 				{
-					if (!_noIntra || (_noIntra && _trs->Find(dest)<0))
+					if (!_noIntra || _trs->Find(dest)<0)
 					{
 						SNM_SndRcv* send = new SNM_SndRcv();
 						if (send->FillIOFromReaper(tr, dest, 0, idx))
@@ -91,7 +91,7 @@ void CopySendsReceives(bool _noIntra, WDL_PtrList<MediaTrack>* _trs,
 				MediaTrack* src = (MediaTrack*)GetSetTrackSendInfo(tr, -1, idx, "P_SRCTRACK", NULL);
 				while (src)
 				{
-					if (!_noIntra || (_noIntra && _trs->Find(src)<0))
+					if (!_noIntra || _trs->Find(src)<0)
 					{
 						SNM_SndRcv* rcv = new SNM_SndRcv();
 						if (rcv->FillIOFromReaper(src, tr, -1, idx))
@@ -142,8 +142,8 @@ bool PasteSendsReceives(WDL_PtrList<MediaTrack>* _trs,
 	for (int i=0; i<_trs->GetSize(); i++)
 	{
 		// when the nb of copied tracks' routings == nb of dest tracks, paste them respectively
-		if ((!_snds || (_snds && _trs->GetSize()==_snds->GetSize())) && 
-			(!_rcvs || (_rcvs && _trs->GetSize()==_rcvs->GetSize())))
+		if ((!_snds || _trs->GetSize()==_snds->GetSize()) &&
+		    (!_rcvs || _trs->GetSize()==_rcvs->GetSize()))
 		{
 			updated |= PasteSendsReceives(true, _trs->Get(i), _snds, i, ps);
 			updated |= PasteSendsReceives(false, _trs->Get(i), _rcvs, i, ps);

--- a/SnM/SnM_Window.cpp
+++ b/SnM/SnM_Window.cpp
@@ -371,7 +371,7 @@ void ShowThemeHelper(WDL_FastString* _report, HWND _hwnd, bool _mcp, bool _sel)
 				{
 					MediaTrack* tr = (MediaTrack*)GetWindowLongPtr(w, GWLP_USERDATA);
 					int trIdx = CSurf_TrackToID(tr, false);
-					if (trIdx>=0 && (!_sel || (_sel && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+					if (trIdx>=0 && (!_sel || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 					{
 						RECT r;	GetClientRect(w, &r);
 						char* trName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
@@ -585,7 +585,7 @@ void ShowFXChain(COMMAND_T* _ct)
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
 		// NULL _ct => all tracks, selected tracks otherwise
-		if (tr && (!_ct || (_ct && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+		if (tr && (!_ct || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 			TrackFX_Show(tr, (focusedFX == -1 ? GetSelectedTrackFX(tr) : focusedFX), 1);
 	}
 }
@@ -597,7 +597,7 @@ void HideFXChain(COMMAND_T* _ct)
 	for (int i=0; i <= GetNumTracks(); i++) // incl. master
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
-		if (tr && (!_ct || (_ct && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL)))) 
+		if (tr && (!_ct || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 		{
 			TrackFX_Show(tr, -1, 0); // no valid index required for closing FX chain
 
@@ -622,7 +622,7 @@ void ToggleFXChain(COMMAND_T* _ct)
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
 		// NULL _ct => all tracks, selected tracks otherwise
-		if (tr && (!_ct || (_ct && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL)))) {
+		if (tr && (!_ct || GetMediaTrackInfo_Value(tr, "I_SELECTED"))) {
 			int currentFX = TrackFX_GetChainVisible(tr);
 			TrackFX_Show(tr, GetSelectedTrackFX(tr), (currentFX == -2 || currentFX >= 0) ? 0 : 1);
 		}
@@ -688,7 +688,7 @@ void ToggleFloatTakeFX(MediaItem_Take* _take, int _fx)
 // showflag=0 for toggle, =2 for hide floating window (valid index), =3 for show floating window (valid index)
 void FloatUnfloatFXs(MediaTrack* _tr, bool _all, int _showFlag, int _fx, bool _selTracks) 
 {
-	bool matchTrack = (_tr && (!_selTracks || (_selTracks && *(int*)GetSetMediaTrackInfo(_tr, "I_SELECTED", NULL))));
+	const bool matchTrack = _tr && (!_selTracks || GetMediaTrackInfo_Value(_tr, "I_SELECTED"));
 	if (_all && matchTrack)
 	{
 		int nbFx = TrackFX_GetCount(_tr);
@@ -705,7 +705,7 @@ void FloatUnfloatFXs(MediaTrack* _tr, bool _all, int _showFlag, int _fx, bool _s
 
 void FloatUnfloatTakeFXs(MediaTrack * _tr, bool _all, int _showFlag, int _fx, bool _selTracks)
 {
-	bool matchTrack = (_tr && (!_selTracks || (_selTracks && *(int*)GetSetMediaTrackInfo(_tr, "I_SELECTED", NULL))));
+	const bool matchTrack = _tr && (!_selTracks || GetMediaTrackInfo_Value(_tr, "I_SELECTED"));
 	if (_all && matchTrack)
 	{
 		for (int k = 0; k < CountTrackMediaItems(_tr); k++)
@@ -767,7 +767,7 @@ void FloatUnfloatFXs(bool _all, int _showFlag, int _fx, bool _selTracks)
 	for (int i=0; i <= GetNumTracks(); i++) // incl. master
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
-		if (tr && (_all || !_selTracks || (_selTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+		if (tr && (_all || !_selTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 			FloatUnfloatFXs(tr, _all, _showFlag, _fx, _selTracks);
 	}
 }
@@ -780,7 +780,7 @@ void FloatUnfloatTakeFXs(bool _all, int _showFlag, int _fx, bool _selTracks)
 	for (int i = 1; i <= GetNumTracks(); i++) // skip master
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
-		if (tr && (_all || !_selTracks || (_selTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+		if (tr && (_all || !_selTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 			FloatUnfloatTakeFXs(tr, _all, _showFlag, _fx, _selTracks);
 	}
 }
@@ -889,7 +889,7 @@ bool CycleTracksAndFXs(int _trStart, int _fxStart, int _dir, bool _selectedTrack
 
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
 		int fxCount = tr ? TrackFX_GetCount(tr) : 0;
-		if (tr && fxCount &&  (!_selectedTracks || (_selectedTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+		if (tr && fxCount &&  (!_selectedTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 		{
 			int cpt2 = 0;
 			int j = (i==_trStart ? _fxStart+_dir : (_dir<0 ? fxCount-1 : 0));
@@ -932,7 +932,7 @@ bool FloatOnlyJob(MediaTrack* _tr, int _fx, bool _selectedTracks)
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
 		int fxCount = (tr ? TrackFX_GetCount(tr) : 0);
-		if (fxCount && (!_selectedTracks || (_selectedTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+		if (fxCount && (!_selectedTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 			for (int j = 0; j < fxCount; j++)
 				if (tr != _tr || j != _fx) 
 					FloatUnfloatFXs(tr, false, 2, j, true);
@@ -954,7 +954,7 @@ bool CycleFocusFXWnd(int _dir, bool _selectedTracks, bool* _cycled)
 		{
 			MediaTrack* tr = CSurf_TrackFromID(i, false);
 			if (tr && TrackFX_GetCount(tr) && 
-				(!_selectedTracks || (_selectedTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+				(!_selectedTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 			{
 				int prevFocused = GetFocusedTrackFXWnd(tr);
 				if (firstFXFound < 0)
@@ -969,7 +969,7 @@ bool CycleFocusFXWnd(int _dir, bool _selectedTracks, bool* _cycled)
 
 		// there was no already focused window if we're here..
 		// => focus the 1st found one
-		if (firstTrFound) 
+		if (firstTrFound)
 			return FocusJob(firstTrFound, firstFXFound, _selectedTracks);
 	}
 	return false;
@@ -1013,7 +1013,7 @@ void CycleFocusFXMainWnd(int _dir, bool _selectedTracks, bool _showmain)
 			{
 				MediaTrack* tr = CSurf_TrackFromID(trCpt, false);
 				int fxCount = (tr ? TrackFX_GetCount(tr) : 0);
-				if (fxCount && (!_selectedTracks || (_selectedTracks && *(int*)GetSetMediaTrackInfo(tr, "I_SELECTED", NULL))))
+				if (fxCount && (!_selectedTracks || GetMediaTrackInfo_Value(tr, "I_SELECTED")))
 				{
 					for (int j = (_dir > 0 ? 0 : (fxCount-1)); (j < fxCount) && (j>=0); j+=_dir)
 					{

--- a/Xenakios/main.cpp
+++ b/Xenakios/main.cpp
@@ -547,7 +547,7 @@ void ItemPreview(int mode, MediaItem* item, MediaTrack* track, double volume, do
 		GetSetMediaItemInfo(item, "B_MUTE", &g_bFalse); // needs to be set before getting the source
 
 		PCM_source* src = DuplicateSource((PCM_source*)item); // Casting from MediaItem* to PCM_source works!  Who would have known?
-		if (src && (!isMidi || (isMidi && effectiveMidiTakeLen > 0 && effectiveMidiTakeLen > startOffset)))
+		if (src && (!isMidi || (effectiveMidiTakeLen > 0 && effectiveMidiTakeLen > startOffset)))
 		{
 			GetSetMediaItemInfo((MediaItem*)src, "D_POSITION", &g_d0);
 			if (isMidi) GetSetMediaItemInfo((MediaItem*)src, "D_LENGTH", &effectiveMidiTakeLen);


### PR DESCRIPTION
Booleans are always true if they aren't false.