### PR TITLE
Expose PCM_SOURCE_EXT_GETBITRATE to ReaScripts

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -325,6 +325,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetCommandText), "const char*", "int,int", "section,command", "Wrapper for the unexposed kbd_getTextFromCmd API function. See <a href='#CF_EnumerateActions'>CF_EnumerateActions</a> for common section IDs.", },
 
 	{ APIFUNC(CF_GetMediaSourceBitDepth), "int", "PCM_source*", "src", "Returns the bit depth if available (0 otherwise).", },
+	{ APIFUNC(CF_GetMediaSourceBitRate), "double", "PCM_source*", "src", "Returns the bit rate for WAVE (wav, aif) and streaming/variable formats (mp3, ogg, opus). REAPER v6.19 or later is required for non-WAVE formats.", },
 	{ APIFUNC(CF_GetMediaSourceOnline), "bool", "PCM_source*", "src", "Returns the online/offline status of the given source.", },
 	{ APIFUNC(CF_SetMediaSourceOnline), "void", "PCM_source*,bool", "src,set", "Set the online/offline status of the given source (closes files when set=false).", },
 	{ APIFUNC(CF_GetMediaSourceMetadata), "bool", "PCM_source*,const char*,char*,int", "src,name,out,out_sz", "Get the value of the given metadata field (eg. DESC, ORIG, ORIGREF, DATE, TIME, UMI, CODINGHISTORY for BWF).", },

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -313,6 +313,26 @@ int CF_GetMediaSourceBitDepth(PCM_source *source)
   return source ? source->GetBitsPerSample() : 0;
 }
 
+double CF_GetMediaSourceBitRate(PCM_source *source)
+{
+  if(!source)
+    return 0;
+
+  double brate{};
+  if(source->Extended(PCM_SOURCE_EXT_GETBITRATE, &brate, nullptr, nullptr))
+    return brate;
+
+  if(strcmp(source->GetType(), "WAVE"))
+    return 0;
+
+  // constant bit rate
+  const double chans  = source->GetNumChannels(),
+               bdepth = source->GetBitsPerSample(),
+               srate  = source->GetSampleRate();
+
+  return srate * bdepth * chans;
+}
+
 bool CF_GetMediaSourceOnline(PCM_source *source)
 {
   return source && source->IsAvailable();

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -48,6 +48,7 @@ int CF_EnumSelectedFX(HWND chain, int index = -1);
 bool CF_SelectTrackFX(MediaTrack *, int index);
 
 int CF_GetMediaSourceBitDepth(PCM_source *);
+double CF_GetMediaSourceBitRate(PCM_source *);
 bool CF_GetMediaSourceOnline(PCM_source *);
 void CF_SetMediaSourceOnline(PCM_source *, bool set);
 bool CF_GetMediaSourceMetadata(PCM_source *, const char *name, char *buf, int bufSize);

--- a/reaper/reaper_plugin.h
+++ b/reaper/reaper_plugin.h
@@ -404,6 +404,7 @@ typedef struct
 #define PCM_SOURCE_EXT_SETSECONDARYSOURCELIST 0x1000B // parm1=(PCM_source**)sourcelist, parm2=list size, parm3=close any existing src not in the list
 #define PCM_SOURCE_EXT_ISOPENEDITOR 0x1000C // returns 1 if this source is currently open in an editor, parm1=1 to close
 #define PCM_SOURCE_EXT_GETITEMCONTEXT 0x10010 // parm1=MediaItem**, parm2=MediaItem_Take**, parm3=MediaTrack**
+#define PCM_SOURCE_EXT_GETBITRATE 0x10012 // parm1=(double*)bitrate, https://forum.cockos.com/showpost.php?p=2376588
 #define PCM_SOURCE_EXT_CONFIGISFILENAME 0x20000
 #define PCM_SOURCE_EXT_GETBPMANDINFO 0x40000 // parm1=pointer to double for bpm. parm2=pointer to double for snap/downbeat offset (seconds).
 #define PCM_SOURCE_EXT_GETNTRACKS 0x80000 // for midi data, returns number of tracks that would have been available


### PR DESCRIPTION
6.18+dev1211's `PCM_SOURCE_EXT_GETBITRATE` is only implemented in a few types of PCM sources (mp3, ogg, opus). I've added a basic CBR implementation for WAV sources which works in older versions of REAPER.

Not sure if this is good enough for inclusion in SWS since many source types are not supported.