### PR TITLE
Fix hit test of TCP tracks (after hiding master) and of the in-MCP master track in REAPER v6

### DIFF
--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -2897,22 +2897,21 @@ MediaTrack* HwndToTrack (HWND hwnd, int* hwndContext, POINT ptScreen)
 				POINT ptloc = ptScreen;
 				ScreenToClient(hwnd,&ptloc);
 				int tracks = GetNumTracks();
-				for (int i = -1; i < tracks; ++i)
+				for (int i = !*ConfigVar<int>{"showmaintrack"}; i <= tracks; ++i)
 				{
-					MediaTrack* chktrack = i<0 ? GetMasterTrack(NULL) : GetTrack(NULL, i);
-					void *p;
-					if (!(p=GetSetMediaTrackInfo(chktrack,"B_SHOWINTCP",NULL)) || !*(bool *)p) 
+					MediaTrack* chktrack = CSurf_TrackFromID(i, false);
+
+					if (!GetMediaTrackInfo_Value(chktrack, "B_SHOWINTCP"))
 						continue;
-					p = GetSetMediaTrackInfo(chktrack,"I_TCPY",NULL);
-					int ypos = p ? *(int *)p : 0;
-					p = GetSetMediaTrackInfo(chktrack,"I_TCPH",NULL);
-					int h = p ? *(int *)p : 0;
+
+					const double ypos = GetMediaTrackInfo_Value(chktrack, "I_TCPY"),
+					             h    = GetMediaTrackInfo_Value(chktrack, "I_TCPH");
+
 					if (ptloc.y >= ypos && ptloc.y < ypos + h)
 					{
 						track = chktrack;
 						break;
 					}
-
 				}
 			}
 		}

--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -2666,12 +2666,18 @@ HWND GetMixerWnd ()
 	return FindReaperWndByPreparedString(s_name);
 }
 
-HWND GetMixerMasterWnd ()
+HWND GetMixerMasterWnd (HWND mixer)
 {
 	static char* s_name = NULL;
 	if (!s_name)
 		AllocPreparedString(__localizeFunc("Mixer Master", "mixer", 0), &s_name);
-	return FindReaperWndByPreparedString(s_name);
+
+	HWND master = FindReaperWndByPreparedString(s_name);
+
+	if (!master) // v6 in mixer
+		master = FindWindowEx(mixer, nullptr, nullptr, "master");
+
+	return master;
 }
 
 HWND GetMediaExplorerWnd ()
@@ -2931,7 +2937,7 @@ MediaTrack* HwndToTrack (HWND hwnd, int* hwndContext, POINT ptScreen)
 		bool is_container;
 		HWND mcp = GetMcpWnd(is_container);
 		HWND mixer = GetParent(mcp);
-		HWND mixerMaster = GetMixerMasterWnd();
+		HWND mixerMaster = GetMixerMasterWnd(mixer);
 		HWND hwndPParent = GetParent(hwndParent);
 
 		if (is_container)

--- a/Breeder/BR_Util.h
+++ b/Breeder/BR_Util.h
@@ -254,7 +254,7 @@ HWND GetArrangeWnd ();
 HWND GetRulerWndAlt ();
 HWND GetTransportWnd ();
 HWND GetMixerWnd ();
-HWND GetMixerMasterWnd ();
+HWND GetMixerMasterWnd (HWND mixer);
 HWND GetMediaExplorerWnd ();
 HWND GetMcpWnd (bool &isContainer);
 HWND GetTcpWnd (bool &isContainer);


### PR DESCRIPTION
- `B_SHOWINTCP` is always 1 for the master track even when hidden (as documented)
- `I_TCPH` is not cleared after hiding the master track from the TCP

Therefore, in REAPER v6 (when `is_container` is true), `HwndToTrack` would assume the master track is always visible after it has been shown once in the TCP.

Reported at https://forum.cockos.com/showpost.php?p=2381122

---

Also, it turns out detecting the master track inside the mixer was also broken in REAPER v6.