### PR TITLE
Version 2.12.1.2

### DIFF
--- a/Breeder/BR_Util.h
+++ b/Breeder/BR_Util.h
@@ -254,7 +254,7 @@ HWND GetArrangeWnd ();
 HWND GetRulerWndAlt ();
 HWND GetTransportWnd ();
 HWND GetMixerWnd ();
-HWND GetMixerMasterWnd ();
+HWND GetMixerMasterWnd (HWND mixer);
 HWND GetMediaExplorerWnd ();
 HWND GetMcpWnd (bool &isContainer);
 HWND GetTcpWnd (bool &isContainer);

--- a/SnM/SnM_Window.cpp
+++ b/SnM/SnM_Window.cpp
@@ -1067,11 +1067,14 @@ void CycleFloatFXWndSelTracks(COMMAND_T* _ct)
 				if (!firstTrFound) {
 					firstTrFound = tr;
 					firstFXFound = (dir < 0 ? (fxCount-1) : 0);
+					while (TrackFX_GetOffline(tr, firstFXFound)
+							&& (dir < 0 ? firstFXFound > 0 : firstFXFound < fxCount-1))
+						firstFXFound += dir;
 				}
 
 				// specific case: make it work even no FX window is focused
 				// (classic pitfall when the action list is focused, see
-				// http://forum.cockos.com/showpost.php?p=708536&postcount=305)
+				// https://forum.cockos.com/showpost.php?p=708536)
 				int prevFocused = GetFocusedTrackFXWnd(tr);
 				if (prevFocused < 0)
 					prevFocused = GetFirstTrackFXWnd(tr, dir);
@@ -1084,7 +1087,7 @@ void CycleFloatFXWndSelTracks(COMMAND_T* _ct)
 
 		// there was no focused window if we're here..
 		// => float only the 1st found one
-		if (firstTrFound) 
+		if (firstTrFound)
 			FloatOnlyJob(firstTrFound, firstFXFound, true);
 	}
 }

--- a/version.h.in
+++ b/version.h.in
@@ -1,5 +1,5 @@
-#define SWS_VERSION 2,12,1,1
-#define SWS_VERSION_STR "2, 12, 1, 1\0"
+#define SWS_VERSION 2,12,1,2
+#define SWS_VERSION_STR "2, 12, 1, 2\0"
 #define SWS_VERSION_TYPE "Pre-release"
 #define GIT_COMMIT "@GIT_COMMIT@"
 #cmakedefine GIT_BRANCH "@GIT_BRANCH@"

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -1,3 +1,9 @@
+!v2.12.1.2 pre-release build (December 23, 2020)
+
++Fix "Float previous/next FX" actions not cycling if the last/first FX is offline (issue 1474)
++Fix detection of the in-mixer master track in REAPER v6
++Fix detection of tracks in the TCP after hiding the master track in REAPER v6 (report https://forum.cockos.com/showpost.php?p=2381122|here|)
+
 !v2.12.1.1 pre-release build (December 7, 2020)
 
 Accessibility:


### PR DESCRIPTION
**v2.12.1.2 pre-release build (December 23, 2020)**

+ Fix "Float previous/next FX" actions not cycling if the last/first FX is offline (report [here](https://forum.cockos.com/showpost.php?p=2360077))
+ Fix detection of the in-mixer master track in REAPER v6
+ Fix detection of tracks in the TCP after hiding the master track in REAPER v6 (report [here](https://forum.cockos.com/showpost.php?p=2381122))
