### PR TITLE
ReaScript: CF_EnumMediaSourceCues() - optionally get if a source cue is a chapter marker

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -329,7 +329,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_SetMediaSourceOnline), "void", "PCM_source*,bool", "src,set", "Set the online/offline status of the given source (closes files when set=false).", },
 	{ APIFUNC(CF_GetMediaSourceMetadata), "bool", "PCM_source*,const char*,char*,int", "src,name,out,out_sz", "Get the value of the given metadata field (eg. DESC, ORIG, ORIGREF, DATE, TIME, UMI, CODINGHISTORY for BWF).", },
 	{ APIFUNC(CF_GetMediaSourceRPP), "bool", "PCM_source*,char*,int", "src,fnOut,fnOut_sz", "Get the project associated with this source (BWF, subproject...).", },
-	{ APIFUNC(CF_EnumMediaSourceCues), "int", "PCM_source*,int,double*,double*,bool*,char*,int", "src,index,timeOut,endTimeOut,isRegionOut,nameOut,nameOut_sz", "Enumerate the source's media cues. Returns the next index or 0 when finished.", },
+	{ APIFUNC(CF_EnumMediaSourceCues), "int", "PCM_source*,int,double*,double*,bool*,char*,int,bool*", "src,index,timeOut,endTimeOut,isRegionOut,nameOut,nameOut_sz,isChapterOutOptional", "Enumerate the source's media cues. Returns the next index or 0 when finished.", },
 	{ APIFUNC(CF_ExportMediaSource), "bool", "PCM_source*,const char*", "src,fn", "Export the source to the given file (MIDI only).", },
 
 	{ NULL, } // denote end of table

--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -349,7 +349,7 @@ bool CF_GetMediaSourceRPP(PCM_source *source, char *buf, const int bufSize)
 }
 
 int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time,
-  double *endTime, bool *isRegion, char *name, const int nameSize)
+  double *endTime, bool *isRegion, char *name, const int nameSize, bool *isChapter)
 {
   if(!source)
     return 0;
@@ -368,6 +368,9 @@ int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time,
   if(name && cue.m_name)
     snprintf(name, nameSize, "%s", cue.m_name);
 
+  if (isChapter)
+      *isChapter = cue.m_flags & 4;
+ 
   return add ? index + add : 0;
 }
 

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -52,5 +52,5 @@ bool CF_GetMediaSourceOnline(PCM_source *);
 void CF_SetMediaSourceOnline(PCM_source *, bool set);
 bool CF_GetMediaSourceMetadata(PCM_source *, const char *name, char *buf, int bufSize);
 bool CF_GetMediaSourceRPP(PCM_source *source, char *buf, const int bufSize);
-int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize);
+int CF_EnumMediaSourceCues(PCM_source *source, const int index, double *time, double *endTime, bool *isRegion, char *name, const int nameSize, bool *isChapter);
 bool CF_ExportMediaSource(PCM_source *source, const char *file);


### PR DESCRIPTION
> v6.19 - December 18 2020
>   + API: PCM_SOURCE_EXT_ENUMCUES_EX distinguishes between cues and chapter markers

Lua test code:
```
reaper.ClearConsole()

function msg(m)
  return reaper.ShowConsoleMsg(tostring(m) .. "\n")
end

item = reaper.GetSelectedMediaItem(0, 0)
take =  reaper.GetActiveTake(item)
src = reaper.GetMediaItemTake_Source(take)

local i = 0
while true do
  -- retval, time, endTime, isRegion, name = reaper.CF_EnumMediaSourceCues( src, i ) -- optional param not provided
  retval, time, endTime, isRegion, name, isChapter = reaper.CF_EnumMediaSourceCues(src, i)
  msg("retval. ".. retval)
  msg("name: " .. name)
  if isChapter ~= nil then 
    msg("isChapter: " .. tostring(isChapter)) 
  end
  msg("\n")
  if retval == 0 then
    break
  end

  i = i + 1
end
```

Audio files with chapter markers are e.g. [here](https://auphonic.com/blog/2013/07/03/chapter-marks-and-enhanced-podcasts/).

edit:
I'm not sure if I get this [comment](https://github.com/justinfrankel/reaper-sdk/blob/bab8de9516516b4be24ff3ec5374d77508493e7d/reaper-plugins/reaper_plugin.h#L397) correctly:
> &1=DEPRECATED caller must call Extended(PCM_SOURCE_EXT_ENUMCUES, -1, &cue, 0) when finished

edit2:
But I think this is only relevant when _setting_, so probably no need to call above here?
 
On a side note:
reaper-sdk (including `reaper_plugin.h`) [moved](https://github.com/justinfrankel/reaper-sdk) to GitHub recently, maybe we could add it as a submodule in future?