### PR TITLE
GetArrangeWnd(), GetRulerWndAlt(), GetNotesView(), GetPianoView(): use windows control IDs instead of FindWindowEx()/SearchCildren()

### DIFF
--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -2570,74 +2570,30 @@ HWND FindFloatingToolbarWndByName (const char* toolbarName)
 		}
 }
 
+// IDs of child windows are the same on all platforms
+// https://forum.cockos.com/showpost.php?p=2388026&postcount=5
+enum WndControlIDs               // caption:
+{
+	main_arrange   = 0x000003E8, // trackview
+	main_ruler     = 0x000003ED, // timeline
+
+	midi_notesView = 0x000003E9, // midiview
+	midi_pianoView = 0x000003EB  // midipianoview
+};
+
 HWND GetArrangeWnd ()
 {
-	static HWND s_hwnd = NULL; /* More efficient and Justin says it's safe: http://askjf.com/index.php?q=2653s */
-
+	static HWND s_hwnd = nullptr;
 	if (!s_hwnd)
-	{
-		#ifdef _WIN32
-			if (IsLocalized())
-			{
-				char preparedName[2048];
-				PrepareLocalizedString(__localizeFunc("trackview", "DLG_102", 0), preparedName, sizeof(preparedName));
-
-				HWND wnd = SearchChildren(preparedName, g_hwndParent);
-				while (wnd)
-				{
-					char buf[256];
-					GetClassName(wnd, buf, sizeof(buf));
-					if (!strcmp(buf, "REAPERTrackListWindow"))
-					{
-						s_hwnd = wnd;
-						break;
-					}
-					wnd = SearchChildren(preparedName, g_hwndParent, wnd);
-				}
-			}
-			else
-			{
-				s_hwnd = FindWindowEx(g_hwndParent, 0, "REAPERTrackListWindow", __localizeFunc("trackview", "DLG_102", 0));
-			}
-		#else
-			return GetWindow(g_hwndParent, GW_CHILD);
-		#endif
-	}
+		s_hwnd = GetDlgItem(g_hwndParent, WndControlIDs::main_arrange);
 	return s_hwnd;
 }
 
 HWND GetRulerWndAlt ()
 {
-	static HWND s_hwnd = NULL; /* More efficient and Justin says it's safe: http://askjf.com/index.php?q=2653s */
+	static HWND s_hwnd = nullptr;
 	if (!s_hwnd)
-	{
-		#ifdef _WIN32
-			if (IsLocalized())
-			{
-				char preparedName[2048];
-				PrepareLocalizedString(__localizeFunc("timeline", "DLG_102", 0), preparedName, sizeof(preparedName));
-
-				HWND wnd = SearchChildren(preparedName, g_hwndParent);
-				while (wnd)
-				{
-					char buf[256];
-					GetClassName(wnd, buf, sizeof(buf));
-					if (!strcmp(buf, "REAPERTimeDisplay"))
-					{
-						s_hwnd = wnd;
-						break;
-					}
-					wnd = SearchChildren(preparedName, g_hwndParent, wnd);
-				}
-			}
-			else
-			{
-				s_hwnd = FindWindowEx(g_hwndParent, 0, "REAPERTimeDisplay", __localizeFunc("timeline", "DLG_102", 0));
-			}
-		#else
-			return GetWindow(GetArrangeWnd(), GW_HWNDNEXT);
-		#endif
-	}
+		s_hwnd = GetDlgItem(g_hwndParent, WndControlIDs::main_ruler);
 	return s_hwnd;
 }
 
@@ -2813,47 +2769,17 @@ HWND GetTcpTrackWnd (MediaTrack* track, bool &isContainer)
 HWND GetNotesView (HWND midiEditor)
 {
 	if (MIDIEditor_GetMode(midiEditor) != -1)
-	{
-		#ifdef _WIN32
-			static char* s_name  = (IsLocalized()) ? (NULL) : (const_cast<char*>(__localizeFunc("midiview", "midi_DLG_102", 0)));
-
-			if (IsLocalized())
-			{
-				if (!s_name)
-					AllocPreparedString(__localizeFunc("midiview", "midi_DLG_102", 0),&s_name);
-				return SearchChildren(s_name, midiEditor);
-			}
-			else
-				return FindWindowEx(midiEditor, NULL, NULL , s_name);
-		#else
-			return GetWindow(GetWindow(midiEditor, GW_CHILD), GW_HWNDNEXT);
-		#endif
-	}
+		return GetDlgItem(midiEditor, WndControlIDs::midi_notesView);
 	else
-		return NULL;
+		return nullptr;
 }
 
 HWND GetPianoView (HWND midiEditor)
 {
 	if (MIDIEditor_GetMode(midiEditor) != -1)
-	{
-		#ifdef _WIN32
-			static char* s_name  = (IsLocalized()) ? (NULL) : (const_cast<char*>(__localizeFunc("midipianoview", "midi_DLG_102", 0)));
-
-			if (IsLocalized())
-			{
-				if (!s_name)
-					AllocPreparedString(__localizeFunc("midipianoview", "midi_DLG_102", 0),&s_name);
-				return SearchChildren(s_name, midiEditor);
-			}
-			else
-				return FindWindowEx(midiEditor, NULL, NULL , s_name);
-		#else
-			return GetWindow(midiEditor, GW_CHILD);
-		#endif
-	}
+		return GetDlgItem(midiEditor, WndControlIDs::midi_pianoView);
 	else
-		return NULL;
+		return nullptr;
 }
 
 HWND GetTrackView (HWND midiEditor)


### PR DESCRIPTION
As discussed on Slack recently.

It also registers a temporary basic test action `SWS/NF: (temp) Test Window control IDs` to quickly check if the returned pointers are the same for both methods (will be removed and cleaned up before merging).