### PR TITLE
Fix listview column context menu always being shown when right clicking above the list

### DIFF
--- a/sws_wnd.cpp
+++ b/sws_wnd.cpp
@@ -1424,7 +1424,7 @@ bool SWS_ListView::HeaderHitTest(const POINT &point) const
 	// Fixed in REAPER v6.03
 	return ListView_HeaderHitTest(m_hwndList, point);
 #else
-	return point.y <= headerHeight;
+	return point.y >= 0 && point.y <= headerHeight;
 #endif
 }
 


### PR DESCRIPTION
(on Linux and Windows)

`HeaderHitTest` is called from `GetHitItem` even when the cursor position is outside the list view's rect. This was not handled.

Regression from v2.12 via 81a23d32f9fcd2fe1ae2d6629513108f496cd226.