### PR TITLE
SWS/S&M: {Toggle arming of, Arm, Disarm} all active envelopes for selected tracks: also apply on send envelopes

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -303,6 +303,7 @@ APIdef g_apidefs[] =
 	{ APIFUNC(NF_Win32_GetSystemMetrics), "int", "int", "nIndex", "Equivalent to win32 API GetSystemMetrics().", },
 	{ APIFUNC(NF_GetSWS_RMSoptions), "void", "double*,double*", "targetOut,windowSizeOut", "Get SWS analysis/normalize options. See <a href=\"#NF_SetSWS_RMSoptions\">NF_SetSWS_RMSoptions</a>.", },
 	{ APIFUNC(NF_SetSWS_RMSoptions), "bool", "double,double", "targetLevel,windowSize", "Set SWS analysis/normalize options (same as running action 'SWS: Set RMS analysis/normalize options'). targetLevel: target RMS normalize level (dB), windowSize: window size for peak RMS (sec.)", },
+	{ APIFUNC(NF_ArmEnvelope), "bool", "TrackEnvelope*,int", "envelope,mode", "Arm/disarm/toogle arm a Track envelope. mode: -1=toggle, 0=disarm, 1=arm. Returns true on success. Only works on active envelopes.", },
 	// /*** nofish stuff ***
 
 	{ APIFUNC(SN_FocusMIDIEditor), "void", "", "", "Focuses the active/open MIDI editor.", },

--- a/SnM/SnM_Chunk.h
+++ b/SnM/SnM_Chunk.h
@@ -297,15 +297,38 @@ class SNM_ArmEnvParserPatcher : public SNM_ChunkParserPatcher
 public:
 	SNM_ArmEnvParserPatcher(MediaTrack* _tr) : SNM_ChunkParserPatcher(_tr) {
 		m_newValue = -1; // i.e. toggle
+		m_skipReceiveEnvs = false;
 	}
 	~SNM_ArmEnvParserPatcher() {}
 	void SetNewValue(int _newValue) {m_newValue = _newValue;}
+	void SkipReceiveEns(bool _skipReceiveEns) {m_skipReceiveEnvs = _skipReceiveEns;}
 protected:
 	bool NotifyChunkLine(int _mode, 
 		LineParser* _lp, const char* _parsedLine, int _linePos,
 		int _parsedOccurence, WDL_PtrList<WDL_FastString>* _parsedParents,
 		WDL_FastString* _newChunk, int _updates);
 private:
+	int m_newValue;
+	bool m_skipReceiveEnvs;
+};
+
+// similar to SNM_ArmEnvParserPatcher, but works on a TrackEnvelope* directly
+class SNM_ArmEnvParserPatcher_Env : public SNM_ChunkParserPatcher
+{
+public:
+	SNM_ArmEnvParserPatcher_Env(TrackEnvelope* _env) : SNM_ChunkParserPatcher(_env) {
+		m_envIsActive = false;
+		m_newValue = -1; // i.e. toggle
+	}
+	~SNM_ArmEnvParserPatcher_Env() {}
+	void SetNewValue(int _newValue) { m_newValue = _newValue; }
+protected:
+	bool NotifyChunkLine(int _mode,
+		LineParser* _lp, const char* _parsedLine, int _linePos,
+		int _parsedOccurence, WDL_PtrList<WDL_FastString>* _parsedParents,
+		WDL_FastString* _newChunk, int _updates) override;
+private:
+	bool m_envIsActive;
 	int m_newValue;
 };
 

--- a/nofish/NF_ReaScript.cpp
+++ b/nofish/NF_ReaScript.cpp
@@ -37,7 +37,7 @@
 #include "../Breeder/BR_Loudness.h" // #880
 #include "../SnM/SnM_Notes.h" // #755
 #include "../SnM/SnM_Project.h" // #974
-#include "../SnM/SnM_Chunk.h" // SNM_FXSummaryParser
+#include "../SnM/SnM_Chunk.h" // SNM_FXSummaryParser, SNM_ArmEnvParserPatcher_Env
 
 // #781, peak/RMS
 double DoGetMediaItemMaxPeakAndMaxPeakPos(MediaItem* item, double* maxPeakPosOut) // maxPeakPosOut == NULL: peak only
@@ -336,6 +336,17 @@ bool NF_TakeFX_GetFXModuleName(MediaItem * item, int fx, char * nameOut, int nam
 int NF_Win32_GetSystemMetrics(int nIndex)
 {
 	return GetSystemMetrics(nIndex);
+}
+
+bool NF_ArmEnvelope(TrackEnvelope* env, int mode)
+{
+	if (env && mode > -2 && mode < 2)
+	{
+		SNM_ArmEnvParserPatcher_Env p(env);
+		p.SetNewValue(mode);
+		return (p.ParsePatch(-1) > 0);
+	}
+	return false;
 }
 
 // #974

--- a/nofish/NF_ReaScript.h
+++ b/nofish/NF_ReaScript.h
@@ -53,6 +53,7 @@ void           NF_UpdateSWSMarkerRegionSubWindow();
 
 bool           NF_TakeFX_GetFXModuleName(MediaItem* item, int fx, char* nameOut, int nameOutSz);
 int            NF_Win32_GetSystemMetrics(int nIndex);
+bool           NF_ArmEnvelope(TrackEnvelope* env, int mode);
 
 
 // #974


### PR DESCRIPTION
fixes #1513

+ReaScript: add NF_ArmEnvelope()
(I know we can do this via `BR_EnvSetProperties()` but it comes 'for free' with the added `SNM_ArmEnvParserPatcher_Env` and can be done directly on a `TrackEnvelope*`, no need to alloc `BR_Envelope*` first.)

There's currently a new bug introduced with my code with the `SWS/S&M: Toggle arming of all active envelopes for selected tracks` action in that when having a send track **and** the corresponding receive track selected when running this action, it toggles twice (on the send and on the receiving track) so effectively does nothing damnit.
Need to think about it (suggestions welcome :D).

update1:
Thinking about it, that these actions patch receive env's is not quite right imo (sure Envelope properties panel lists Receive envelopes, but visually they live on the sending tracks. Opinions?). Thus I made it now so that the actions only work on send envelopes (apart from the dedicated "Toggle arming of all receive ... envelopes for selected tracks" actions of course) which also solves the double toggling issue mentioned above.

update2:
Hm..I dunno, behaviour change is maybe not that good.
But the old behaviour together with this bugfix seems to lead to a handling problem.
If user has selected send and corressponding receive track and runs the "toggle arm active envs" action it's actually literally kinda 'correct' that it toggles twice (-> no-op) I'd say but of course not desired.
Think I'll stop the self-conversation for now and wait for comments/opinions. :)
  