### PR TITLE
add actions: SWS/NF: Toggle Play/stop (off) or Play/pause (on), SWS/NF: Play/stop or Play/pause (obey 'SWS/NF: Toggle Play/stop or Play/pause' toggle state)

### DIFF
--- a/nofish/nofish.cpp
+++ b/nofish/nofish.cpp
@@ -41,6 +41,7 @@
 ******************************************************************************/
 namespace {
 	int gf_NFObeyTrackHeightLock;
+	int gf_NFTogglePlayStopPlayPause;
 }
 
 //////////////////////////////////////////////////////////////////
@@ -423,6 +424,25 @@ bool NF_IsObeyTrackHeightLockEnabled()
 	return IsObeyTrackHeightLockEnabled();
 }
 
+static void TogglePlayStopPlayPause(COMMAND_T* ct = nullptr)
+{
+	gf_NFTogglePlayStopPlayPause = !gf_NFTogglePlayStopPlayPause;
+	WritePrivateProfileString(SWS_INI, "NFTogglePlayStopPlayPause", gf_NFTogglePlayStopPlayPause ? "1" : "0", get_ini_file());
+}
+
+int IsTogglePlayStopPlayPauseEnabled(COMMAND_T* _ct = nullptr) {
+	return gf_NFTogglePlayStopPlayPause;
+}
+
+static void PlayStopPlayPause(COMMAND_T* ct = nullptr)
+{
+	if (gf_NFTogglePlayStopPlayPause)
+		Main_OnCommand(40073, 0); // Transport: Play/pause
+	else
+		Main_OnCommand(40044, 0); // Transport: Play/stop
+}
+
+
 //////////////////////////////////////////////////////////////////
 //                                                              //
 // Register commands                                            //
@@ -462,6 +482,9 @@ static COMMAND_T g_commandTable[] =
 	// toggle Xenakios track height actions and SWS vertical zoom actions obey track height lock
 	{ { DEFACCEL, "SWS/NF: Toggle obey track height lock in vertical zoom and track height actions" }, "NF_TOGGLE_OBEY_TRACK_HEIGHT_LOCK", ToggleObeyTrackHeightLock, NULL, 0, IsObeyTrackHeightLockEnabled},
 
+	{ { DEFACCEL, "SWS/NF: Toggle Play/stop (off) or Play/pause (on)" }, "NF_TOGGLE_PLAY_STOP_PLAY_PAUSE", TogglePlayStopPlayPause, NULL, 0, IsTogglePlayStopPlayPauseEnabled},
+	{ { DEFACCEL, "SWS/NF: Play/stop or Play/pause (obey 'SWS/NF: Toggle Play/stop or Play/pause' toggle state)" }, "NF_PLAY_STOP_PLAY_PAUSE", PlayStopPlayPause, NULL, 0},
+
 	//!WANT_LOCALIZE_1ST_STRING_END
 
 	{ {}, LAST_COMMAND, },
@@ -470,7 +493,8 @@ static COMMAND_T g_commandTable[] =
 int nofish_Init()
 {
 	SWSRegisterCommands(g_commandTable);
-	gf_NFObeyTrackHeightLock = GetPrivateProfileInt(SWS_INI, "NFObeyTrackHeightLock", 0, get_ini_file()); // disabled by default
+	gf_NFObeyTrackHeightLock     = GetPrivateProfileInt(SWS_INI, "NFObeyTrackHeightLock",     0, get_ini_file()); // disabled by default
+	gf_NFTogglePlayStopPlayPause = GetPrivateProfileInt(SWS_INI, "NFTogglePlayStopPlayPause", 0, get_ini_file());
 	return 1;
 }
 


### PR DESCRIPTION
(for description see commit message)

I added these actions because I'd like to have the ability to have Transport: Play/stop and Transport: Play/pause using the _same_ shortcut (using different shortcuts as is by default doesn't play well with my muscle memory) without reassigning shortcuts and have visual feedback (toolbar button) which of them is currently active.

This would otherwise only be possible by running a background script I think(?) 