### PR TITLE
Add ability for region playlist crop and append to include tempo mark…

### DIFF
--- a/SnM/SnM_Marker.cpp
+++ b/SnM/SnM_Marker.cpp
@@ -384,7 +384,7 @@ bool GetAllTempoMarkers(WDL_PtrList<void>* _tempoMarkers, ReaProject* _proj)
 		while (token != NULL)
 		{
 			RawTempoMarkerData newTempoMarker = RawTempoMarkerData();
-			if (sscanf(token, "PT %lf %lf %d %u %d %d %d %s %u %u", &newTempoMarker.position, &newTempoMarker.bpm, &newTempoMarker.linearBool, &newTempoMarker.beatDivision, &newTempoMarker.intData4, &newTempoMarker.settingsBitmask, &newTempoMarker.intData6, newTempoMarker.stringData7, &newTempoMarker.uintData8, &newTempoMarker.metronomePattern) >= 2)
+			if (sscanf(token, "PT %lf %lf %d %u %d %d %d %s %u %u %d", &newTempoMarker.position, &newTempoMarker.bpm, &newTempoMarker.linearBool, &newTempoMarker.beatDivision, &newTempoMarker.selectionBool, &newTempoMarker.settingsBitmask, &newTempoMarker.bezierTension, newTempoMarker.quantizationSettings, &newTempoMarker.metronomePatternL32, &newTempoMarker.metronomePatternH32, &newTempoMarker.beatBase) >= 2)
 			{
 				tempoDataMap[index] = newTempoMarker;
 				index++;
@@ -433,7 +433,7 @@ bool GetTempoMarkersInInterval(WDL_PtrList<void>* _tempoMarkers, ReaProject* _pr
 		while (token != NULL)
 		{
 			RawTempoMarkerData newTempoMarker = RawTempoMarkerData();
-			if (sscanf(token, "PT %lf %lf %d %u %d %d %d %s %u %u", &newTempoMarker.position, &newTempoMarker.bpm, &newTempoMarker.linearBool, &newTempoMarker.beatDivision, &newTempoMarker.intData4, &newTempoMarker.settingsBitmask, &newTempoMarker.intData6, newTempoMarker.stringData7, &newTempoMarker.uintData8, &newTempoMarker.metronomePattern) >= 2)
+			if (sscanf(token, "PT %lf %lf %d %u %d %d %d %s %u %u %d", &newTempoMarker.position, &newTempoMarker.bpm, &newTempoMarker.linearBool, &newTempoMarker.beatDivision, &newTempoMarker.selectionBool, &newTempoMarker.settingsBitmask, &newTempoMarker.bezierTension, newTempoMarker.quantizationSettings, &newTempoMarker.metronomePatternL32, &newTempoMarker.metronomePatternH32, &newTempoMarker.beatBase) >= 2)
 			{
 				tempoDataMap[index] = newTempoMarker;
 				index++;
@@ -519,12 +519,12 @@ bool DuplicateTempoMarkers(WDL_PtrList<void>* _tempoMarkers, ReaProject* _proj, 
 		string newState = "";
 		int index = 0;
 		double position;
-		int data5;
+		int settingsBitmask;
 		char* token = strtok(envState, "\n");
 
 		while (token != NULL)
 		{
-			int foundValues = sscanf(token, "PT %lf %*lf %*d %*u %*d %d %*d %*s %*u %*u", &position, &data5);
+			int foundValues = sscanf(token, "PT %lf %*lf %*d %*u %*d %d %*d %*s %*u %*u %*d", &position, &settingsBitmask);
 			if (foundValues >= 1)
 			{
 				std::map<int, RawTempoMarkerData>::iterator findResult = newMarkersId.find(index);
@@ -535,7 +535,7 @@ bool DuplicateTempoMarkers(WDL_PtrList<void>* _tempoMarkers, ReaProject* _proj, 
 					char appendString[2048];
 					if (foundValues == 1)
 					{
-						sprintf(appendString, " %u %d", findResult->second.beatDivision, findResult->second.intData4);
+						sprintf(appendString, " %u %d", findResult->second.beatDivision, findResult->second.selectionBool);
 						newToken.append(appendString);
 					}
 					else
@@ -543,7 +543,7 @@ bool DuplicateTempoMarkers(WDL_PtrList<void>* _tempoMarkers, ReaProject* _proj, 
 						newToken = newToken.substr(0, newToken.size() - 2);
 					}
 
-					sprintf(appendString, " %d %d %s %u %u", findResult->second.settingsBitmask, findResult->second.intData6, findResult->second.stringData7, findResult->second.uintData8, findResult->second.metronomePattern);
+					sprintf(appendString, " %d %d %s %u %u %d", findResult->second.settingsBitmask, findResult->second.bezierTension, findResult->second.quantizationSettings, findResult->second.metronomePatternL32, findResult->second.metronomePatternH32, findResult->second.beatBase);
 					newToken.append(appendString);
 					newState.append(newToken);
 					newState.append("\n");

--- a/SnM/SnM_Marker.h
+++ b/SnM/SnM_Marker.h
@@ -74,16 +74,17 @@ protected:
 //Handle tempo markers for region playlist
 struct RawTempoMarkerData
 {
-	double position = -1;
-	double bpm = -1;
-	int linearBool = -1;
-	unsigned int beatDivision = -1;
-	int intData4 = -1; //Not sure what it is
-	int settingsBitmask = -1;
-	int intData6 = -1; //Not sure what it is
-	char stringData7[10]; //Not sure what it is
-	unsigned int uintData8 = -1; //Not sure what it is
-	unsigned int metronomePattern = -1;
+	double position = 0;
+	double bpm = 0;
+	int linearBool = 0;
+	unsigned int beatDivision = 0; //High 16 bits are time signature bottom, low 16 bits are time signature top
+	int selectionBool = 0; //Is this point selected
+	int settingsBitmask = 0;
+	int bezierTension = 0; //Not used for tempo markers
+	char quantizationSettings[10]; //Not sure how this works but I guess that if you quantize the tempo marker it would change this.
+	unsigned int metronomePatternL32 = 0;
+	unsigned int metronomePatternH32 = 0;
+	int beatBase = 0;
 };
 
 class TempoMarker

--- a/SnM/SnM_Marker.h
+++ b/SnM/SnM_Marker.h
@@ -71,4 +71,60 @@ protected:
 	int m_id;
 };
 
+//Handle tempo markers for region playlist
+struct RawTempoMarkerData
+{
+	double position = -1;
+	double bpm = -1;
+	int linearBool = -1;
+	unsigned int beatDivision = -1;
+	int intData4 = -1; //Not sure what it is
+	int settingsBitmask = -1;
+	int intData6 = -1; //Not sure what it is
+	char stringData7[10]; //Not sure what it is
+	unsigned int uintData8 = -1; //Not sure what it is
+	unsigned int metronomePattern = -1;
+};
+
+class TempoMarker
+{
+public:
+	TempoMarker(double _dTimePos, int _measurePos, double _dBeatPos, double _dBpm, int _timesig_num, int _timesig_denom, bool _bLinearTempo, RawTempoMarkerData _rawData);
+	~TempoMarker() {}
+
+	double GetTimePosition() { return m_dTimePos; }
+	void SetTimePosition(double dTimePos) { m_dTimePos = dTimePos; }
+	int GetMeasurePosition() { return m_measurePos; }
+	void SetMeasurePosition(int measurePos) { m_measurePos = measurePos; }
+	double GetBeatPosition() { return m_dBeatPos; }
+	void SetBeatPosition(double dBeatPos) { m_dBeatPos = dBeatPos; }
+	double GetBPM() { return m_dBpm; }
+	void SetBPM(double dBpm) { m_dBpm = dBpm; }
+	int GetTimeSignatureNumerator() { return m_timesig_num; }
+	void SetTimeSignatureNumerator(int timesig_num) { m_timesig_num = timesig_num; }
+	int GetTimeSignatureDenominator() { return m_timesig_denom; }
+	void SetTimeSignatureDenominator(int timesig_denom) { m_timesig_denom = timesig_denom; }
+	bool IsLinearTempo() { return m_bLinearTempo; }
+	void SetIsLinearTempo(bool bLinearTempo) { m_bLinearTempo = bLinearTempo; }
+	RawTempoMarkerData GetRawMarkerData() { return m_rawData; }
+	void SetRawMarkerData(RawTempoMarkerData rawData) { m_rawData = rawData; };
+
+protected:
+	double m_dTimePos;
+	int m_measurePos;
+	double m_dBeatPos;
+	double m_dBpm;
+	int m_timesig_num;
+	int m_timesig_denom;
+	bool m_bLinearTempo;
+	RawTempoMarkerData m_rawData;
+
+};
+
+
+
+bool GetAllTempoMarkers(WDL_PtrList<void>* _tempoMarkers, ReaProject* _proj);
+bool GetTempoMarkersInInterval(WDL_PtrList<void>* _tempoMarkers, ReaProject* _proj, double _pos1, double _pos2);
+bool IsTempoMarkerInInterval(TempoMarker* _tempoMarker, double _pos1, double _pos2);
+bool DuplicateTempoMarkers(WDL_PtrList<void>* _tempoMarkers, ReaProject* _proj, const char* _undoTitle, double _nudgePos);
 #endif

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1867,6 +1867,8 @@ void AppendPasteCropPlaylist(RegionPlaylist* _playlist, const AppendPasteCropPla
 
 				WDL_PtrList<void> itemsToKeep;
 				GetItemsInInterval(&itemsToKeep, rgnpos, rgnend, false);
+				WDL_PtrList<void> tempoMarkersToKeep;
+				GetTempoMarkersInInterval(&tempoMarkersToKeep, NULL, rgnpos, rgnend);
 				// store regions
 				bool found = false;
 				for (int k = 0; !found && k<rgns.GetSize(); k++)
@@ -1891,6 +1893,7 @@ void AppendPasteCropPlaylist(RegionPlaylist* _playlist, const AppendPasteCropPla
 				for (int k = 0; k < plItem->m_cnt; k++)
 				{
 					DupSelItems(NULL, endPos-rgnpos, &itemsToKeep); // overrides the native ApplyNudge()
+					DuplicateTempoMarkers(&tempoMarkersToKeep, NULL, NULL, endPos - rgnpos);
 					endPos += (rgnend-rgnpos);
 				}
 
@@ -1995,6 +1998,8 @@ void AppendPasteCropPlaylist(RegionPlaylist* _playlist, const AppendPasteCropPla
 
 	Main_OnCommand(40296, 0); // select all tracks
 	Main_OnCommand(40210, 0); // copy tracks
+	WDL_PtrList<void> tempoMarkers;
+	GetAllTempoMarkers(&tempoMarkers, NULL);
 
 	PreventUIRefresh(-1);
 
@@ -2031,6 +2036,8 @@ void AppendPasteCropPlaylist(RegionPlaylist* _playlist, const AppendPasteCropPla
 	// new project: the playlist is empty at this point
 	g_pls.Get()->Add(dupPlaylist);
 	g_pls.Get()->m_editId = 0;
+
+	DuplicateTempoMarkers(&tempoMarkers, NULL, NULL, 0);
 
 	PreventUIRefresh(-1);
 	SNM_UIRefresh(NULL);


### PR DESCRIPTION
…ers fixes #1462

Pretty new to this so feel free to review and comment anything that could be done better.
As commit name says, this makes it that the region playlist "Append" and "Crop" commands also take in account tempo markers.
Tested on windows on a quite complex session successfully.
The whole part with chunks is because we needed to have also the "Metronome Pattern" data duplicated, but it isn't accessible via standard getters and setters.