### PR TITLE
Fix persisting colors on macOS [Fix #1564]

### DIFF
--- a/Color/Color.cpp
+++ b/Color/Color.cpp
@@ -45,9 +45,8 @@ static bool g_bRecRedRuler = false;
 
 void UpdateCustomColors()
 {
-#ifndef __APPLE__
 	GetPrivateProfileStruct("REAPER", "custcolors", g_custColors, sizeof(g_custColors), get_ini_file());
-#else
+#ifdef __APPLE__
 	GetCustomColors(g_custColors);
 #endif
 }
@@ -66,9 +65,8 @@ void PersistColors()
 	char str[256];
 	sprintf(str, "%d %d", g_crGradStart, g_crGradEnd);
 	WritePrivateProfileString(SWS_INI, GRADIENT_COLOR_KEY, str, get_ini_file());
-#ifndef __APPLE__
 	WritePrivateProfileStruct("REAPER", "custcolors", g_custColors, sizeof(g_custColors), get_ini_file());
-#else
+#ifdef __APPLE__
 	SetCustomColors(g_custColors);
 #endif
 }


### PR DESCRIPTION
We are not persisting the custom colors to REAPER.ini on macOS for some reason. The user has to restore the custom colors every time Reaper is restarted. This fixes #1564 

It would be nice with an explanation as to why we weren't doing this in the first place and if I might have missed something vital.
