### PR TITLE
Add support for REAPER 6.38 custom note order/visibility mode

### DIFF
--- a/Breeder/BR_MidiUtil.h
+++ b/Breeder/BR_MidiUtil.h
@@ -45,7 +45,8 @@ enum BR_MidiNoteshow
 {
 	SHOW_ALL_NOTES             = 0,
 	HIDE_UNUSED_NOTES          = 1,
-	HIDE_UNUSED_UNNAMED_NOTES  = 2
+	HIDE_UNUSED_UNNAMED_NOTES  = 2,
+	CUSTOM_NOTES_VIEW          = 3,
 };
 
 /******************************************************************************
@@ -138,6 +139,7 @@ public:
 
 	/* Misc */
 	HWND GetEditor ();
+	vector<int> GetUsedNamedNotes ();
 
 	/* Check if MIDI editor data is valid - should call right after creating the object  */
 	bool IsValid ();
@@ -154,7 +156,7 @@ private:
 	double m_filterEventPosRepeat, m_filterEventPosLo, m_filterEventPosHi, m_filterEventLenLo, m_filterEventLenHi;
 	bool m_filterEnabled, m_filterInverted, m_filterEventParam, m_filterEventVal, m_filterEventPos, m_filterEventLen;
 	bool m_valid;
-	vector<int> m_ccLanes, m_ccLanesHeight;
+	vector<int> m_ccLanes, m_ccLanesHeight, m_notesOrder;
 };
 
 /******************************************************************************
@@ -217,7 +219,6 @@ double ME_PositionAtMouseCursor (bool checkRuler, bool checkCCLanes);
 /******************************************************************************
 * Miscellaneous                                                               *
 ******************************************************************************/
-vector<int> GetUsedNamedNotes (HWND midiEditor, MediaItem_Take* take, bool used, bool named, int channelForNames);
 vector<int> GetSelectedNotes (MediaItem_Take* take);
 vector<int> MuteUnselectedNotes (MediaItem_Take* take); // returns previous mute state of all notes
 set<int> GetUsedCCLanes (HWND midiEditor, int detect14bit, bool selectedEventsOnly); // detect14bit: 0-> don't detect 14-bit, 1->detect partial 14-bit (count both 14 bit lanes and their counterparts) 2->detect full 14-bit (detect only if all CCs that make it have exactly same time positions)

--- a/Breeder/BR_MouseUtil.cpp
+++ b/Breeder/BR_MouseUtil.cpp
@@ -865,8 +865,8 @@ bool BR_MouseInfo::GetContextMIDI (POINT p, HWND hwnd, BR_MouseInfo::MouseInfo& 
 		ScreenToClient(segmentHwnd, &p);
 		RECT r; GetClientRect(segmentHwnd, &r);
 
-		if (midiEditor.GetPianoRoll() == 0 || midiEditor.GetPianoRoll() == 1)
-			mouseInfo.pianoRollMode = midiEditor.GetPianoRoll();
+		// ignoring extra flags from GetPianoRoll() (eg. custom note order mode=0x10000)
+		mouseInfo.pianoRollMode = midiEditor.GetPianoRoll() & 0xffff;
 
 		// Make sure mouse is really in note editing area
 		if (cursorSegment == MIDI_WND_NOTEVIEW)
@@ -962,7 +962,7 @@ bool BR_MouseInfo::GetContextMIDI (POINT p, HWND hwnd, BR_MouseInfo::MouseInfo& 
 					if (realMouseY > 0)
 					{
 						bool processKeyboardSeparately = true;
-						vector<int> visibleNoteRows = GetUsedNamedNotes(mouseInfo.midiEditor, NULL, midiEditor.GetNoteshow() != SHOW_ALL_NOTES, midiEditor.GetNoteshow() == HIDE_UNUSED_UNNAMED_NOTES, midiEditor.GetDrawChannel());
+						const vector<int> visibleNoteRows = midiEditor.GetUsedNamedNotes();
 
 						if (cursorSegment == MIDI_WND_NOTEVIEW)
 							processKeyboardSeparately = false;
@@ -1088,8 +1088,7 @@ bool BR_MouseInfo::GetContextMIDIInline (BR_MouseInfo::MouseInfo& mouseInfo, int
 		mouseInfo.window = "midi_editor";
 		mouseInfo.inlineMidi = true;
 
-		if (midiEditor.GetPianoRoll() == 0 || midiEditor.GetPianoRoll() == 1)
-			mouseInfo.pianoRollMode = midiEditor.GetPianoRoll();
+		mouseInfo.pianoRollMode = midiEditor.GetPianoRoll() & 0xffff;
 
 		// Get heights of various elements
 		int ccFullHeight = midiEditor.GetCCLanesFullheight(false);


### PR DESCRIPTION
Enabling custom note view mode sets `m_noteshow` to `3` and `m_pianoroll` to `0x10000 | 1`.