### PR TITLE
Zoom actions: fix honoring track height lock, avoid potential division by zero crash

### DIFF
--- a/Zoom.cpp
+++ b/Zoom.cpp
@@ -116,6 +116,7 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 	if (bMinimizeOthers)
 	{
 		*ConfigVar<int>("vzoom2") = 0;
+		int iMinimizedTracks = 0;
 		// setting I_HEIGHTOVERRIDE to 0 on locked track effectively disables track lock
 		// see https://forum.cockos.com/showthread.php?p=2202082
 		for (int i = 0; i <= GetNumTracks(); i++)
@@ -123,12 +124,15 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 			MediaTrack* tr = CSurf_TrackFromID(i, false);
 			const bool locked = GetMediaTrackInfo_Value(tr, "B_HEIGHTLOCK");
 			if (!obeyHeightLock || !locked)
+			{
 				SetMediaTrackInfo_Value(tr, "I_HEIGHTOVERRIDE", locked ? minTrackHeight : 0);
+				iMinimizedTracks += 1;
+			}		
 		}
 
 		Main_OnCommand(40112, 0); // Zoom out vert to minimize envelope lanes too (since vZoom is now 0) (calls refresh)
-		//TrackList_AdjustWindows(false);
-		//UpdateTimeline();
+		if (iMinimizedTracks <= 1) // ignore master track since there can be no items on it
+			return;
 
 		// Get the size of shown but not zoomed tracks
 		int iNotZoomedSize = 0;
@@ -150,7 +154,7 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 				{
 					int trackHeight = 0;
 					if (obeyHeightLock && locked)
-						GetSetMediaTrackInfo(tr, "I_HEIGHTOVERRIDE", &trackHeight);
+						trackHeight = static_cast<int>(GetMediaTrackInfo_Value(tr, "I_HEIGHTOVERRIDE"));
 					else
 						trackHeight = GetTrackHeightFromVZoomIndex(tr, 0);
 
@@ -249,7 +253,7 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 				{
 					const bool locked = GetMediaTrackInfo_Value(tr, "B_HEIGHTLOCK");
 					if (obeyHeightLock && locked)
-						GetSetMediaTrackInfo(tr, "I_HEIGHTOVERRIDE", &trackHeight);
+						trackHeight = static_cast<int>(GetMediaTrackInfo_Value(tr, "I_HEIGHTOVERRIDE"));
 					else
 						trackHeight = GetTrackHeightFromVZoomIndex(tr, iZoom);
 


### PR DESCRIPTION
closes #1577

@cfillion Re: https://github.com/reaper-oss/sws/issues/1577#issuecomment-968114970
Not sure how it happened (doesn't matter in the end), but wrong code seems to have sneaked in somehow
[here](https://github.com/reaper-oss/sws/blob/5d31e552ad3bcec8e03b0344d1833ea4d2f5fbf6/Zoom.cpp#L153) and [here](https://github.com/reaper-oss/sws/blob/5d31e552ad3bcec8e03b0344d1833ea4d2f5fbf6/Zoom.cpp#L252).
This _sets_ the track height rather than getting it as per your suggestion https://github.com/reaper-oss/sws/pull/1414#issuecomment-707447408, doesn't it?
That's why the actions didn't behave as intended I think (minimizing height locked tracks).

edit:
Oh was it this perhaps? :) (I'm not good at Git blame :P)
https://github.com/reaper-oss/sws/pull/1414#issuecomment-709520114
I'll cast to int then.

Also put in a check to avoid the potential division by zero but not sure if there's a better way.

edit:
Updated the div. by zero code.
