### PR TITLE
Improve iteration in UnregisterAllCmds()

### DIFF
--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -307,25 +307,27 @@ bool SWSFreeUnregisterDynamicCmd(int id)
 	return false;
 }
 
+void SWSUnregisterCmdImpl(COMMAND_T* ct)
+{
+	if (!ct->uniqueSectionId && ct->doCommand)
+	{
+		plugin_register("-gaccel", &ct->accel);
+	}
+	else if (ct->onAction)
+	{
+		static custom_action_register_t s;
+		s.idStr = ct->id;
+		s.uniqueSectionId = ct->uniqueSectionId;
+		plugin_register("-custom_action", (void*)&s);
+	}
+}
+
 // Returns the COMMAND_T entry (so it can be freed if necessary)
 COMMAND_T* SWSUnregisterCmd(int id)
 {
 	if (COMMAND_T* ct = g_commands.Get(id, NULL))
 	{
-		if (!ct->uniqueSectionId && ct->doCommand)
-		{
-			plugin_register("-gaccel", &ct->accel);
-/* this is no-op ATM
-			plugin_register("-command_id", &id);
-*/
-		}
-		else if (ct->onAction)
-		{
-			static custom_action_register_t s;
-			s.idStr = ct->id;
-			s.uniqueSectionId = ct->uniqueSectionId;
-			plugin_register("-custom_action", (void*)&s);
-		}
+		SWSUnregisterCmdImpl(ct);
 		g_commands.Delete(id);
 #ifdef ACTION_DEBUG
 		g_cmdFiles.Delete(id);
@@ -336,8 +338,10 @@ COMMAND_T* SWSUnregisterCmd(int id)
 }
 
 void UnregisterAllCmds() {
-	for (int i=g_iFirstCommand; i<=g_iLastCommand; i++)
-		SWSUnregisterCmd(i);
+	for (int i = 0; i < g_commands.GetSize(); ++i) {
+		SWSUnregisterCmdImpl(*g_commands.EnumeratePtr(i));
+	}
+	g_commands.DeleteAll();
 }
 
 #ifdef ACTION_DEBUG


### PR DESCRIPTION
The current dev version of REAPER increases the command ID space to over 1G possible entries. In that version, `UnregisterAllCmds()` takes a noticeable amount of time to run when REAPER is quit. The proposal enumerates over only registered commands, rather than the entire available range.