### PR TITLE
Support 32-bit action IDs (added in v6.43+dev1222)

### DIFF
--- a/Breeder/BR.cpp
+++ b/Breeder/BR.cpp
@@ -97,7 +97,7 @@ bool BR_GlobalActionHook (int cmd, int val, int valhw, int relmode, HWND hwnd)
 
 bool BR_SwsActionHook (COMMAND_T* ct, int flagOrRelmode, HWND hwnd)
 {
-	int cmd = ct->accel.accel.cmd;
+	const int cmd = ct->cmdId;
 
 	// Action applies next action
 	if (cmd >= g_nextActionLoCmd && cmd <= g_nextActionHiCmd && g_nextActionApplyers.find(cmd) != g_nextActionApplyers.end())

--- a/Color/Color.cpp
+++ b/Color/Color.cpp
@@ -1109,13 +1109,13 @@ static void menuhook(const char* menustr, HMENU hMenu, int flag)
 			i++;
 		do
 		{
-			AddToMenuOrdered(hSubMenu, __localizeFunc(g_commandTable[i].menuText,"sws_menu",0), g_commandTable[i].accel.accel.cmd);
+			AddToMenuOrdered(hSubMenu, __localizeFunc(g_commandTable[i].menuText,"sws_menu",0), g_commandTable[i].cmdId);
 			i++;
 		}
 		while (!(g_commandTable[i-1].doCommand == pLastCommand && g_commandTable[i-1].user == 15));
 
 		// Finish with color dialog
-		AddToMenuOrdered(hSubMenu, __localizeFunc(g_commandTable[0].menuText,"sws_menu",0), g_commandTable[0].accel.accel.cmd);
+		AddToMenuOrdered(hSubMenu, __localizeFunc(g_commandTable[0].menuText,"sws_menu",0), g_commandTable[0].cmdId);
 
 		if (menuid == 0)
 			AddSubMenu(hMenu, hSubMenu, __LOCALIZE("SWS track color","sws_menu"), 40359);

--- a/Fingers/CommandHandler.cpp
+++ b/Fingers/CommandHandler.cpp
@@ -181,9 +181,7 @@ int RprCommandManager::getCommandId(const char *id)
         me->mSWSCommands.end(), SWSCommandFinder(id));
 
     if (command != me->mSWSCommands.end())
-    {
-        return command->accel.accel.cmd;
-    }
+        return command->cmdId;
     return -1;
 }
 

--- a/MarkerActions/MarkerActions.cpp
+++ b/MarkerActions/MarkerActions.cpp
@@ -212,7 +212,7 @@ static COMMAND_T g_commandTable[] =
 
 static void RefreshMAToolbar()
 {
-	RefreshToolbar(g_commandTable[0].accel.accel.cmd);
+	RefreshToolbar(g_commandTable[0].cmdId);
 }
 
 int MarkerActionsInit()

--- a/Misc/FolderActions.cpp
+++ b/Misc/FolderActions.cpp
@@ -202,7 +202,7 @@ int FolderActionsInit()
 	int i = -1;
 	while (g_commandTable[++i].id != LAST_COMMAND)
 		if (g_commandTable[i].doCommand == IndentTracks || g_commandTable[i].doCommand == UnindentTracks)
-			AddToMenu(hTrackMenu, g_commandTable[i].menuText, g_commandTable[i].accel.accel.cmd);*/
+			AddToMenu(hTrackMenu, g_commandTable[i].menuText, g_commandTable[i].cmdId);*/
 
 	return 1;
 }

--- a/Projects/ProjectList.cpp
+++ b/Projects/ProjectList.cpp
@@ -123,8 +123,8 @@ void SWS_ProjectListWnd::OnCommand(WPARAM wParam, LPARAM lParam)
 HMENU SWS_ProjectListWnd::OnContextMenu(int x, int y, bool* wantDefaultItems)
 {
 	HMENU hMenu = CreatePopupMenu();
-	AddToMenu(hMenu, __localizeFunc(g_projMgrCmdTable[0].menuText,"sws_menu",0), g_projMgrCmdTable[0].accel.accel.cmd);
-	AddToMenu(hMenu, __localizeFunc(g_projMgrCmdTable[1].menuText,"sws_menu",0), g_projMgrCmdTable[1].accel.accel.cmd);
+	AddToMenu(hMenu, __localizeFunc(g_projMgrCmdTable[0].menuText,"sws_menu",0), g_projMgrCmdTable[0].cmdId);
+	AddToMenu(hMenu, __localizeFunc(g_projMgrCmdTable[1].menuText,"sws_menu",0), g_projMgrCmdTable[1].cmdId);
 	return hMenu;
 }
 

--- a/Projects/ProjectMgr.cpp
+++ b/Projects/ProjectMgr.cpp
@@ -368,7 +368,7 @@ static void menuhook(const char* menustr, HMENU hMenu, int flag)
 		// Delete all related project entries and regenerate
 		int iFirstPos;
 
-		hMenu = FindMenuItem(hMenu, g_projMgrCmdTable[g_iORPCmdIndex].accel.accel.cmd, &iFirstPos);
+		hMenu = FindMenuItem(hMenu, g_projMgrCmdTable[g_iORPCmdIndex].cmdId, &iFirstPos);
 
 		if (hMenu)
 		{
@@ -396,7 +396,7 @@ static void menuhook(const char* menustr, HMENU hMenu, int flag)
 				mi.fType = MFT_STRING;
 				mi.fState = MFS_GRAYED;
 				mi.dwTypeData = (char *)__localizeFunc(g_projMgrCmdTable[g_iORPCmdIndex].menuText,"sws_menu",0);
-				mi.wID = g_projMgrCmdTable[g_iORPCmdIndex].accel.accel.cmd;
+				mi.wID = g_projMgrCmdTable[g_iORPCmdIndex].cmdId;
 				InsertMenuItem(hMenu, iFirstPos, true, &mi);
 			}
 			else

--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -948,23 +948,23 @@ void ExclusiveToggle(COMMAND_T* _ct)
 		for (INT_PTR i=0; i<SNM_MAX_DYN_ACTIONS; i++)
 			if (COMMAND_T* ct = SWSGetCommand(_ct->doCommand, i))
 			{
-				if (ct->accel.accel.cmd != _ct->accel.accel.cmd) {
+				if (ct->cmdId != _ct->cmdId) {
 					ct->fakeToggle = false;
-					RefreshToolbar(ct->accel.accel.cmd);
+					RefreshToolbar(ct->cmdId);
 				}
 			}
 			else
 				break;
 */
 	//JFB! enough ATM but relies on *ordered* cmds, cmd ids, etc
-	int id = _ct->accel.accel.cmd - (int)_ct->user;
+	int id = _ct->cmdId - (int)_ct->user;
 	for (int i=0; i<SNM_MAX_DYN_ACTIONS; i++)
 	{
 		if (COMMAND_T* ct = SWSGetCommandByID(id+i))
 		{
 			if ((int)ct->user == i) // real break condition
 			{
-				if (ct->accel.accel.cmd != _ct->accel.accel.cmd)
+				if (ct->cmdId != _ct->cmdId)
 					ct->fakeToggle = false;
 			}
 			else

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -72,9 +72,8 @@ static WDL_IntKeyedArray<WDL_String*> g_cmdFiles(freeCmdFilesValue);
 #endif
 static WDL_IntKeyedArray<COMMAND_T*> g_commands; // no valdispose (cmds can be allocated in different ways)
 
-int g_iFirstCommand = 0;
-int g_iLastCommand = 0;
-
+static int g_iFirstCommand;
+static int g_iLastCommand;
 
 bool hookCommandProc(int iCmd, int flag)
 {
@@ -102,7 +101,7 @@ bool hookCommandProc(int iCmd, int flag)
 		if (BR_SwsActionHook(cmd, flag, NULL))
 			return true;
 
-		if (!cmd->uniqueSectionId && cmd->accel.accel.cmd==iCmd && cmd->doCommand)
+		if (!cmd->uniqueSectionId && cmd->cmdId == iCmd && cmd->doCommand)
 		{
 			if (sReentrantCmds.Find(cmd->id)<0)
 			{
@@ -141,7 +140,7 @@ bool hookCommandProc2(KbdSectionInfo* sec, int cmdId, int val, int valhw, int re
 	// Ignore commands that don't have anything to do with us from this point forward
 	if (COMMAND_T* cmd = SWSGetCommandByID(cmdId))
 	{
-		if (cmd->uniqueSectionId==sec->uniqueID && cmd->accel.accel.cmd==cmdId)
+		if (cmd->uniqueSectionId==sec->uniqueID && cmd->cmdId==cmdId)
 		{
 			// job for hookCommandProc?
 			// note: we could perform cmd->doCommand() here, but we'd loose the "flag" param value
@@ -198,7 +197,7 @@ int toggleActionHook(int iCmd)
 	static WDL_PtrList<const char> sReentrantCmds;
 	if (COMMAND_T* cmd = SWSGetCommandByID(iCmd))
 	{
-		if (cmd->accel.accel.cmd==iCmd && cmd->getEnabled)
+		if (cmd->cmdId==iCmd && cmd->getEnabled)
 		{
 			if (sReentrantCmds.Find(cmd->id) == -1)
 			{
@@ -250,7 +249,7 @@ int SWSRegisterCmd(COMMAND_T* pCommand, const char* cFile, int cmdId, bool local
 	}
 	else
 		cmdId = 0;
-	pCommand->accel.accel.cmd = cmdId;
+	pCommand->cmdId = cmdId;
 
 	// now that it is registered, restore the default action name
 	if (pCommand->accel.desc != defaultName) pCommand->accel.desc = defaultName;
@@ -265,7 +264,7 @@ int SWSRegisterCmd(COMMAND_T* pCommand, const char* cFile, int cmdId, bool local
 	g_cmdFiles.Insert(cmdId, new WDL_String(cFile));
 #endif
 
-	return pCommand->accel.accel.cmd;
+	return pCommand->cmdId;
 }
 
 // For each item in table call SWSRegisterCommand
@@ -358,8 +357,8 @@ void ActionsList(COMMAND_T*)
 			{
 				if (COMMAND_T* cmd = g_commands.Enumerate(i, NULL, NULL))
 				{
-					WDL_String* pFn = g_cmdFiles.Get(cmd->accel.accel.cmd, NULL);
-					snprintf(cBuf, sizeof(cBuf), "\"%s\",%s,%d,_%s\n", cmd->accel.desc, pFn ? pFn->Get() : "", cmd->accel.accel.cmd, cmd->id);
+					WDL_String* pFn = g_cmdFiles.Get(cmd->cmdId, NULL);
+					snprintf(cBuf, sizeof(cBuf), "\"%s\",%s,%d,_%s\n", cmd->accel.desc, pFn ? pFn->Get() : "", cmd->cmdId, cmd->id);
 					fputs(cBuf, f);
 				}
 			}
@@ -381,7 +380,7 @@ int SWSGetCommandID(void (*cmdFunc)(COMMAND_T*), INT_PTR user, const char** pMen
 			{
 				if (pMenuText)
 					*pMenuText = cmd->menuText;
-				return cmd->accel.accel.cmd;
+				return cmd->cmdId;
 			}
 		}
 	}
@@ -425,7 +424,7 @@ HMENU SWSCreateMenuFromCommandTable(COMMAND_T pCommands[], HMENU hMenu, int* iIn
 				AddSubMenu(hMenu, hSubMenu, __localizeFunc(name,"sws_menu",0));
 			}
 			else
-				AddToMenu(hMenu, __localizeFunc(name,"sws_menu",0), pCommands[i].accel.accel.cmd);
+				AddToMenu(hMenu, __localizeFunc(name,"sws_menu",0), pCommands[i].cmdId);
 		}
 		i++;
 	}

--- a/sws_util.h
+++ b/sws_util.h
@@ -93,6 +93,7 @@ typedef struct COMMAND_T
 	int uniqueSectionId;
 	void(*onAction)(COMMAND_T*, int, int, int, HWND);
 	bool fakeToggle;
+	int cmdId;
 } COMMAND_T;
 
 
@@ -152,8 +153,6 @@ extern int g_i1;
 extern int g_i2;
 extern bool g_bTrue;
 extern bool g_bFalse;
-extern int g_iFirstCommand;
-extern int g_iLastCommand;
 extern MTRand g_MTRand;
 
 // Stuff to do in swell someday


### PR DESCRIPTION
Main section actions (registered using `command_id`+`gaccel`) remain 16-bit (limited by the `ACCEL` structure from Windows/SWELL using a `short`).

Other sections (registered using `custom_action`) were expanded to a 32-bit ID.