### PR TITLE
Don't unregister commands when REAPER quits

### DIFF
--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -335,11 +335,6 @@ COMMAND_T* SWSUnregisterCmd(int id)
 	return NULL;
 }
 
-void UnregisterAllCmds() {
-	for (int i=g_iFirstCommand; i<=g_iLastCommand; i++)
-		SWSUnregisterCmd(i);
-}
-
 #ifdef ACTION_DEBUG
 void ActionsList(COMMAND_T*)
 {
@@ -660,7 +655,6 @@ extern "C"
 error:
 			if (plugin_register)
 			{
-				UnregisterAllCmds();
 				plugin_register("-hookcommand2", (void*)hookCommandProc2);
 				plugin_register("-hookcommand", (void*)hookCommandProc);
 //				plugin_register("-hookpostcommand", (void*)hookPostCommandProc);


### PR DESCRIPTION
according to Justin's comment:
"SWS should be updated to not unregister IDs it doesn't own (or not unregister IDs at all, really)"
https://forum.cockos.com/showthread.php?p=2509487#post2509487

Would probably supersede #1591.
I've left `SWSUnregisterCmd()` in because it's also used by Cycle actions (`FlushCycleactions()`).
