### PR TITLE
acendan: Squashed commit. Add ReaScript API: AC_GetMediaFileCoverImage()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,7 @@ add_subdirectory(TrackList)
 add_subdirectory(Utility)
 add_subdirectory(Wol)
 add_subdirectory(Xenakios)
+add_subdirectory(acendan)
 
 # the langpack target must be included after all sources files are registered
 add_subdirectory(BuildUtils)

--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -36,6 +36,7 @@
 #include "snooks/SN_ReaScript.h"
 #include "cfillion/cfillion.hpp"
 #include "nofish/NF_ReaScript.h"
+#include "acendan/AC_ReaScript.h"
 #include "Misc/Analysis.h"
 
 
@@ -351,6 +352,8 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetMediaSourceRPP), "bool", "PCM_source*,char*,int", "src,fnOut,fnOut_sz", "Get the project associated with this source (BWF, subproject...).", },
 	{ APIFUNC(CF_EnumMediaSourceCues), "int", "PCM_source*,int,double*,double*,bool*,char*,int,bool*", "src,index,timeOut,endTimeOut,isRegionOut,nameOut,nameOut_sz,isChapterOut", "Enumerate the source's media cues. Returns the next index or 0 when finished.", },
 	{ APIFUNC(CF_ExportMediaSource), "bool", "PCM_source*,const char*", "src,fn", "Export the source to the given file (MIDI only).", },
+
+	{ APIFUNC(AC_GetMediaFileCoverImage), "bool", "const char*,char*,int", "path,temppathOut,temppathOut_sz", "Returns a temp path with the given file's embedded cover image, if found. Supports WAV, MP3, FLAC, MP4, ASF, APE, MPC", },
 
 	{ NULL, } // denote end of table
 };

--- a/acendan/AC_ReaScript.cpp
+++ b/acendan/AC_ReaScript.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+/ AC_ReaScript.cpp
+/
+/ Copyright (c) 2022 acendan
+/ https://forum.cockos.com/member.php?u=142333
+/ https://github.com/acendan/reascripts
+/ https://aaroncendan.me
+/
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+
+#include "stdafx.h"
+#include "AC_ReaScript.h"
+#include "acendan.h"
+
+bool AC_GetMediaFileCoverImage(const char* path, char* temppathOut, int temppathOut_sz)
+{
+	return acendan::GetMediaFileCoverImage(path, temppathOut, temppathOut_sz);
+}

--- a/acendan/AC_ReaScript.h
+++ b/acendan/AC_ReaScript.h
@@ -1,0 +1,34 @@
+/******************************************************************************
+/ AC_ReaScript.h
+/
+/ Copyright (c) 2022 acendan
+/ https://forum.cockos.com/member.php?u=142333
+/ https://github.com/acendan/reascripts
+/ https://aaroncendan.me
+/
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#pragma once
+
+// acendan ReaScript API
+bool AC_GetMediaFileCoverImage(const char* path, char* temppathOut, int temppathOut_sz);

--- a/acendan/CMakeLists.txt
+++ b/acendan/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(sws
+PRIVATE
+  AC_ReaScript.cpp
+  acendan.cpp
+  cover.cpp
+)

--- a/acendan/acendan.cpp
+++ b/acendan/acendan.cpp
@@ -1,0 +1,74 @@
+/******************************************************************************
+/ acendan.cpp
+/
+/ Copyright (c) 2022 acendan
+/ https://forum.cockos.com/member.php?u=142333
+/ https://github.com/acendan/reascripts
+/ https://aaroncendan.me
+/
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#include "stdafx.h"
+#include "acendan.h"
+#include "cover.h"
+
+namespace acendan
+{
+	Player player;
+	
+	// Load the image data from a file into a temp .jpg file. Temp file is destroyed on REAPER shutdown.
+	bool GetMediaFileCoverImage(const char* path, char* temppathOut, int temppathOut_sz)
+	{
+		if (!path || !*path || !temppathOut || temppathOut_sz <= 0) return false;
+		*temppathOut = 0;
+
+		if (acendan::player.FindCover(path))
+		{
+			const auto& coverPath = acendan::player.GetCoverPath();
+			if (!coverPath.empty())
+			{
+				snprintf(temppathOut, temppathOut_sz, "%s", coverPath.c_str());
+			}
+		}
+
+		return !!*temppathOut;
+	}
+}
+
+/******************************************************************************/
+// Register commands in Actions List - must have !WANT_LOCAL... comments!
+// { { DEFACCEL, "ACendan: Hello World" }, "AC_HELLO_WORLD", acendan::HelloWorld, NULL },
+
+//!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
+static COMMAND_T g_commandTable[] =
+{
+
+	{ {}, LAST_COMMAND, },
+};
+//!WANT_LOCALIZE_1ST_STRING_END
+
+int acendan_Init()
+{
+	SWSRegisterCommands(g_commandTable);
+	return 1;
+}

--- a/acendan/acendan.h
+++ b/acendan/acendan.h
@@ -1,0 +1,37 @@
+/******************************************************************************
+/ acendan.h
+/
+/ Copyright (c) 2022 acendan
+/ https://forum.cockos.com/member.php?u=142333
+/ https://github.com/acendan/reascripts
+/ https://aaroncendan.me
+/
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+#pragma once
+
+int acendan_Init();
+
+namespace acendan
+{
+	bool GetMediaFileCoverImage(const char* path, char* temppathOut, int temppathOut_sz);
+}

--- a/acendan/cover.cpp
+++ b/acendan/cover.cpp
@@ -1,0 +1,321 @@
+/******************************************************************************
+/ cover.cpp
+/
+/ Copyright (c) 2022 acendan
+/ https://forum.cockos.com/member.php?u=142333
+/ https://github.com/acendan/reascripts
+/ https://aaroncendan.me
+/
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+
+#include "stdafx.h"
+#include "cover.h"
+
+#include <taglib/ape/apefile.h>
+#include <taglib/ape/apetag.h>
+#include <taglib/asf/asffile.h>
+#include <taglib/mpeg/id3v1/id3v1genres.h>
+#include <taglib/mpeg/id3v2/id3v2tag.h>
+#include <taglib/mpeg/id3v2/frames/attachedpictureframe.h>
+#include <taglib/mpeg/id3v2/frames/commentsframe.h>
+#include <taglib/mpeg/id3v2/frames/textidentificationframe.h>
+#include <taglib/flac/flacfile.h>
+#include <taglib/mpc/mpcfile.h>
+#include <taglib/mpeg/mpegfile.h>
+#include <taglib/mp4/mp4file.h>
+#include <taglib/tag.h>
+#include <taglib/toolkit/taglib.h>
+#include <taglib/toolkit/tstring.h>
+#include <taglib/ogg/vorbis/vorbisfile.h>
+#include <taglib/riff/wav/wavfile.h>
+
+#include <sys/stat.h>		// For FileExists()
+
+/******************************************************************************/
+namespace
+{
+	// Check whether file exists on filesystem. Could be swapped with std::filesystem::exists() if needed/preferred.
+	bool FileExists(const std::string& filepath)
+	{
+		struct stat buffer;
+		return (stat(filepath.c_str(), &buffer) == 0);
+	}
+
+	// Get temporary file for cover art image
+	std::string GetTempFilePath(const std::string& extension = ".jpg")
+	{
+		char buffer[L_tmpnam];
+		tmpnam(buffer);
+		std::string tempFile = buffer;
+		tempFile = tempFile.substr(0, tempFile.find_last_of(".")) + extension;
+		return tempFile;
+	}
+
+	// Write ByteVector image data to file
+	bool WriteCoverToFile(const TagLib::ByteVector& data, const std::string& target)
+	{
+		FILE* f = fopen(target.c_str(), "wb");
+		if (f)
+		{
+			const bool written = fwrite(data.data(), 1, data.size(), f) == data.size();
+			fclose(f);
+			return written;
+		}
+
+		return false;
+	}
+
+	// APE: https://www.monkeysaudio.com/developers.html
+	bool ExtractCoverAPE(TagLib::APE::Tag* tag, const std::string& target)
+	{
+		const TagLib::APE::ItemListMap& listMap = tag->itemListMap();
+		if (listMap.contains("COVER ART (FRONT)"))
+		{
+			const TagLib::ByteVector nullStringTerminator(1, 0);
+			TagLib::ByteVector item = listMap["COVER ART (FRONT)"].value();
+			const int pos = item.find(nullStringTerminator);	// Skip the filename.
+			if (pos != -1)
+			{
+				const TagLib::ByteVector& pic = item.mid(pos + 1);
+				return WriteCoverToFile(pic, target);
+			}
+		}
+
+		return false;
+	}
+
+	// ID3: https://id3.org/
+	bool ExtractCoverID3(TagLib::ID3v2::Tag* tag, const std::string& target)
+	{
+		const TagLib::ID3v2::FrameList& frameList = tag->frameList("APIC");
+		if (!frameList.isEmpty())
+		{
+			// Just grab the first image.
+			const auto* frame = (TagLib::ID3v2::AttachedPictureFrame*)frameList.front();
+			return WriteCoverToFile(frame->picture(), target);
+		}
+
+		return false;
+	}
+
+	// ASF: https://docs.microsoft.com/en-us/windows/win32/wmformat/overview-of-the-asf-format
+	bool ExtractCoverASF(TagLib::ASF::File* file, const std::string& target)
+	{
+		const TagLib::ASF::AttributeListMap& attrListMap = file->tag()->attributeListMap();
+		if (attrListMap.contains("WM/Picture"))
+		{
+			const TagLib::ASF::AttributeList& attrList = attrListMap["WM/Picture"];
+			if (!attrList.isEmpty())
+			{
+				// Let's grab the first cover. TODO: Check/loop for correct type.
+				const TagLib::ASF::Picture& wmpic = attrList[0].toPicture();
+				if (wmpic.isValid())
+				{
+					return WriteCoverToFile(wmpic.picture(), target);
+				}
+			}
+		}
+
+		return false;
+	}
+
+	// FLAC: https://xiph.org/flac/
+	bool ExtractCoverFLAC(TagLib::FLAC::File* file, const std::string& target)
+	{
+		const TagLib::List<TagLib::FLAC::Picture*>& picList = file->pictureList();
+		if (!picList.isEmpty())
+		{
+			// Just grab the first image.
+			const TagLib::FLAC::Picture* pic = picList[0];
+			return WriteCoverToFile(pic->data(), target);
+		}
+
+		return false;
+	}
+
+	// MPEG: https://www.mpeg.org/
+	bool ExtractCoverMP4(TagLib::MP4::File* file, const std::string& target)
+	{
+		TagLib::MP4::Tag* tag = file->tag();
+		const TagLib::MP4::ItemListMap& itemListMap = tag->itemListMap();
+		if (itemListMap.contains("covr"))
+		{
+			const TagLib::MP4::CoverArtList& coverArtList = itemListMap["covr"].toCoverArtList();
+			if (!coverArtList.isEmpty())
+			{
+				const TagLib::MP4::CoverArt* pic = &(coverArtList.front());
+				return WriteCoverToFile(pic->data(), target);
+			}
+		}
+
+		return false;
+	}
+
+}  // namespace
+
+
+/******************************************************************************/
+// Checks if cover art is in cache.
+bool CCover::GetCached(std::string& path)
+{
+	path += ".art";
+	return FileExists(path);
+}
+
+// Attempts to find local cover art in various formats.
+bool CCover::GetLocal(std::string filename, const std::string& folder, std::string& target)
+{
+	std::string testPath = folder + filename + ".";
+	std::string::size_type origLen = testPath.length();
+
+	const int extCount = 4;
+	std::string extName[extCount] = { "jpg", "jpeg", "png", "bmp" };
+
+	for (int i = 0; i < extCount; ++i)
+	{
+		testPath += extName[i];
+		if (FileExists(testPath))
+		{
+			target = testPath;
+			return true;
+		}
+		else
+		{
+			// Get rid of the added extension
+			testPath.resize(origLen);
+		}
+	}
+
+	return false;
+}
+
+// Attempts to extract cover art from audio files.
+bool CCover::GetEmbedded(const TagLib::FileRef& fr, const std::string& target)
+{
+	bool found = false;
+
+	if (TagLib::MPEG::File* file = dynamic_cast<TagLib::MPEG::File*>(fr.file()))
+	{
+		if (file->ID3v2Tag())
+		{
+			found = ExtractCoverID3(file->ID3v2Tag(), target);
+		}
+		if (!found && file->APETag())
+		{
+			found = ExtractCoverAPE(file->APETag(), target);
+		}
+	}
+	else if (TagLib::FLAC::File* file = dynamic_cast<TagLib::FLAC::File*>(fr.file()))
+	{
+		found = ExtractCoverFLAC(file, target);
+
+		if (!found && file->ID3v2Tag())
+		{
+			found = ExtractCoverID3(file->ID3v2Tag(), target);
+		}
+	}
+	else if (TagLib::RIFF::WAV::File* file = dynamic_cast<TagLib::RIFF::WAV::File*>(fr.file()))
+	{
+		if (auto* tag = file->ID3v2Tag())
+		{
+			found = ExtractCoverID3(tag, target);
+		}
+	}
+	else if (TagLib::MP4::File* file = dynamic_cast<TagLib::MP4::File*>(fr.file()))
+	{
+		found = ExtractCoverMP4(file, target);
+	}
+	else if (TagLib::ASF::File* file = dynamic_cast<TagLib::ASF::File*>(fr.file()))
+	{
+		found = ExtractCoverASF(file, target);
+	}
+	else if (TagLib::APE::File* file = dynamic_cast<TagLib::APE::File*>(fr.file()))
+	{
+		if (file->APETag())
+		{
+			found = ExtractCoverAPE(file->APETag(), target);
+		}
+	}
+	else if (TagLib::MPC::File* file = dynamic_cast<TagLib::MPC::File*>(fr.file()))
+	{
+		if (file->APETag())
+		{
+			found = ExtractCoverAPE(file->APETag(), target);
+		}
+	}
+
+	return found;
+}
+
+// Returns path without filename
+std::string CCover::GetFileFolder(const std::string& file)
+{
+	std::string::size_type pos = file.find_last_of(L'\\');
+	if (pos != std::string::npos)
+	{
+		return file.substr(0, ++pos);
+	}
+
+	return file;
+}
+
+/******************************************************************************/
+Player::Player()
+{
+	m_TempCoverPath = GetTempFilePath();
+}
+
+Player::~Player()
+{
+	// Delete temp image file
+	std::remove(m_TempCoverPath.c_str());
+}
+
+bool Player::FindCover(const std::string& fp)
+{
+	m_FilePath = fp;
+	m_CoverPath.clear();
+
+	TagLib::FileRef fr(m_FilePath.c_str(), false);
+	if (!fr.isNull() && CCover::GetEmbedded(fr, m_TempCoverPath))
+	{
+		m_CoverPath = m_TempCoverPath;
+	}
+	else
+	{
+		std::string trackFolder = CCover::GetFileFolder(m_FilePath);
+
+		if (!CCover::GetLocal("cover", trackFolder, m_CoverPath) &&
+			!CCover::GetLocal("folder", trackFolder, m_CoverPath))
+		{
+			// Nothing found
+			m_CoverPath.clear();
+		}
+	}
+	return !m_CoverPath.empty();
+}
+
+std::string Player::GetCoverPath()
+{
+	return m_CoverPath;
+}

--- a/acendan/cover.h
+++ b/acendan/cover.h
@@ -1,0 +1,77 @@
+/******************************************************************************
+/ cover.h
+/
+/ Copyright (c) 2022 acendan
+/ https://forum.cockos.com/member.php?u=142333
+/ https://github.com/acendan/reascripts
+/ https://aaroncendan.me
+/
+/
+/ Permission is hereby granted, free of charge, to any person obtaining a copy
+/ of this software and associated documentation files (the "Software"), to deal
+/ in the Software without restriction, including without limitation the rights to
+/ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+/ of the Software, and to permit persons to whom the Software is furnished to
+/ do so, subject to the following conditions:
+/
+/ The above copyright notice and this permission notice shall be included in all
+/ copies or substantial portions of the Software.
+/
+/ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+/ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+/ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+/ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+/ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+/ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+/ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+/ OTHER DEALINGS IN THE SOFTWARE.
+/
+******************************************************************************/
+#pragma once
+
+#include <taglib/fileref.h>		// Required for forward declaration of CCover::GetEmbedded
+
+/******************************************************************************/
+/*
+* The following classes have been adapted from Rainmeter's implementation of
+* TagLib for parsing media cover art. Rainmeter is open source, covered under
+* a GNU GPL v2 license. See respective file attributions below...
+*
+* Copyright (C) 2011 Rainmeter Project Developers
+*
+* This Source Code Form is subject to the terms of the GNU General Public
+* License; either version 2 of the License, or (at your option) any later
+* version. If a copy of the GPL was not distributed with this file, You can
+* obtain one at <https://www.gnu.org/licenses/gpl-2.0.html>.
+*
+* Rainmeter/Library/NowPlaying/Cover.h
+* https://github.com/rainmeter/rainmeter/blob/master/Library/NowPlaying/Cover.h
+*/
+class CCover
+{
+public:
+	static bool GetCached(std::string& path);
+	static bool GetLocal(std::string filename, const std::string& folder, std::string& target);
+	static bool GetEmbedded(const TagLib::FileRef& fr, const std::string& target);
+	static std::string GetFileFolder(const std::string& file);
+};
+
+/******************************************************************************/
+/*
+* Rainmeter/Library/NowPlaying/Player.h
+* https://github.com/rainmeter/rainmeter/blob/master/Library/NowPlaying/Player.h
+*/
+class Player
+{
+public:
+	Player();
+	~Player();
+
+	bool FindCover(const std::string& fp);
+	std::string GetCoverPath();
+
+protected:
+	std::string m_TempCoverPath;	// Path to temp image file
+	std::string m_CoverPath;		// Path to cover art image
+	std::string m_FilePath;			// Path to media file
+};

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -57,6 +57,7 @@
 #include "Wol/wol.h"
 #include "nofish/nofish.h"
 #include "snooks/snooks.h"
+#include "acendan/acendan.h"
 
 #define LOCALIZE_IMPORT_PREFIX "sws_"
 #include <WDL/localize/localize-import.h>
@@ -1287,6 +1288,8 @@ error:
 			ERR_RETURN("nofish init error.")
 		if (!snooks_Init())
 			ERR_RETURN("snooks init error.")
+		if (!acendan_Init())
+			ERR_RETURN("acendan init error.")
 		if (!SNM_Init(rec)) // keep it as the last init (for cycle actions)
 			ERR_RETURN("S&M init error.")
 


### PR DESCRIPTION
1. acendan: Initial commit. Add ReaScript API: AC_GetMediaFileCoverImage()
2. Removed <codecvt>, was previously relying on wstrings for file I/O, but no longer needed for character encoding conversions.
3. Swap std::copy for snprintf. Add newline to end of files.

Tested: Win10, OSX 10.14.6, Linux Mint