### PR TITLE
Preserve CC shapes in REAPER v6 when using BR_MidiCCEvents

### DIFF
--- a/Breeder/BR_ProjState.h
+++ b/Breeder/BR_ProjState.h
@@ -122,13 +122,13 @@ public:
 	int  GetSlot ();
 	int CountSavedEvents();
 	double GetSourcePpqStart ();
-	void AddEvent (double ppqPos, int msg2, int msg3, int channel); // always add events in time order from first to last
+	void AddEvent (double ppqPos, int msg2, int msg3, int channel, int shape = 0, double beztension = 0); // always add events in time order from first to last
 
 private:
 	struct Event
 	{
-		double positionPpq;
-		int channel, msg2, msg3;
+		double positionPpq, beztension;
+		int channel, msg2, msg3, shape;
 		bool mute;
 		Event ();
 		Event (double positionPpq, int channel, int msg2, int msg3, bool mute);

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -996,6 +996,7 @@ error:
 		IMPAPI(MIDI_SetItemExtents); // v5.0pre (no data on exact build in whatsnew, but I'm pretty sure I never saw this in v4)
 		IMPAPI(MIDI_SetNote);
 		IMPAPI(MIDI_SetTextSysexEvt);
+		IMPAPI(MIDI_Sort); IMPAPI(MIDI_DisableSort);
 		IMPAPI(MIDIEditor_GetActive);
 		IMPAPI(MIDIEditor_GetMode);
 		IMPAPI(MIDIEditor_GetSetting_int);


### PR DESCRIPTION
Affected actions:

- Copy selected CC events in active item
- Restore event to CC lane
- Save selected events in CC lane