### PR TITLE
Take playrate and stretch markers into account in "SWS/AW: Fill gaps between selected items (quick, no crossfade)", "(advanced)" and "(advanced, use last settings)"

### DIFF
--- a/Misc/Adam.cpp
+++ b/Misc/Adam.cpp
@@ -549,7 +549,8 @@ void AWFillGapsAdv(const char* title, char* retVals)
 					{
 						MediaItem_Take* currentTake = GetMediaItemTake(item2, takeIndex);
 						double startOffset = GetMediaItemTakeInfo_Value(currentTake, "D_STARTOFFS");
-						startOffset -= item2StartDiff;
+						const double playRate = GetMediaItemTakeInfo_Value(currentTake, "D_PLAYRATE");
+						startOffset -= item2StartDiff * playRate;
 						SetMediaItemTakeInfo_Value(currentTake, "D_STARTOFFS", startOffset);
 					}
 
@@ -651,7 +652,8 @@ void AWFillGapsQuick(COMMAND_T* t)
 						{
 							MediaItem_Take* currentTake = GetMediaItemTake(item2, takeIndex);
 							double startOffset = GetMediaItemTakeInfo_Value(currentTake, "D_STARTOFFS");
-							startOffset -= item2StartDiff;
+							const double playRate = GetMediaItemTakeInfo_Value(currentTake, "D_PLAYRATE");
+							startOffset -= item2StartDiff * playRate;
 							SetMediaItemTakeInfo_Value(currentTake, "D_STARTOFFS", startOffset);
 						}
 

--- a/Misc/ItemParams.cpp
+++ b/Misc/ItemParams.cpp
@@ -457,22 +457,8 @@ void CrossfadeSelItems(COMMAND_T* t)
 								GetSetMediaItemInfo(item2, "D_SNAPOFFSET", &dSnapOffset2);
 							}
 
-							for (int iTake = 0; iTake < GetMediaItemNumTakes(item2); iTake++)
-							{
-								MediaItem_Take* take = GetMediaItemTake(item2, iTake);
-								if (take)
-								{
-									double dOffset = *(double*)GetSetMediaItemTakeInfo(take, "D_STARTOFFS", NULL);
+							AdjustTakesStartOffset(item2, dEdgeAdj);
 
-									// NF fix: also take Playrate into account
-									double dPlayrate = *(double*)GetSetMediaItemTakeInfo(take, "D_PLAYRATE", NULL);
-									dOffset -= (dEdgeAdj * dPlayrate);
-									GetSetMediaItemTakeInfo(take, "D_STARTOFFS", &dOffset);
-
-									// NF: fix / workaround for setting take start offset doesn't work if containing stretch markers
-									UpdateStretchMarkersAfterSetTakeStartOffset(take, dEdgeAdj * dPlayrate);
-								}
-							}
 							bChanges = true;
 							break;
 						}

--- a/sws_util.h
+++ b/sws_util.h
@@ -240,11 +240,9 @@ bool TrackMatchesGuid(ReaProject*, MediaTrack*, const GUID*);
 inline bool TrackMatchesGuid(MediaTrack* tr, const GUID* g) { return TrackMatchesGuid(nullptr, tr, g); }
 const char *stristr(const char* a, const char* b);
 
-// NF: fix / workaround for setting take start offset doesn't work if containing stretch markers
-// see https://forum.cockos.com/showthread.php?t=180571
-// probably all functions setting take start offset should use this for now, until it's changed in REAPER
+// adjust take start offset obeying play rate and its stretch markers
 // caller must check for take != NULL
-void UpdateStretchMarkersAfterSetTakeStartOffset(MediaItem_Take* take, double takeStartOffset_multiplyPlayrate);
+void AdjustTakesStartOffset(MediaItem *, double adjustment);
 
 // returns source filename also if source is section/reversed (see PCM_source::GetFilename() comment)
 const char* SWS_GetSourceFileName(PCM_source* src);


### PR DESCRIPTION
The xfade variant of the quick action was already fixed via 86a86807844638fa86b181fbafc04e34764e4589.

Fixes #1657