### PR TITLE
Limit toolbars auto refresh to when a watched action's toggle state changes

### DIFF
--- a/Misc/Adam.h
+++ b/Misc/Adam.h
@@ -35,6 +35,12 @@ void UpdateItemTimebaseToolbar();
 void UpdateTimebaseToolbar();
 void AWDoAutoGroup(bool rec);
 
+// for SNM_RefreshToolbars
+int IsGridSwing(COMMAND_T*);
+int IsProjectTimebase(COMMAND_T*);
+int IsSelTracksTimebase(COMMAND_T*);
+int IsSelItemsTimebase(COMMAND_T*);
+
 // #587
 void NFDoAutoGroupTakesMode(WDL_TypedBuf<MediaItem*> selItems);
 

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -372,6 +372,11 @@ void ActionsList(COMMAND_T*)
 }
 #endif
 
+COMMAND_T** SWSGetCommand(const int index)
+{
+	return g_commands.EnumeratePtr(index);
+}
+
 //JFB questionnable func: ok most of the time but, for ex.,
 // 2 different cmds can share the same function pointer cmd->doCommand
 int SWSGetCommandID(void (*cmdFunc)(COMMAND_T*), INT_PTR user, const char** pMenuText)

--- a/sws_util.h
+++ b/sws_util.h
@@ -210,6 +210,7 @@ bool SWSFreeUnregisterDynamicCmd(int id);
 
 void ActionsList(COMMAND_T*);
 int SWSGetCommandID(void (*cmdFunc)(COMMAND_T*), INT_PTR user = 0, const char** pMenuText = NULL);
+COMMAND_T** SWSGetCommand(int index);
 COMMAND_T* SWSGetCommandByID(int cmdId);
 int IsSwsAction(const char* _actionName);
 


### PR DESCRIPTION
Avoids calling `RefreshToolbar` blindly every `ToolbarsAutoRefreshFreq` in S&M.ini when the toolbar auto refresh feature is enabled (by default) as per https://forum.cockos.com/showthread.php?p=2629385.

I've tested every action that were covered by `SNM_RefreshToolbars`, and found that the following actions do not need it (REAPER invokes the `toggleaction` hook) in both v5.99 and v6 (dev0102):
- SWS/S&M: Toolbar - Toggle track envelopes in touch/latch/latch preview/write: Using actions, UI or API = OK
- SWS/AW: Toggle click track mute: same as above
- SWS/AW: Toggle triplet grid: Using actions or Grid Settings = OK
- SWS/AW: Toggle dotted grid: idem
- SWS/AW: Set grid to ... preserving grid type: idem

However there may be edge cases I haven't found where it would still be needed. For example, "SWS/AW: Toggle swing grid" does not need auto-refresh when using the native action "Grid: Toggle swing grid", but does need it when toggling the checkbox in Grid Settings.

Maybe it would be safer to keep watching & auto-refreshing those actions anyway, just in case?