### PR TITLE
Deprecate CF_EnumerateActions and CF_GetCommandText

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -340,8 +340,8 @@ APIdef g_apidefs[] =
 	{ APIFUNC(CF_GetCustomColor), "int", "int", "index", "Get one of 16 SWS custom colors (0xBBGGRR on Windows, 0xRRGGBB everyhwere else). Index is zero-based.", },
 	{ APIFUNC(CF_SetCustomColor), "void", "int,int", "index,color", "Set one of 16 SWS custom colors (0xBBGGRR on Windows, 0xRRGGBB everyhwere else). Index is zero-based.", },
 
-	{ APIFUNC(CF_EnumerateActions), "int", "int,int,char*,int", "section,index,nameOut,nameOut_sz", "Wrapper for the unexposed kbd_enumerateActions API function.\nMain=0, Main (alt recording)=100, MIDI Editor=32060, MIDI Event List Editor=32061, MIDI Inline Editor=32062, Media Explorer=32063", },
-	{ APIFUNC(CF_GetCommandText), "const char*", "int,int", "section,command", "Wrapper for the unexposed kbd_getTextFromCmd API function. See <a href='#CF_EnumerateActions'>CF_EnumerateActions</a> for common section IDs.", },
+	{ APIFUNC(CF_EnumerateActions), "int", "int,int,char*,int", "section,index,nameOut,nameOut_sz", "Deprecated, see kbd_enumerateActions (v6.71+). Wrapper for the unexposed kbd_enumerateActions API function.\nMain=0, Main (alt recording)=100, MIDI Editor=32060, MIDI Event List Editor=32061, MIDI Inline Editor=32062, Media Explorer=32063", },
+	{ APIFUNC(CF_GetCommandText), "const char*", "int,int", "section,command", "Deprecated, see kbd_getTextFromCmd (v6.71+). Wrapper for the unexposed kbd_getTextFromCmd API function. See <a href='#CF_EnumerateActions'>CF_EnumerateActions</a> for common section IDs.", },
 
 	{ APIFUNC(CF_GetMediaSourceBitDepth), "int", "PCM_source*", "src", "Returns the bit depth if available (0 otherwise).", },
 	{ APIFUNC(CF_GetMediaSourceBitRate), "double", "PCM_source*", "src", "Returns the bit rate for WAVE (wav, aif) and streaming/variable formats (mp3, ogg, opus). REAPER v6.19 or later is required for non-WAVE formats.", },

--- a/cfillion/cfillion.hpp
+++ b/cfillion/cfillion.hpp
@@ -40,6 +40,7 @@ void CF_GetSWSVersion(char *buf, int bufSize);
 int CF_GetCustomColor(int index);
 void CF_SetCustomColor(int index, int color);
 
+// deprecated, exposed natively in REAPER v6.71
 int CF_EnumerateActions(int section, int idx, char *nameBuf, int nameBufSize);
 const char *CF_GetCommandText(int section, int command);
 


### PR DESCRIPTION
Closes #1710