### PR TITLE
Enable text editing shortcuts in the Notes text field

### DIFF
--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -148,16 +148,21 @@ NotesWnd::~NotesWnd() = default;
 void NotesWnd::OnInitDlg()
 {
 	m_edit = GetDlgItem(m_hwnd, IDC_EDIT1);
+	HWND edit2 = GetDlgItem(m_hwnd, IDC_EDIT2);
 
 	// don't passthrough input to the main window
 	// https://forum.cockos.com/showthread.php?p=1208961
 	SetWindowLongPtr(m_edit, GWLP_USERDATA, 0xdeadf00b);
-	SetWindowLongPtr(GetDlgItem(m_hwnd, IDC_EDIT2), GWLP_USERDATA, 0xdeadf00b);
+	SetWindowLongPtr(edit2,  GWLP_USERDATA, 0xdeadf00b);
 
 #ifdef __APPLE__
 	// Prevent shortcuts in the menubar from triggering main window actions
 	// bypassing the accelerator hook return value
 	SWS_Mac_MakeDefaultWindowMenu(m_hwnd);
+
+	// WS_VSCROLL makes SWELL use an NSTextView instead of NSTextField
+	Mac_TextViewSetAllowsUndo(m_edit, true);
+	Mac_TextViewSetAllowsUndo(edit2,  true);
 #endif
 
 	m_resize.init_item(IDC_EDIT1, 0.0, 0.0, 1.0, 1.0);

--- a/sws_util.h
+++ b/sws_util.h
@@ -178,6 +178,7 @@ void ShowColorChooser(COLORREF initialCol);
 bool GetChosenColor(COLORREF* pColor);
 void HideColorChooser();
 void SetMenuItemSwatch(HMENU hMenu, UINT pos, int size, COLORREF color);
+void SWS_Mac_MakeDefaultWindowMenu(HWND);
 #endif
 
 struct SWS_Cursor {

--- a/sws_util.h
+++ b/sws_util.h
@@ -179,6 +179,7 @@ bool GetChosenColor(COLORREF* pColor);
 void HideColorChooser();
 void SetMenuItemSwatch(HMENU hMenu, UINT pos, int size, COLORREF color);
 void SWS_Mac_MakeDefaultWindowMenu(HWND);
+void Mac_TextViewSetAllowsUndo(HWND, bool);
 #endif
 
 struct SWS_Cursor {

--- a/sws_util.mm
+++ b/sws_util.mm
@@ -237,3 +237,16 @@ void SetMenuItemSwatch(HMENU hMenu, UINT pos, int iSize, COLORREF color)
   NSRectFill(NSMakeRect(0, 0, size.width, size.height));
   [item.image unlockFocus];
 }
+
+void SWS_Mac_MakeDefaultWindowMenu(HWND hwnd)
+{
+  // Replace the menubar with an empty one with just an "Edit" menu
+  // when the given window has focus.
+  if (HMENU menu = SWELL_GetDefaultModalWindowMenu()) {
+    if ((menu = SWELL_DuplicateMenu(menu))) {
+      SetMenu(hwnd, menu);
+      menu = GetSubMenu(menu, 0); // "REAPER" menu
+      SWELL_SetMenuDestination(menu, GetMainHwnd());
+    }
+  }
+}

--- a/sws_util.mm
+++ b/sws_util.mm
@@ -250,3 +250,9 @@ void SWS_Mac_MakeDefaultWindowMenu(HWND hwnd)
     }
   }
 }
+
+void Mac_TextViewSetAllowsUndo(HWND hwnd, const bool enable)
+{
+  if(hwnd && [(id)hwnd isKindOfClass:[NSTextView class]])
+    [(NSTextView *)hwnd setAllowsUndo:enable];
+}


### PR DESCRIPTION
The macOS menubar triggers main window shortcuts bypassing the accelerator hook's return value. The Action List and other REAPER windows prevent this by replacing the menubar when they receive focus. This PR does the same thing for the SWS Notes window. The replacement menubar only has "REAPER" and "Edit" menus. (This only works when undocked. REAPER has the same problem.)

Undo/redo works in the Action List's filter field because SWELL creates a NSTextFIeld for it. SWS notes sets the `WS_VSCROLL` style and that creates a NSTextView instead. Undo/redo in NSTextView must be explicitly enabled via the [`allowsUndo`](https://developer.apple.com/documentation/appkit/nstextview/1449450-allowsundo?language=objc) property.

On Linux keys don't appear to passthrough to the main window at all so it already worked as-is without this PR.

The `0xdeadf00b` hack, which was Windows-only, doesn't appear to have an effect anymore (at least in REAPER v6.68+). I've kept it because I don't know for sure if/when it was removed.

Closes #1721 