### PR TITLE
BR Mouse context: don't detect envelope segment when mouse cursor is outside of automation items bounds and underlying envelope is bypassed

### DIFF
--- a/Breeder/BR_EnvelopeUtil.h
+++ b/Breeder/BR_EnvelopeUtil.h
@@ -189,6 +189,7 @@ private:
 		EnvProperties& operator=  (const EnvProperties& properties);
 		vector<WDL_FastString> automationItems;
 		//POOLEDENVINST id pos length offset rate timeBased baseline(.5=0) amplitude loop ? ?
+		// see https://forum.cockos.com/showpost.php?p=2198410
 		// For now we're just storing as strings in properties and not handling parsing of these
 		//struct AutomationItem
 		//{

--- a/Breeder/BR_MouseUtil.h
+++ b/Breeder/BR_MouseUtil.h
@@ -159,6 +159,7 @@ private:
 	int IsMouseOverEnvelopeLine (BR_Envelope& envelope, int drawableEnvHeight, int yOffset, int mouseDisplayX, int mouseY, double mousePos, double arrangeStart, double arrangeZoom, int* pointUnderMouse);
 	int IsMouseOverEnvelopeLineTrackLane (MediaTrack* track, int trackHeight, int trackOffset, list<TrackEnvelope*>& laneEnvs, int mouseDisplayX, int mouseY, double mousePos, double arrangeStart, double arrangeZoom, TrackEnvelope** trackEnvelope, int* pointUnderMouse);
 	int IsMouseOverEnvelopeLineTake (MediaItem_Take* take, int takeHeight, int takeOffset, int mouseDisplayX, int mouseY, double mousePos, double arrangeStart, double arrangeZoom, TrackEnvelope** trackEnvelope, int* pointUnderMouse);
+	bool IsMouseOverAI(BR_Envelope& envelope, int drawableEnvHeight, int yOffset, int mouseY, double mousePos);
 	int GetRulerLaneHeight (int rulerH, int lane);
 	int IsHwndMidiEditor (HWND hwnd, HWND* midiEditor, HWND* subView);
 	static bool SortEnvHeightsById (const pair<int,int>& left, const pair<int,int>& right);


### PR DESCRIPTION
fixes #1727, fixes #1488

\# BR_EnvelopeUtil.h: add link to schwa's post listing AI tokens

Seems to work:
![env det](https://user-images.githubusercontent.com/7658194/220249401-d17b8cf6-9102-4acf-ac43-dd0a07db7c31.gif)

```
function main()
  window ,segment, detail = reaper.BR_GetMouseCursorContext()
  reaper.defer(main)
end

main()
```

