### PR TITLE
Use the more adequate GoToRegion API method in Region Playlist + other improvements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # External files
 /vendor
+
+# IDE's
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@
 # External files
 /vendor
 
-# IDE's
-/.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,8 @@ if(MSVC)
     # https://web.archive.org/web/20151123133638/https://connect.microsoft.com/VisualStudio/feedback/details/1789709/visual-c-2015-runtime-broken-on-windows-server-2003-c-11-magic-statics
     /Zc:threadSafeInit-
   )
+elseif(APPLE)
+  add_compile_options(-fsigned-char -fstack-protector-strong -fdiagnostics-color --sysroot ${CMAKE_OSX_SYSROOT})
 else()
   add_compile_options(-fsigned-char -fstack-protector-strong -fdiagnostics-color)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,6 @@ if(MSVC)
     # https://web.archive.org/web/20151123133638/https://connect.microsoft.com/VisualStudio/feedback/details/1789709/visual-c-2015-runtime-broken-on-windows-server-2003-c-11-magic-statics
     /Zc:threadSafeInit-
   )
-elseif(APPLE)
-  add_compile_options(-fsigned-char -fstack-protector-strong -fdiagnostics-color --sysroot ${CMAKE_OSX_SYSROOT})
 else()
   add_compile_options(-fsigned-char -fstack-protector-strong -fdiagnostics-color)
 endif()

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1396,13 +1396,15 @@ void PrepareToEndPlaylist ()
 	EnumProjectMarkers2 (NULL, markerIdx, nullptr, &g_safeTimeToEndPlaylist, nullptr, nullptr, nullptr);
 }
 
-void SeekRegion (const int _reaperRegionId)
+// Should only be called from SeekRegionDelayer and SeekRegion
+void SeekRegionImpl (const int _reaperRegionId)
 {
 	const double cursorpos = GetCursorPositionEx(NULL);
 	PreventUIRefresh(1);
-	GoToRegion (NULL, g_nextRegionId, false);
-	if ((GetPlayStateEx(NULL)&1) != 1)
+	GoToRegion (NULL, _reaperRegionId, false);
+	if ((GetPlayStateEx(NULL)&1) != 1) {
 		OnPlayButton();
+	}
 	SetEditCurPos2(NULL, cursorpos, false, false);
 	PreventUIRefresh(-1);
 
@@ -1411,6 +1413,49 @@ void SeekRegion (const int _reaperRegionId)
 	snprintf(dbg, sizeof(dbg), "GoToRegion() - Reaper Region Id: %d\n", _reaperRegionId);
 	OutputDebugString(dbg);
 #endif
+}
+
+// GoToRegion timing issue workaround
+class SeekRegionDelayer {
+	static constexpr int delayAmount = 5;
+
+	int regionId;
+	int currentDelay = -1;
+
+public:
+	void Schedule (int _regionToSchedule)
+	{
+		regionId = _regionToSchedule;
+		currentDelay = delayAmount;
+	}
+
+	void Reset ()
+	{
+		currentDelay = -1;
+	}
+
+	void Update ()
+	{
+		if (currentDelay > 0)
+			--currentDelay;
+		
+		if (currentDelay == 0) {
+			currentDelay = -1;
+			SeekRegionImpl(regionId);
+		}
+	}
+};
+
+SeekRegionDelayer g_seekRegionDelayer;
+
+void SeekRegion (const int _reaperRegionId)
+{
+	if (g_playPlaylist<0) {
+		// Called from PlaylistPlay to play the very first region --> must not delay
+		SeekRegionImpl(_reaperRegionId);
+	} else {
+		g_seekRegionDelayer.Schedule(_reaperRegionId);
+	}
 }
 
 enum class SeekMethod {
@@ -1456,21 +1501,26 @@ bool SeekItem(const int _plId, const int _nextItemId, const int _curItemId, cons
 	return false;
 }
 
-static bool IsInNextRegion (const double pos)
-{
-	// NF: potentially fix #886
-	// it seems that if '+0.01' isn't added to 'pos' below, adjacent regions are no more occasionally skipped
-	// https://forum.cockos.com/showpost.php?p=1935561&postcount=6 and my own tests so far seem to confirm also
-	// but I'm unsure what potential side effects this might have
-	return g_nextRgnPos <= (pos/*+0.01*/) && pos <= g_nextRgnEnd;	//JFB!! +0.01 because 'pos' can be a bit ahead of time
-																	// +1 sample block would be better, but no API..
-																	// note: sync loss detection will deal with this in the worst case
-}
+constexpr double timeEps = 0.01; // 10 ms
 
 static bool IsInCurrentRegion (const double pos)
 {
-	return g_curRgnPos <= (pos+0.01) && pos <= g_curRgnEnd; 	//JFB!! +0.01 because 'pos' can be a bit ahead of time
-																// +1 sample block would be better, but no API..
+	return (g_curRgnPos-timeEps) <= pos && pos < (g_curRgnEnd+timeEps);
+}
+
+static bool IsInNextRegion (const double pos)
+{
+	if (g_playCur == g_playNext) {
+		// happens when region is looped
+		return IsInCurrentRegion(pos);
+	}
+
+	// We need to be careful because the relaxed intervals
+	// [g_curRgnPos  - timeEps, g_curRgnEnd  + timeEps)
+	// [g_nextRgnPos - timeEps, g_nextRgnEnd + timeEps)
+	// can overlap if the regions are very close or touching
+	return !IsInCurrentRegion(pos) &&
+			(g_nextRgnPos-timeEps) <= pos && pos < (g_nextRgnEnd+timeEps);
 }
 
 // the meat!
@@ -1481,6 +1531,8 @@ void PlaylistRun()
 {
 	if (g_playPlaylist<0)
 		return;
+
+	g_seekRegionDelayer.Update();
 
 #if defined(_SNM_RGNPL_DEBUG1) || defined(_SNM_RGNPL_DEBUG2)
 	char dbg[256] = "";
@@ -1701,6 +1753,7 @@ void PlaylistPlay(int _plId, int _itemId)
 			g_endOfPlaylistSeekIssued = false;
 			if (SeekItem(_plId, _itemId, (g_playPlaylist==_plId ? g_playCur : -1), SeekMethod::IgnoreMarkers))
 			{
+				g_seekRegionDelayer.Reset();
 				g_playPlaylist = _plId; // enables PlaylistRun()
 				if (RegionPlaylistWnd* w = g_rgnplWndMgr.Get())
 					w->Update(); // for the play button, next/previous region actions, etc....

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1434,11 +1434,8 @@ void PlaylistRun()
 				if (g_rgnLoop>0)
 					g_rgnLoop--;
 
-				SeekPlay(g_nextRgnPos); // then exit
-			}
-
-			if (isLastPassInRegion) // if, not else if!
-			{
+				SeekPlay(g_nextRgnPos);
+			} else if (isLastPassInRegion){
 				int nextId = GetNextValidItem(g_playPlaylist, g_playCur, false, g_repeatPlaylist, g_shufflePlaylist);
 
 				// loop corner cases

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -115,11 +115,15 @@ int g_playPlaylist = -1;		// -1: stopped, playlist id otherwise
 bool g_unsync = false;			// true when switching to a position that is not part of the playlist
 int g_playCur = -1;				// index of the item being played, -1 means "not playing yet"
 int g_playNext = -1;			// index of the next item to be played, -1 means "the end"
+int g_nextRegionId = -1;		// index of the region that g_playNext refers to, can be used passed to GoToRegion API call
 int g_rgnLoop = 0;				// region loop count: 0 not looping, <0 infinite loop, n>0 looping n times
 bool g_plLoop = false;			// other (corner case) loops in the playlist?
 double g_lastRunPos = -1.0;
 double g_nextRgnPos, g_nextRgnEnd;
 double g_curRgnPos = 0.0, g_curRgnEnd = -1.0; // to detect unsync, end<pos means non relevant
+double g_safeTimeToEndPlaylist = -1.0; 	// the 'smooth seek to after the end of project' trick can only be pulled off
+										// with regular smooth seek --> we need to schedule it after markers
+bool g_endOfPlaylistSeekIssued = false;
 
 int g_oldSeekPref = -1;
 int g_oldStopprojlenPref = -1;
@@ -204,8 +208,8 @@ double RegionPlaylist::GetLength()
 	return infinite ? length*(-1) : length;
 }
 
-// get the 1st marker/region num which has nested marker/region
-int RegionPlaylist::GetNestedMarkerRegion()
+// get the 1st region num which has a nested region
+int RegionPlaylist::GetNestedRegion()
 {
 	for (int i=0; i<GetSize(); i++)
 	{
@@ -227,10 +231,45 @@ int RegionPlaylist::GetNestedMarkerRegion()
 								(dEnd>=(rgnpos+SNM_FUDGE_FACTOR) && dEnd<=(rgnend-SNM_FUDGE_FACTOR)))
 								return num;
 						}
-						else if (dPos>=(rgnpos+SNM_FUDGE_FACTOR) && dPos<=(rgnend-SNM_FUDGE_FACTOR))
-							return num;
 					}
 					lastx=x;
+				}
+			}
+		}
+	}
+	return -1;
+}
+
+constexpr const char* DedicatedEndRegionName = "<END>";
+
+int RegionPlaylist::GetRegionWithUnsafeMarker()
+{
+	if (EndsWithDedicatedEndRegion ()) {
+		return -1;
+	}
+
+	for (int i=0; i<GetSize(); i++)
+	{
+		if (RgnPlaylistItem* plItem = Get(i))
+		{
+			double rgnend;
+			int num;
+			const int rgnidx = EnumMarkerRegionById(NULL, plItem->m_rgnId, NULL, NULL, &rgnend, NULL, &num, NULL);
+			if (rgnidx>=0)
+			{
+				int markerIdx = -1;
+				GetLastMarkerAndCurRegion (NULL, rgnend - SNM_FUDGE_FACTOR, &markerIdx, nullptr);
+				if (markerIdx == -1) {
+					// not sure if possible
+					continue;
+				}
+				double markerPos;
+				EnumProjectMarkers2 (NULL, markerIdx, nullptr, &markerPos, nullptr, nullptr, nullptr);
+
+				constexpr double safeDistanceToPreviousMarker = 1.0;
+
+				if (rgnend - markerPos < safeDistanceToPreviousMarker) {
+					return num;
 				}
 			}
 		}
@@ -251,6 +290,19 @@ int RegionPlaylist::GetGreaterMarkerRegion(double _pos)
 	return -1;
 }
 
+bool RegionPlaylist::EndsWithDedicatedEndRegion()
+{
+	const int lastItemIdx = GetSize () - 1;
+	if (IsValidIem (lastItemIdx)) {
+		const RgnPlaylistItem* const plItem = Get(lastItemIdx);
+		const char* name;
+		EnumMarkerRegionById(NULL, plItem->m_rgnId, NULL, NULL, NULL, &name, NULL, NULL);
+		if (strcmp (name, DedicatedEndRegionName) == 0 && plItem->m_cnt < 0) {
+			return true;
+		}
+	}
+	return false;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // RegionPlaylistView
@@ -1326,23 +1378,54 @@ int GetPrevValidItem(int _plId, int _itemId, bool _startWith, bool _repeat, bool
 	return -1;
 }
 
-bool SeekItem(int _plId, int _nextItemId, int _curItemId)
+void PrepareToEndPlaylist ()
+{
+	// temp override of the "stop play at project end" option
+	if (ConfigVar<int> opt = "stopprojlen") {
+		g_oldStopprojlenPref = *opt;
+		*opt = 1;
+	}
+	g_playNext = -1;
+	g_nextRegionId = -1;
+	g_rgnLoop = 0;
+	g_nextRgnPos = SNM_GetProjectLength()+1.0;
+	g_nextRgnEnd = g_nextRgnPos+1.0;
+
+	int markerIdx = 0;
+	GetLastMarkerAndCurRegion (NULL, g_curRgnEnd - SNM_FUDGE_FACTOR, &markerIdx, nullptr);
+	EnumProjectMarkers2 (NULL, markerIdx, nullptr, &g_safeTimeToEndPlaylist, nullptr, nullptr, nullptr);
+}
+
+void SeekRegion (const int _reaperRegionId)
+{
+	const double cursorpos = GetCursorPositionEx(NULL);
+	PreventUIRefresh(1);
+	GoToRegion (NULL, g_nextRegionId, false);
+	if ((GetPlayStateEx(NULL)&1) != 1)
+		OnPlayButton();
+	SetEditCurPos2(NULL, cursorpos, false, false);
+	PreventUIRefresh(-1);
+
+#if defined(_SNM_RGNPL_DEBUG1) || defined(_SNM_RGNPL_DEBUG2)
+	char dbg[256] = "";
+	snprintf(dbg, sizeof(dbg), "GoToRegion() - Reaper Region Id: %d\n", _reaperRegionId);
+	OutputDebugString(dbg);
+#endif
+}
+
+enum class SeekMethod {
+	IgnoreMarkers,
+	ConsiderMarkers
+};
+
+bool SeekItem(const int _plId, const int _nextItemId, const int _curItemId, const SeekMethod _method)
 {
 	if (RegionPlaylist* pl = g_pls.Get()->Get(_plId))
 	{
 		// trick to stop the playlist in sync: smooth seek to the end of the project (!)
 		if (_nextItemId<0)
 		{
-			// temp override of the "stop play at project end" option
-			if (ConfigVar<int> opt = "stopprojlen") {
-				g_oldStopprojlenPref = *opt;
-				*opt = 1;
-			}
-			g_playNext = -1;
-			g_rgnLoop = 0;
-			g_nextRgnPos = SNM_GetProjectLength()+1.0;
-			g_nextRgnEnd = g_nextRgnPos+1.0;
-			SeekPlay(g_nextRgnPos);
+			PrepareToEndPlaylist ();
 			return true;
 		}
 		else if (RgnPlaylistItem* next = pl->Get(_nextItemId))
@@ -1351,6 +1434,7 @@ bool SeekItem(int _plId, int _nextItemId, int _curItemId)
 			if (EnumMarkerRegionById(NULL, next->m_rgnId, NULL, &a, &b, NULL, NULL, NULL)>=0)
 			{
 				g_playNext = _nextItemId;
+				g_nextRegionId = GetMarkerRegionNumFromId (next->m_rgnId);
 				g_playCur = _plId==g_playPlaylist ? g_playCur : _curItemId;
 				g_rgnLoop = next->m_cnt<0 ? -1 : next->m_cnt>1 ? next->m_cnt : 0;
 				g_nextRgnPos = a;
@@ -1359,7 +1443,12 @@ bool SeekItem(int _plId, int _nextItemId, int _curItemId)
 					g_curRgnPos = 0.0;
 					g_curRgnEnd = -1.0;
 				}
-				SeekPlay(g_nextRgnPos);
+
+				if (_method == SeekMethod::IgnoreMarkers) {
+					SeekRegion (g_nextRegionId);
+				} else {
+					SeekPlay(g_nextRgnPos);
+				}
 				return true;
 			}
 		}
@@ -1398,6 +1487,15 @@ void PlaylistRun()
 #endif
 	bool updated = false;
 	const double pos = GetPlayPosition2Ex(NULL);
+
+	const bool isPlaylistAboutToEnd = g_playNext == -1;
+	if (isPlaylistAboutToEnd)
+	{
+		if (!g_endOfPlaylistSeekIssued && g_safeTimeToEndPlaylist < pos) {
+			SeekPlay (g_nextRgnPos);
+			g_endOfPlaylistSeekIssued = true;
+		}
+	}
 
 	if (IsInNextRegion (pos))
 	{
@@ -1445,13 +1543,13 @@ void PlaylistRun()
 #ifdef _SNM_RGNPL_DEBUG1
 					snprintf(dbg, sizeof(dbg), "SEEK - Current = %d, Next = %d\n", g_playCur, nextId); OutputDebugString(dbg);
 #endif
-					if (!SeekItem(g_playPlaylist, nextId, g_playCur))
-						SeekItem(g_playPlaylist, -1, g_playCur); // end of playlist..
+					if (!SeekItem(g_playPlaylist, nextId, g_playCur, SeekMethod::IgnoreMarkers))
+						SeekItem(g_playPlaylist, -1, g_playCur, SeekMethod::IgnoreMarkers); // end of playlist..
 				} else {
 					if (g_rgnLoop>0)
 						g_rgnLoop--;
 
-					SeekPlay(g_nextRgnPos);
+					SeekRegion (g_nextRegionId);
 				}
 			}
 		}
@@ -1475,7 +1573,7 @@ void PlaylistRun()
 			int spareItemId = -1;
 			if (RegionPlaylist* pl = g_pls.Get()->Get(g_playPlaylist))
 				spareItemId = pl->IsInPlaylist(pos, g_repeatPlaylist, g_playCur>=0?g_playCur:0);
-			if (spareItemId<0 || !SeekItem(g_playPlaylist, spareItemId, -1))
+			if (spareItemId<0 || !SeekItem(g_playPlaylist, spareItemId, -1, SeekMethod::ConsiderMarkers))
 			{
 #ifdef _SNM_RGNPL_DEBUG2
 				snprintf(dbg, sizeof(dbg), ">>> SYNC LOSS, SEEK expected region pos = %f\n", g_nextRgnPos); OutputDebugString(dbg);
@@ -1556,11 +1654,22 @@ void PlaylistPlay(int _plId, int _itemId)
 			}
 		}
 
-		num = pl->GetNestedMarkerRegion();
+		num = pl->GetNestedRegion();
 		if (num>0)
 		{
 			char msg[256] = "";
-			snprintf(msg, sizeof(msg), __LOCALIZE_VERFMT("The playlist #%d might not work as expected!\nIt contains nested markers/regions (inside region %d at least).","sws_DLG_165"), _plId+1, num);
+			snprintf(msg, sizeof(msg), __LOCALIZE_VERFMT("The playlist #%d might not work as expected!\nIt contains nested regions (inside region %d at least).","sws_DLG_165"), _plId+1, num);
+			if (IDCANCEL == MessageBox(g_rgnplWndMgr.GetMsgHWND(), msg, __LOCALIZE("S&M - Warning","sws_DLG_165"), MB_OKCANCEL)) {
+				PlaylistStop();
+				return;
+			}
+		}
+
+		const int unsafeRegion = pl->GetRegionWithUnsafeMarker();
+		if (unsafeRegion>0)
+		{
+			char msg[512] = "";
+			snprintf(msg, sizeof(msg), __LOCALIZE_VERFMT("The playlist #%d might not work as expected!\nSome regions have a marker just before the end (region %d at least).\nPlaylist might end unexpectedly, if such a region is the last one.\nPlease delete all markers that are within 1 second of the end of a region, or consider creating your own region named \"%s\" , with infinite loop, to override this warning.","sws_DLG_165"), _plId+1, unsafeRegion, DedicatedEndRegionName);
 			if (IDCANCEL == MessageBox(g_rgnplWndMgr.GetMsgHWND(), msg, __LOCALIZE("S&M - Warning","sws_DLG_165"), MB_OKCANCEL)) {
 				PlaylistStop();
 				return;
@@ -1587,7 +1696,10 @@ void PlaylistPlay(int _plId, int _itemId)
 			g_plLoop = false;
 			g_unsync = false;
 			g_lastRunPos = SNM_GetProjectLength()+1.0;
-			if (SeekItem(_plId, _itemId, g_playPlaylist==_plId ? g_playCur : -1))
+			g_nextRegionId = -1;
+			g_safeTimeToEndPlaylist = -1.0;
+			g_endOfPlaylistSeekIssued = false;
+			if (SeekItem(_plId, _itemId, (g_playPlaylist==_plId ? g_playCur : -1), SeekMethod::IgnoreMarkers))
 			{
 				g_playPlaylist = _plId; // enables PlaylistRun()
 				if (RegionPlaylistWnd* w = g_rgnplWndMgr.Get())
@@ -1711,7 +1823,7 @@ void PlaylistResync()
 {
 	if (RegionPlaylist* pl = GetPlaylist(g_playPlaylist))
 		if (RgnPlaylistItem* item = pl->Get(g_playCur))
-			SeekItem(g_playPlaylist, GetNextValidItem(g_playPlaylist, g_playCur, item->m_cnt<0 || item->m_cnt>1, g_repeatPlaylist, g_shufflePlaylist), g_playCur);
+			SeekItem(g_playPlaylist, GetNextValidItem(g_playPlaylist, g_playCur, item->m_cnt<0 || item->m_cnt>1, g_repeatPlaylist, g_shufflePlaylist), g_playCur, SeekMethod::IgnoreMarkers);
 }
 
 void SetPlaylistRepeat(COMMAND_T* _ct)

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1425,18 +1425,18 @@ void PlaylistRun()
 			}
 
 			const bool isNewPassInRegion = isFirstPassInRegion || pos<g_lastRunPos;
+			const bool isLastPassInRegion = g_rgnLoop == 0 || g_rgnLoop == 1;
 
 			// region loop?
-			if (g_rgnLoop && (isNewPassInRegion || g_unsync))
+			if (!isLastPassInRegion && (isNewPassInRegion || g_unsync))
 			{
 				updated = true;
 				if (g_rgnLoop>0)
 					g_rgnLoop--;
-				if (g_rgnLoop)
-					SeekPlay(g_nextRgnPos); // then exit
+
+				SeekPlay(g_nextRgnPos); // then exit
 			}
 
-			const bool isLastPassInRegion = !g_rgnLoop;
 			if (isLastPassInRegion) // if, not else if!
 			{
 				int nextId = GetNextValidItem(g_playPlaylist, g_playCur, false, g_repeatPlaylist, g_shufflePlaylist);

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1510,8 +1510,7 @@ static bool IsInCurrentRegion (const double pos)
 
 static bool IsInNextRegion (const double pos)
 {
-	if (g_playCur == g_playNext) {
-		// happens when region is looped
+	if (g_playCur == g_playNext || g_plLoop) {
 		return IsInCurrentRegion(pos);
 	}
 
@@ -1555,10 +1554,11 @@ void PlaylistRun()
 
 		if (!g_plLoop || g_unsync || pos<g_lastRunPos)
 		{
+			// Playlist Item != Region !!
+			const bool isFirstPassInPlItem = g_playCur != g_playNext || (g_plLoop && pos<g_lastRunPos);
 			g_plLoop = false;
-
-			const bool isFirstPassInRegion = g_playCur != g_playNext;
-			if (isFirstPassInRegion)
+			
+			if (isFirstPassInPlItem)
 			{
 #ifdef _SNM_RGNPL_DEBUG1
 					OutputDebugString("\n");
@@ -1574,7 +1574,8 @@ void PlaylistRun()
 				g_curRgnEnd = g_nextRgnEnd;
 			}
 
-			const bool isNewPassInRegion = isFirstPassInRegion || pos<g_lastRunPos;
+			// Playlist Item != Region !!
+			const bool isNewPassInRegion = isFirstPassInPlItem || pos<g_lastRunPos;
 			if (isNewPassInRegion || g_unsync) {
 				updated = true;
 				

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1436,7 +1436,8 @@ void PlaylistRun()
 					SeekPlay(g_nextRgnPos); // then exit
 			}
 
-			if (!g_rgnLoop) // if, not else if!
+			const bool isLastPassInRegion = !g_rgnLoop;
+			if (isLastPassInRegion) // if, not else if!
 			{
 				int nextId = GetNextValidItem(g_playPlaylist, g_playCur, false, g_repeatPlaylist, g_shufflePlaylist);
 

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1367,153 +1367,159 @@ bool SeekItem(int _plId, int _nextItemId, int _curItemId)
 	return false;
 }
 
+static bool IsInNextRegion (const double pos)
+{
+	// NF: potentially fix #886
+	// it seems that if '+0.01' isn't added to 'pos' below, adjacent regions are no more occasionally skipped
+	// https://forum.cockos.com/showpost.php?p=1935561&postcount=6 and my own tests so far seem to confirm also
+	// but I'm unsure what potential side effects this might have
+	return g_nextRgnPos <= (pos/*+0.01*/) && pos <= g_nextRgnEnd;	//JFB!! +0.01 because 'pos' can be a bit ahead of time
+																	// +1 sample block would be better, but no API..
+																	// note: sync loss detection will deal with this in the worst case
+}
+
+static bool IsInCurrentRegion (const double pos)
+{
+	return g_curRgnPos <= (pos+0.01) && pos <= g_curRgnEnd; 	//JFB!! +0.01 because 'pos' can be a bit ahead of time
+																// +1 sample block would be better, but no API..
+}
+
 // the meat!
 // polls the playing position and smooth seeks if needed
 // remember we always lookup one region ahead!
 // made as idle as possible, polled via SNM_CSurfRun()
 void PlaylistRun()
 {
-	if (g_playPlaylist>=0)
-	{
+	if (g_playPlaylist<0)
+		return;
+
 #if defined(_SNM_RGNPL_DEBUG1) || defined(_SNM_RGNPL_DEBUG2)
-		char dbg[256] = "";
+	char dbg[256] = "";
 #endif
-		bool updated = false;
-		double pos = GetPlayPosition2Ex(NULL);
+	bool updated = false;
+	const double pos = GetPlayPosition2Ex(NULL);
 
-		// NF: potentially fix #886
-		// it seems that if '+0.01' isn't added to 'pos' below, adjacent regions are no more occasionally skipped
-		// https://forum.cockos.com/showpost.php?p=1935561&postcount=6 and my own tests so far seem to confirm also
-		// but I'm unsure what potential side effects this might have
-		if ((pos/*+0.01*/) >= g_nextRgnPos && pos <= g_nextRgnEnd)	//JFB!! +0.01 because 'pos' can be a bit ahead of time
-																// +1 sample block would be better, but no API..
-																// note: sync loss detection will deal with this in the worst case
+	if (IsInNextRegion (pos))
+	{
+		// a bunch of calls end here when looping!!
+
+		if (!g_plLoop || g_unsync || pos<g_lastRunPos)
 		{
-			// a bunch of calls end here when looping!!
+			g_plLoop = false;
 
-			if (!g_plLoop || g_unsync || pos<g_lastRunPos)
+			const bool isFirstPassInRegion = g_playCur != g_playNext;
+			if (isFirstPassInRegion)
 			{
-				g_plLoop = false;
-
-				bool first = false;
-				if (g_playCur != g_playNext 
-/*JFB those vars are only altered here
-					|| g_curRgnPos != g_nextRgnPos || g_curRgnEnd != g_nextRgnEnd
-*/
-					)
-				{
 #ifdef _SNM_RGNPL_DEBUG1
-					 OutputDebugString("\n");
-					snprintf(dbg, sizeof(dbg), "NEXT DETECTED - pos = %f\n", pos); OutputDebugString(dbg);
-					snprintf(dbg, sizeof(dbg), "                g_curRgnPos = %f, g_curRgnEnd = %f\n", g_curRgnPos, g_curRgnEnd); OutputDebugString(dbg);
-					snprintf(dbg, sizeof(dbg), "                g_nextRgnPos = %f, g_nextRgnEnd = %f\n", g_nextRgnPos, g_nextRgnEnd); OutputDebugString(dbg);
-					snprintf(dbg, sizeof(dbg), "                g_playCur = %d, g_playNext = %d\n", g_playCur, g_playNext); OutputDebugString(dbg);
-					snprintf(dbg, sizeof(dbg), "                g_unsync = %d, g_lastRunPos = %f\n", g_unsync, g_lastRunPos); OutputDebugString(dbg);
-#endif
-					first = updated = true;
-					g_playCur = g_playNext;
-					g_curRgnPos = g_nextRgnPos;
-					g_curRgnEnd = g_nextRgnEnd;
-				}
-
-				// region loop?
-				if (g_rgnLoop && (first || g_unsync || pos<g_lastRunPos))
-				{
-					updated = true;
-					if (g_rgnLoop>0)
-						g_rgnLoop--;
-					if (g_rgnLoop)
-						SeekPlay(g_nextRgnPos); // then exit
-				}
-
-				if (!g_rgnLoop) // if, not else if!
-				{
-					int nextId = GetNextValidItem(g_playPlaylist, g_playCur, false, g_repeatPlaylist, g_shufflePlaylist);
-
-					// loop corner cases
-					// ex: 1 item in the playlist + repeat on, or repeat on + last region == first region,
-					//     or playlist = region3, then unknown region (e.g. deleted) and region3 again, or etc..
-					if (nextId>=0)
-						if (RegionPlaylist* pl = GetPlaylist(g_playPlaylist))
-							if (RgnPlaylistItem* next = pl->Get(nextId)) 
-								if (RgnPlaylistItem* cur = pl->Get(g_playCur)) 
-									g_plLoop = (cur->m_rgnId==next->m_rgnId); // valid regions at this point
-
-#ifdef _SNM_RGNPL_DEBUG1
-					snprintf(dbg, sizeof(dbg), "SEEK - Current = %d, Next = %d\n", g_playCur, nextId); OutputDebugString(dbg);
-#endif
-					if (!SeekItem(g_playPlaylist, nextId, g_playCur))
-						SeekItem(g_playPlaylist, -1, g_playCur); // end of playlist..
-					updated = true;
-				}
-			}
-			g_unsync = false;
-		}
-		else if (g_curRgnPos<g_curRgnEnd) // relevant vars?
-		{
-			// seek play requested, waiting for region switch..
-			if ((pos+0.01) >= g_curRgnPos && pos <= g_curRgnEnd) //JFB!! +0.01 because 'pos' can be a bit ahead of time
-																 // +1 sample block would be better, but no API..
-			{
-				// a bunch of calls end here!
-				g_unsync = false;
-			}
-			// playlist no more in sync?
-			else if (!g_unsync)
-			{
-#ifdef _SNM_RGNPL_DEBUG2
-				snprintf(dbg, sizeof(dbg), ">>> SYNC LOSS - pos = %f\n", pos); OutputDebugString(dbg);
+					OutputDebugString("\n");
+				snprintf(dbg, sizeof(dbg), "NEXT DETECTED - pos = %f\n", pos); OutputDebugString(dbg);
 				snprintf(dbg, sizeof(dbg), "                g_curRgnPos = %f, g_curRgnEnd = %f\n", g_curRgnPos, g_curRgnEnd); OutputDebugString(dbg);
 				snprintf(dbg, sizeof(dbg), "                g_nextRgnPos = %f, g_nextRgnEnd = %f\n", g_nextRgnPos, g_nextRgnEnd); OutputDebugString(dbg);
+				snprintf(dbg, sizeof(dbg), "                g_playCur = %d, g_playNext = %d\n", g_playCur, g_playNext); OutputDebugString(dbg);
+				snprintf(dbg, sizeof(dbg), "                g_unsync = %d, g_lastRunPos = %f\n", g_unsync, g_lastRunPos); OutputDebugString(dbg);
 #endif
-				updated = g_unsync = true;
-				int spareItemId = -1;
-				if (RegionPlaylist* pl = g_pls.Get()->Get(g_playPlaylist))
-					spareItemId = pl->IsInPlaylist(pos, g_repeatPlaylist, g_playCur>=0?g_playCur:0);
-				if (spareItemId<0 || !SeekItem(g_playPlaylist, spareItemId, -1))
-				{
-#ifdef _SNM_RGNPL_DEBUG2
-					snprintf(dbg, sizeof(dbg), ">>> SYNC LOSS, SEEK expected region pos = %f\n", g_nextRgnPos); OutputDebugString(dbg);
+				updated = true;
+				g_playCur = g_playNext;
+				g_curRgnPos = g_nextRgnPos;
+				g_curRgnEnd = g_nextRgnEnd;
+			}
+
+			const bool isNewPassInRegion = isFirstPassInRegion || pos<g_lastRunPos;
+
+			// region loop?
+			if (g_rgnLoop && (isNewPassInRegion || g_unsync))
+			{
+				updated = true;
+				if (g_rgnLoop>0)
+					g_rgnLoop--;
+				if (g_rgnLoop)
+					SeekPlay(g_nextRgnPos); // then exit
+			}
+
+			if (!g_rgnLoop) // if, not else if!
+			{
+				int nextId = GetNextValidItem(g_playPlaylist, g_playCur, false, g_repeatPlaylist, g_shufflePlaylist);
+
+				// loop corner cases
+				// ex: 1 item in the playlist + repeat on, or repeat on + last region == first region,
+				//     or playlist = region3, then unknown region (e.g. deleted) and region3 again, or etc..
+				if (nextId>=0)
+					if (RegionPlaylist* pl = GetPlaylist(g_playPlaylist))
+						if (RgnPlaylistItem* next = pl->Get(nextId)) 
+							if (RgnPlaylistItem* cur = pl->Get(g_playCur)) 
+								g_plLoop = (cur->m_rgnId==next->m_rgnId); // valid regions at this point
+
+#ifdef _SNM_RGNPL_DEBUG1
+				snprintf(dbg, sizeof(dbg), "SEEK - Current = %d, Next = %d\n", g_playCur, nextId); OutputDebugString(dbg);
 #endif
-					SeekPlay(g_nextRgnPos);	// try to resync the expected region, best effort
-				}
-#ifdef _SNM_RGNPL_DEBUG2
-				else {
-					snprintf(dbg, sizeof(dbg), ">>> SYNC LOSS, SEEK - Current = %d, Next = %d\n", -1, spareItemId); OutputDebugString(dbg);
-				}
-#endif
+				if (!SeekItem(g_playPlaylist, nextId, g_playCur))
+					SeekItem(g_playPlaylist, -1, g_playCur); // end of playlist..
+				updated = true;
 			}
 		}
-
-		g_lastRunPos = pos;
-		if (updated && (g_osc || g_rgnplWndMgr.Get()))
+		g_unsync = false;
+	}
+	else if (g_curRgnPos<g_curRgnEnd) // relevant vars?
+	{
+		// seek play requested, waiting for region switch..
+		if (IsInCurrentRegion (pos))
+			// a bunch of calls end here!
+			g_unsync = false;
+		// playlist no more in sync?
+		else if (!g_unsync)
 		{
-			// one call to GetMonitoringInfo() for both the wnd & osc
-			WDL_FastString cur, curNum, next, nextNum;
-			GetMonitoringInfo(&curNum, &cur, &nextNum, &next);
-
-			if (RegionPlaylistWnd* w = g_rgnplWndMgr.Get())
-				w->Update(1, &curNum, &cur, &nextNum, &next); // 1: fast update flag
-
-			if (g_osc)
+#ifdef _SNM_RGNPL_DEBUG2
+			snprintf(dbg, sizeof(dbg), ">>> SYNC LOSS - pos = %f\n", pos); OutputDebugString(dbg);
+			snprintf(dbg, sizeof(dbg), "                g_curRgnPos = %f, g_curRgnEnd = %f\n", g_curRgnPos, g_curRgnEnd); OutputDebugString(dbg);
+			snprintf(dbg, sizeof(dbg), "                g_nextRgnPos = %f, g_nextRgnEnd = %f\n", g_nextRgnPos, g_nextRgnEnd); OutputDebugString(dbg);
+#endif
+			updated = g_unsync = true;
+			int spareItemId = -1;
+			if (RegionPlaylist* pl = g_pls.Get()->Get(g_playPlaylist))
+				spareItemId = pl->IsInPlaylist(pos, g_repeatPlaylist, g_playCur>=0?g_playCur:0);
+			if (spareItemId<0 || !SeekItem(g_playPlaylist, spareItemId, -1))
 			{
-				static WDL_FastString sOSC_CURRENT_RGN(OSC_CURRENT_RGN);
-				static WDL_FastString sOSC_NEXT_RGN(OSC_NEXT_RGN);
-
-				if (curNum.GetLength() && cur.GetLength()) curNum.Append(" ");
-				curNum.Append(&cur);
-
-				if (nextNum.GetLength() && next.GetLength()) nextNum.Append(" ");
-				nextNum.Append(&next);
-
-				WDL_PtrList<WDL_FastString> strs;
-				strs.Add(&sOSC_CURRENT_RGN);
-				strs.Add(&curNum);
-				strs.Add(&sOSC_NEXT_RGN);
-				strs.Add(&nextNum);
-				g_osc->SendStrBundle(&strs);
-				strs.Empty(false);
+#ifdef _SNM_RGNPL_DEBUG2
+				snprintf(dbg, sizeof(dbg), ">>> SYNC LOSS, SEEK expected region pos = %f\n", g_nextRgnPos); OutputDebugString(dbg);
+#endif
+				SeekPlay(g_nextRgnPos);	// try to resync the expected region, best effort
 			}
+#ifdef _SNM_RGNPL_DEBUG2
+			else {
+				snprintf(dbg, sizeof(dbg), ">>> SYNC LOSS, SEEK - Current = %d, Next = %d\n", -1, spareItemId); OutputDebugString(dbg);
+			}
+#endif
+		}
+	}
+
+	g_lastRunPos = pos;
+	if (updated && (g_osc || g_rgnplWndMgr.Get()))
+	{
+		// one call to GetMonitoringInfo() for both the wnd & osc
+		WDL_FastString cur, curNum, next, nextNum;
+		GetMonitoringInfo(&curNum, &cur, &nextNum, &next);
+
+		if (RegionPlaylistWnd* w = g_rgnplWndMgr.Get())
+			w->Update(1, &curNum, &cur, &nextNum, &next); // 1: fast update flag
+
+		if (g_osc)
+		{
+			static WDL_FastString sOSC_CURRENT_RGN(OSC_CURRENT_RGN);
+			static WDL_FastString sOSC_NEXT_RGN(OSC_NEXT_RGN);
+
+			if (curNum.GetLength() && cur.GetLength()) curNum.Append(" ");
+			curNum.Append(&cur);
+
+			if (nextNum.GetLength() && next.GetLength()) nextNum.Append(" ");
+			nextNum.Append(&next);
+
+			WDL_PtrList<WDL_FastString> strs;
+			strs.Add(&sOSC_CURRENT_RGN);
+			strs.Add(&curNum);
+			strs.Add(&sOSC_NEXT_RGN);
+			strs.Add(&nextNum);
+			g_osc->SendStrBundle(&strs);
+			strs.Empty(false);
 		}
 	}
 }

--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1425,34 +1425,34 @@ void PlaylistRun()
 			}
 
 			const bool isNewPassInRegion = isFirstPassInRegion || pos<g_lastRunPos;
-			const bool isLastPassInRegion = g_rgnLoop == 0 || g_rgnLoop == 1;
-
-			// region loop?
-			if (!isLastPassInRegion && (isNewPassInRegion || g_unsync))
-			{
+			if (isNewPassInRegion || g_unsync) {
 				updated = true;
-				if (g_rgnLoop>0)
-					g_rgnLoop--;
+				
+				// region loop?
+				const bool isLastPassInRegion = g_rgnLoop == 0 || g_rgnLoop == 1;
+				if (isLastPassInRegion) {
+					int nextId = GetNextValidItem(g_playPlaylist, g_playCur, false, g_repeatPlaylist, g_shufflePlaylist);
 
-				SeekPlay(g_nextRgnPos);
-			} else if (isLastPassInRegion){
-				int nextId = GetNextValidItem(g_playPlaylist, g_playCur, false, g_repeatPlaylist, g_shufflePlaylist);
-
-				// loop corner cases
-				// ex: 1 item in the playlist + repeat on, or repeat on + last region == first region,
-				//     or playlist = region3, then unknown region (e.g. deleted) and region3 again, or etc..
-				if (nextId>=0)
-					if (RegionPlaylist* pl = GetPlaylist(g_playPlaylist))
-						if (RgnPlaylistItem* next = pl->Get(nextId)) 
-							if (RgnPlaylistItem* cur = pl->Get(g_playCur)) 
-								g_plLoop = (cur->m_rgnId==next->m_rgnId); // valid regions at this point
+					// loop corner cases
+					// ex: 1 item in the playlist + repeat on, or repeat on + last region == first region,
+					//     or playlist = region3, then unknown region (e.g. deleted) and region3 again, or etc..
+					if (nextId>=0)
+						if (RegionPlaylist* pl = GetPlaylist(g_playPlaylist))
+							if (RgnPlaylistItem* next = pl->Get(nextId)) 
+								if (RgnPlaylistItem* cur = pl->Get(g_playCur)) 
+									g_plLoop = (cur->m_rgnId==next->m_rgnId); // valid regions at this point
 
 #ifdef _SNM_RGNPL_DEBUG1
-				snprintf(dbg, sizeof(dbg), "SEEK - Current = %d, Next = %d\n", g_playCur, nextId); OutputDebugString(dbg);
+					snprintf(dbg, sizeof(dbg), "SEEK - Current = %d, Next = %d\n", g_playCur, nextId); OutputDebugString(dbg);
 #endif
-				if (!SeekItem(g_playPlaylist, nextId, g_playCur))
-					SeekItem(g_playPlaylist, -1, g_playCur); // end of playlist..
-				updated = true;
+					if (!SeekItem(g_playPlaylist, nextId, g_playCur))
+						SeekItem(g_playPlaylist, -1, g_playCur); // end of playlist..
+				} else {
+					if (g_rgnLoop>0)
+						g_rgnLoop--;
+
+					SeekPlay(g_nextRgnPos);
+				}
 			}
 		}
 		g_unsync = false;

--- a/SnM/SnM_RegionPlaylist.h
+++ b/SnM/SnM_RegionPlaylist.h
@@ -58,7 +58,9 @@ public:
 	int IsInPlaylist(double _pos, bool _repeat, int _startWith);
 	int IsInfinite();
 	double GetLength();
-	int GetNestedMarkerRegion();
+	int GetNestedRegion();
+	bool EndsWithDedicatedEndRegion();
+	int GetRegionWithUnsafeMarker();
 	int GetGreaterMarkerRegion(double _pos);
 	WDL_FastString m_name;
 };

--- a/SnM/SnM_RegionPlaylist.h
+++ b/SnM/SnM_RegionPlaylist.h
@@ -60,6 +60,7 @@ public:
 	double GetLength();
 	int GetNestedRegion();
 	int GetRegionWithUnsafeMarker();
+	int GetDangerouslyShortRegion();
 	int GetGreaterMarkerRegion(double _pos);
 	WDL_FastString m_name;
 };

--- a/SnM/SnM_RegionPlaylist.h
+++ b/SnM/SnM_RegionPlaylist.h
@@ -59,7 +59,6 @@ public:
 	int IsInfinite();
 	double GetLength();
 	int GetNestedRegion();
-	bool EndsWithDedicatedEndRegion();
 	int GetRegionWithUnsafeMarker();
 	int GetGreaterMarkerRegion(double _pos);
 	WDL_FastString m_name;

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -938,6 +938,7 @@ error:
 		IMPAPI(GetUserInputs);
 		IMPAPI(get_config_var);
 		IMPAPI(get_ini_file);
+		IMPAPI(GoToRegion);
 		IMPAPI(GR_SelectColor);
 		IMPAPI(GSC_mainwnd);
 		IMPAPI(guidToString);


### PR DESCRIPTION
Fixes  #1512

My goal was to make the Region Playlist more robust and reliable. In my opinion, in its current state it's just not good enough for any serious tasks. I really wanted to use it with my band for live gigs and rehearsals, but the issue with markers and the regular sync losses were unacceptable.

Through experiments I found that proper bound checking was needed to avoid the occasional sync loss/skipped regions due to numeric error. Even though reaper says a region starts at t1 and ends at t2 (EnumProjectMarkers), the reported play position (from GetPlayPosition) can be slightly less than t1 or slightly greater than t2. I chose an epsilon of 10ms as this value was already used in a couple of places.

A much more common bug was the sync loss after the very first region, where it just kept playing past the end of the region. This was due to a timing issue. I could reproduce it with both the smooth seek method and the GoToRegion method. My measurements clearly indicated a correlation between the occurrence of this bug and the time between the PlaylistPlay function call and the first PlaylistRun callback. If this measured time was less than about 5ms, the bug almost always happened. It seems like if not enough time has passed between the OnPlayButton call and the 'scheduling' of the second region via smooth seek/GoToRegion, then Reaper ignored the schedule 'request'. After I delayed the scheduling by 5 callbacks (160-200 ms), I couldn't reproduce this bug anymore. I added this small delay to all GoToRegion calls, just to be safe (and also it was easier this way).

Sadly the ending of the playlist must be done with a smooth seek, which of course also considers regular markers. I timed this after any markers that are within a region, but to be safe, there should be at least 0.5 seconds between the end of the region and any markers within.

I added two checks with warning dialogs due to these changes.

Also I stopped the SYNC LOSS text from flashing when the playlist finished, to make it look more professional.

I tried to keep the sync loss and end-of-playlist behavior the same as before. In my manual testing it was OK.

I tested my changes with looped/missing/touching regions as well as some loop corner cases I found in the c++ code comments. I ran a quite complex playlist with all these different scenarios on infinite loop, with a very elegant abort() call on sync loss or skipped regions, and it ran for about 250 loops without failure before I shut it down.