### PR TITLE
Speed up SWS Track Notes

### DIFF
--- a/SnM/SnM_Find.cpp
+++ b/SnM/SnM_Find.cpp
@@ -115,9 +115,10 @@ bool TrackNotesMatch(MediaTrack* _tr, const char* _searchStr)
 	bool match = false;
 	if (_tr)
 	{
+		const MediaTrackID trId = TrackToTrackID(_tr);
 		for (int i=0; i < g_SNM_TrackNotes.Get()->GetSize(); i++)
 		{
-			if (g_SNM_TrackNotes.Get()->Get(i)->GetTrack() == _tr)
+			if (g_SNM_TrackNotes.Get()->Get(i)->GetTrackID() == trId)
 			{
 				match = stristr(g_SNM_TrackNotes.Get()->Get(i)->GetNotes(), _searchStr) != NULL;
 				break;

--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -769,10 +769,12 @@ void NotesWnd::SaveCurrentTrackNotes(bool _wantUndo)
 	if (g_trNote && CSurf_TrackToID(g_trNote, false) >= 0)
 	{
 		GetWindowText(m_edit, g_lastText, sizeof(g_lastText));
+
+		const MediaTrackID trId = TrackToTrackID(g_trNote);
 		bool found = false;
 		for (int i=0; i < g_SNM_TrackNotes.Get()->GetSize(); i++) 
 		{
-			if (g_SNM_TrackNotes.Get()->Get(i)->GetTrack() == g_trNote)
+			if (g_SNM_TrackNotes.Get()->Get(i)->GetTrackID() == trId)
 			{
 				g_SNM_TrackNotes.Get()->Get(i)->SetNotes(g_lastText); // CRLF removed only when saving the project..
 				found = true;
@@ -1007,8 +1009,9 @@ int NotesWnd::UpdateTrackNotes()
 		{
 			g_trNote = selTr;
 
+			const MediaTrackID trId = TrackToTrackID(g_trNote);
 			for (int i=0; i < g_SNM_TrackNotes.Get()->GetSize(); i++)
-				if (g_SNM_TrackNotes.Get()->Get(i)->GetTrack() == g_trNote) {
+				if (g_SNM_TrackNotes.Get()->Get(i)->GetTrackID() == trId) {
 					SetText(g_SNM_TrackNotes.Get()->Get(i)->GetNotes());
 					return REQUEST_REFRESH;
 				}
@@ -1690,8 +1693,13 @@ int IsNotesLocked(COMMAND_T*) {
 ******************************************************************************/
 const char* NFDoGetSWSTrackNotes(MediaTrack* track)
 {
+	bool isValid = false;
+	const MediaTrackID trId = TrackToTrackID(track, &isValid);
+	if (!isValid)
+		return "";
+
 	for (int i = 0; i < g_SNM_TrackNotes.Get()->GetSize(); i++) {
-		if (g_SNM_TrackNotes.Get()->Get(i)->GetTrack() == track) {
+		if (g_SNM_TrackNotes.Get()->Get(i)->GetTrackID() == trId) {
 			return g_SNM_TrackNotes.Get()->Get(i)->GetNotes();
 			break;
 		}
@@ -1702,12 +1710,17 @@ const char* NFDoGetSWSTrackNotes(MediaTrack* track)
 
 void NFDoSetSWSTrackNotes(MediaTrack* track, const char* buf)
 {
+	bool isValid = false;
+	const MediaTrackID trId = TrackToTrackID(track, &isValid);
+	if (!isValid)
+		return;
+
 	if (MarkProjectDirty)
 		MarkProjectDirty(NULL);
 
 	for (int i = 0; i < g_SNM_TrackNotes.Get()->GetSize(); i++) {
 
-		if (g_SNM_TrackNotes.Get()->Get(i)->GetTrack() == track) {
+		if (g_SNM_TrackNotes.Get()->Get(i)->GetTrackID() == trId) {
 			g_SNM_TrackNotes.Get()->Get(i)->SetNotes(buf);
 
 			// update displayed text if Notes window is visible and notes for set track are displayed

--- a/SnM/SnM_Notes.h
+++ b/SnM/SnM_Notes.h
@@ -55,26 +55,26 @@ enum {
 
 class SNM_TrackNotes {
 public:
+	// The current project (project == NULL) doesn't always match
+	// the notes' project when saving in SaveExtensionConfig [#1141]
 	SNM_TrackNotes(ReaProject* project, const GUID* guid, const char* notes)
-		: m_project{project}, m_guid{*guid}, m_notes{notes}
-	{
-		// The current project (project == NULL) doen't always match
-		// the notes' project when saving in SaveExtensionConfig [#1141]
+		: m_trackId{(project == nullptr ? EnumProjects(-1, nullptr, 0) : project), *guid}
+		, m_notes{notes}
+	{}
 
-		if (!project)
-			m_project = EnumProjects(-1, nullptr, 0);
-	}
+	const MediaTrackID& GetTrackID	  () const { return m_trackId; 			 }
+	const GUID* 		GetGUID		  () const { return &m_trackId.guid; 	 }
+	const char* 		GetNotes	  () const { return m_notes.Get(); 		 }
+	int 				GetNotesLength() const { return m_notes.GetLength(); }
 
-	MediaTrack* GetTrack() { return GuidToTrack(m_project, &m_guid); }
-	const GUID* GetGUID() { return &m_guid; }
-	const char *GetNotes() const { return m_notes.Get(); }
-	int GetNotesLength() const { return m_notes.GetLength(); }
-	void SetNotes(const char *notes) { m_notes.Set(notes); }
+	// use MediaTrackID for lookup instead of this
+	MediaTrack* 	GetTrack	  () const { return TrackIDToTrack(m_trackId); }
+
+	void 			SetNotes(const char *notes) { m_notes.Set(notes); }
 
 private:
-	ReaProject *m_project;
-	GUID m_guid;
-	WDL_FastString m_notes;
+	const MediaTrackID m_trackId;
+	WDL_FastString     m_notes;
 };
 
 class SNM_RegionSubtitle {

--- a/sws_util.cpp
+++ b/sws_util.cpp
@@ -473,6 +473,39 @@ HWND GetRulerWnd()
 	return GetRulerWndAlt(); // BR: will take care of any localization issues
 }
 
+ReaProject* GetProject(MediaTrack* const track)
+{
+	if (track == nullptr)
+		return nullptr;
+
+	ReaProject* proj = GetCurrentProjectInLoadSave();
+	if (proj != nullptr && ValidatePtr2(proj, track, "MediaTrack*"))
+		return proj;
+
+	int idx  = -1;	// current project
+	while((proj = EnumProjects(idx++, nullptr, 0))) {
+		if (ValidatePtr2(proj, track, "MediaTrack*"))
+			return proj;
+	}
+
+	return nullptr;
+}
+
+MediaTrackID TrackToTrackID(MediaTrack* const track, bool* const isValidOut /* = nullptr */)
+{
+	MediaTrackID id{};
+	id.project = GetProject(track);
+
+	if (isValidOut != nullptr)
+		*isValidOut = id.project != nullptr;
+
+	if (id.project != nullptr) {
+		id.guid = *TrackToGuid(id.project, track);
+	}
+
+	return id;
+}
+
 // overrides the native GetTrackGUID(): returns a special GUID for the master track
 // (useful for persistence as no GUID is stored in RPP files for the master..)
 // note: TrackToGuid(NULL) will return also NULL, contrary to GetTrackGUID(NULL)

--- a/sws_util.h
+++ b/sws_util.h
@@ -223,25 +223,44 @@ void SaveWindowPos(HWND hwnd, const char* cKey);
 void RestoreWindowPos(HWND hwnd, const char* cKey, bool bRestoreSize = true);
 void SetWindowPosAtMouse(HWND hwnd);
 
-MediaTrack* GetFirstSelectedTrack();
-int NumSelTracks();
-void SaveSelected();
-void RestoreSelected();
-void ClearSelected();
-int GetFolderDepth(MediaTrack* tr, int* iType, MediaTrack** nextTr);
-int GetTrackVis(MediaTrack* tr); // &1 == mcp, &2 == tcp
-void SetTrackVis(MediaTrack* tr, int vis); // &1 == mcp, &2 == tcp
-int AboutBoxInit(); // Not worth its own .h
-HWND GetTrackWnd();
-HWND GetRulerWnd();
-const GUID* TrackToGuid(ReaProject*, MediaTrack*);
-inline const GUID* TrackToGuid(MediaTrack* tr) { return TrackToGuid(nullptr, tr); }
-MediaTrack* GuidToTrack(ReaProject*, const GUID*);
-inline MediaTrack* GuidToTrack(const GUID* guid) { return GuidToTrack(nullptr, guid); }
-bool GuidsEqual(const GUID* g1, const GUID* g2);
-bool TrackMatchesGuid(ReaProject*, MediaTrack*, const GUID*);
-inline bool TrackMatchesGuid(MediaTrack* tr, const GUID* g) { return TrackMatchesGuid(nullptr, tr, g); }
-const char *stristr(const char* a, const char* b);
+MediaTrack* 	GetFirstSelectedTrack();
+int 			NumSelTracks();
+void 			SaveSelected();
+void 			RestoreSelected();
+void 			ClearSelected();
+int 			GetFolderDepth(MediaTrack* tr, int* iType, MediaTrack** nextTr);
+int 			GetTrackVis(MediaTrack* tr); // &1 == mcp, &2 == tcp
+void 			SetTrackVis(MediaTrack* tr, int vis); // &1 == mcp, &2 == tcp
+int 			AboutBoxInit(); // Not worth its own .h
+HWND 			GetTrackWnd();
+HWND 			GetRulerWnd();
+bool 			GuidsEqual(const GUID* g1, const GUID* g2);
+const char*		stristr(const char* a, const char* b);
+ReaProject*		GetProject(MediaTrack* track);
+
+bool 			TrackMatchesGuid(ReaProject*, MediaTrack*, const GUID*);
+inline bool 	TrackMatchesGuid(MediaTrack* tr, const GUID* g) { return TrackMatchesGuid(nullptr, tr, g); }
+
+const GUID* 		TrackToGuid(ReaProject*, MediaTrack*);
+inline const GUID* 	TrackToGuid(MediaTrack* tr) { return TrackToGuid(nullptr, tr); }
+
+MediaTrack* 		GuidToTrack(ReaProject*, const GUID*);
+inline MediaTrack* 	GuidToTrack(const GUID* guid) { return GuidToTrack(nullptr, guid); }
+
+
+struct MediaTrackID {
+	ReaProject* project;
+	GUID		guid;
+};
+
+MediaTrackID 		TrackToTrackID(MediaTrack* tr, bool* isValidOut = nullptr);
+inline MediaTrack* 	TrackIDToTrack(const MediaTrackID& id) { return GuidToTrack(id.project, &id.guid); }
+
+inline bool operator==(const MediaTrackID& a, const MediaTrackID& b)
+{
+	return a.project == b.project && GuidsEqual(&a.guid, &b.guid);
+}
+
 
 // adjust take start offset obeying play rate and its stretch markers
 // caller must check for take != NULL


### PR DESCRIPTION
Fixes #1614

Calling GuidToTrack in for-loops made some operations painfully slow, e.g. "cfillion_Duplicate tracks (preserving SWS track notes).lua".

I made track-to-tracknotes lookups much faster by just comparing project pointers and guids, which is sufficient to globally identify any track.

Duplicating 256 tracks with notes:

Before:
GetSWSTrackNotes took 888 ms
Duplicate tracks took 41 ms
SetSWSTrackNotes took 4692 ms
The entire lua script took 5637 ms

Now:
GetSWSTrackNotes took: 1 ms
Duplicate tracks took: 53 ms
SetSWSTrackNotes took: 2 ms
The entire lua script took: 67 ms

It's barely even measureable in ms which made me worried that I screwed up something, but it seems to be working by my testing.