### PR TITLE
Use the more adequate GoToRegion API method in Region Playlist + stability improvements

### DIFF
--- a/SnM/SnM_RegionPlaylist.cpp
+++ b/SnM/SnM_RegionPlaylist.cpp
@@ -1644,6 +1644,11 @@ void PlaylistRun()
 		}
 	}
 
+	if (-1 == g_playCur && g_unsync) {
+		// Stop the 'SYNC LOSS' text from flashing after playlist ended. Looks unprofessional.
+		updated = false;
+	}
+
 	g_lastRunPos = pos;
 	if (updated && (g_osc || g_rgnplWndMgr.Get()))
 	{

--- a/SnM/SnM_RegionPlaylist.h
+++ b/SnM/SnM_RegionPlaylist.h
@@ -60,6 +60,7 @@ public:
 	double GetLength();
 	int GetNestedRegion();
 	int GetRegionWithUnsafeMarker();
+	int GetDangerouslyShortRegion();
 	int GetGreaterMarkerRegion(double _pos);
 	WDL_FastString m_name;
 };

--- a/SnM/SnM_RegionPlaylist.h
+++ b/SnM/SnM_RegionPlaylist.h
@@ -58,7 +58,8 @@ public:
 	int IsInPlaylist(double _pos, bool _repeat, int _startWith);
 	int IsInfinite();
 	double GetLength();
-	int GetNestedMarkerRegion();
+	int GetNestedRegion();
+	int GetRegionWithUnsafeMarker();
 	int GetGreaterMarkerRegion(double _pos);
 	WDL_FastString m_name;
 };

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -938,6 +938,7 @@ error:
 		IMPAPI(GetUserInputs);
 		IMPAPI(get_config_var);
 		IMPAPI(get_ini_file);
+		IMPAPI(GoToRegion);
 		IMPAPI(GR_SelectColor);
 		IMPAPI(GSC_mainwnd);
 		IMPAPI(guidToString);


### PR DESCRIPTION
Fixes  #1512
Fixes #1575
Fixes  #914

My goal was to make the Region Playlist more robust and reliable. In my opinion, in its current state it's just not good enough for any serious tasks. I really wanted to use it with my band for live gigs and rehearsals, but the issue with markers and the regular sync losses were unacceptable.

Through experiments I found that proper bound checking was needed to avoid the occasional sync loss/skipped regions due to numeric error. Even though reaper says a region starts at t1 and ends at t2 (EnumProjectMarkers), the reported play position (from GetPlayPosition) can be slightly less than t1 or slightly greater than t2. I chose an epsilon of 10ms as this value was already used in a couple of places.

A much more common bug was the sync loss after the very first region, where it just kept playing past the end of the region. This was due to a timing issue. I could reproduce it with both the smooth seek method and the GoToRegion method. My measurements clearly indicated a correlation between the occurrence of this bug and the time between the PlaylistPlay function call and the first PlaylistRun callback. If this measured time was less than about 5ms, the bug almost always happened. It seems like if not enough time has passed between the OnPlayButton call and the 'scheduling' of the second region via smooth seek/GoToRegion, then Reaper ignored the schedule 'request'. After I delayed the scheduling by 5 callbacks (160-200 ms), I couldn't reproduce this bug anymore. I added this small delay to all GoToRegion calls, just to be safe (and also it was easier this way).

Sadly the ending of the playlist must be done with a smooth seek, which of course also considers regular markers. I timed this after any markers that are within a region, but to be safe, there should be at least 0.5 seconds between the end of the region and any markers within.

I added two checks with warning dialogs due to these changes.

Also I stopped the SYNC LOSS text from flashing when the playlist finished, to make it look more professional.

I tried to keep the sync loss and end-of-playlist behavior the same as before. In my manual testing it was OK.

I tested my changes with looped/missing/touching regions as well as some loop corner cases I found in the c++ code comments. I ran a quite complex playlist with all these different scenarios on infinite loop, with a very elegant abort() call on sync loss or skipped regions, and it ran for about 250 loops without failure before I shut it down.