### PR TITLE
Store colors in a platform-agnostic format

### DIFF
--- a/Color/Color.h
+++ b/Color/Color.h
@@ -26,9 +26,8 @@
 ******************************************************************************/
 #pragma once
 
-extern COLORREF g_custColors[16];
-extern COLORREF g_crGradStart;
-extern COLORREF g_crGradEnd;
+extern COLORREF g_custColors[16]; // in native format (RGB or BGR), shared with REAPER
+extern COLORREF g_crGradStart, g_crGradEnd; // in portable format (RGB)
 
 void UpdateCustomColors();
 void PersistColors();
@@ -37,3 +36,11 @@ COLORREF CalcGradient(COLORREF crStart, COLORREF crEnd, double dPos);
 int ColorInit();
 void ColorExit();
 void ShowColorDialog(COMMAND_T* = NULL);
+
+int SWS_ColorToNative(int xrgb);
+// int SWS_ColorFromNative(int bgr_or_rgb);
+#define SWS_ColorFromNative SWS_ColorToNative
+
+// convert to/from RGB with optional enable bit, or negative value
+int ImportColor(int stored);
+int ExportColor(int rgb_or_neg);

--- a/Misc/Adam.cpp
+++ b/Misc/Adam.cpp
@@ -953,7 +953,7 @@ void AWDoAutoGroup(bool rec)
 				int rndColor;
 				if (g_AWAutoGroupRndColor)
 					// use WDL Mersenne Twister
-					rndColor = ColorToNative(g_MTRand.randInt(255), g_MTRand.randInt(255), g_MTRand.randInt(255)) | 0x1000000;
+					rndColor = RGB(g_MTRand.randInt(255), g_MTRand.randInt(255), g_MTRand.randInt(255)) | 0x1000000;
 
 				for (int i = 0; i < selItems.GetSize(); i++) {
 					MediaItem* item = selItems.Get()[i];
@@ -1026,7 +1026,7 @@ void NFDoAutoGroupTakesMode(WDL_TypedBuf<MediaItem*> origSelItems)
 
 	int rndColor;
 	if (g_AWAutoGroupRndColor)
-		rndColor = ColorToNative(g_MTRand.randInt(255), g_MTRand.randInt(255), g_MTRand.randInt(255)) | 0x1000000;
+		rndColor = RGB(g_MTRand.randInt(255), g_MTRand.randInt(255), g_MTRand.randInt(255)) | 0x1000000;
 
 	// do column-wise grouping
 	// loop through columns of items

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -742,7 +742,6 @@ error:
 /* unused
 		IMPAPI(Audio_RegHardwareHook);
 */
-		IMPAPI(ColorToNative)
 		IMPAPI(CoolSB_GetScrollInfo);
 		IMPAPI(CoolSB_SetScrollInfo);
 		IMPAPI(CountActionShortcuts);


### PR DESCRIPTION
Changes the color storage format to 0x2RRGGBB everywhere. The extra bit indicates whether the new format is in use. (0x1000000 being already taken by REAPER and auto-color stores it in projects.)

Existing settings are converted automatically. Loading new settings with an old version of SWS will temporarily swap the colors on Windows until updated again.

Custom colors remain swapped between Windows and Linux because those are stored by REAPER.

Fixes #1811, fixes #1400