### PR TITLE
Simplified implementation of #1801 (SNM_TrackNotes lookup optimization)

### DIFF
--- a/ReaScript.cpp
+++ b/ReaScript.cpp
@@ -28,6 +28,7 @@
 #include "stdafx.h"
 #include "SnM/SnM_FX.h"
 #include "SnM/SnM_Misc.h"
+#include "SnM/SnM_Notes.h"
 #include "SnM/SnM_Resources.h"
 #include "SnM/SnM_Routing.h"
 #include "SnM/SnM_Track.h"

--- a/SnM/SnM_Find.cpp
+++ b/SnM/SnM_Find.cpp
@@ -112,9 +112,6 @@ bool TrackNameMatch(MediaTrack* _tr, const char* _searchStr) {
 
 bool TrackNotesMatch(MediaTrack* _tr, const char* _searchStr) 
 {
-	if (!_tr)
-		return false;
-
 	SNM_TrackNotes *notes = SNM_TrackNotes::find(_tr);
 	return notes && stristr(notes->GetNotes(), _searchStr);
 }

--- a/SnM/SnM_Find.cpp
+++ b/SnM/SnM_Find.cpp
@@ -112,19 +112,11 @@ bool TrackNameMatch(MediaTrack* _tr, const char* _searchStr) {
 
 bool TrackNotesMatch(MediaTrack* _tr, const char* _searchStr) 
 {
-	bool match = false;
-	if (_tr)
-	{
-		for (int i=0; i < g_SNM_TrackNotes.Get()->GetSize(); i++)
-		{
-			if (g_SNM_TrackNotes.Get()->Get(i)->GetTrack() == _tr)
-			{
-				match = stristr(g_SNM_TrackNotes.Get()->Get(i)->GetNotes(), _searchStr) != NULL;
-				break;
-			}
-		}
-	}
-	return match;
+	if (!_tr)
+		return false;
+
+	SNM_TrackNotes *notes = SNM_TrackNotes::find(_tr);
+	return notes && stristr(notes->GetNotes(), _searchStr);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -129,10 +129,14 @@ bool g_internalMkrRgnChange = false;
 
 SNM_TrackNotes *SNM_TrackNotes::find(MediaTrack *track)
 {
+	const GUID *guid = TrackToGuid(track);
+	if (!guid)
+		return nullptr;
+
 	for (int i = 0; i < g_SNM_TrackNotes.Get()->GetSize(); ++i)
 	{
 		SNM_TrackNotes *notes = g_SNM_TrackNotes.Get()->Get(i);
-		if (notes->GetTrack() == track)
+		if (GuidsEqual(guid, notes->GetGUID()))
 			return notes;
 	}
 	return nullptr;

--- a/SnM/SnM_Notes.h
+++ b/SnM/SnM_Notes.h
@@ -55,6 +55,8 @@ enum {
 
 class SNM_TrackNotes {
 public:
+	static SNM_TrackNotes *find(MediaTrack *);
+
 	SNM_TrackNotes(ReaProject* project, const GUID* guid, const char* notes)
 		: m_project{project}, m_guid{*guid}, m_notes{notes}
 	{
@@ -189,10 +191,6 @@ void SetActionHelpFilename(COMMAND_T*);
 bool GetStringFromNotesChunk(WDL_FastString* _notes, char* _buf, int _bufMaxSize);
 bool GetNotesChunkFromString(const char* _buf, WDL_FastString* _notes, const char* _startLine = NULL);
 
-
-extern SWSProjConfig<WDL_PtrList_DOD<SNM_TrackNotes> > g_SNM_TrackNotes;
-
-
 void NotesSetTrackTitle();
 void NotesSetTrackListChange();
 
@@ -207,8 +205,8 @@ int IsNotesLocked(COMMAND_T*);
 void WriteGlobalNotesToFile();
 
 // ReaScript export
-const char* NFDoGetSWSTrackNotes(MediaTrack* track);
-void NFDoSetSWSTrackNotes(MediaTrack* track, const char* buf);
+const char* NF_GetSWSTrackNotes(MediaTrack*);
+void NF_SetSWSTrackNotes(MediaTrack*, const char* buf);
 
 const char* NFDoGetSWSMarkerRegionSub(int mkrRgnIdx);
 bool NFDoSetSWSMarkerRegionSub(const char* mkrRgnSubIn, int mkrRgnIdx);

--- a/nofish/NF_ReaScript.cpp
+++ b/nofish/NF_ReaScript.cpp
@@ -296,16 +296,6 @@ bool NF_AnalyzeTakeLoudness2(MediaItem_Take * take, bool analyzeTruePeak, double
 }
 
 // #755, Track notes
-const char* NF_GetSWSTrackNotes(MediaTrack* track)
-{
-	return NFDoGetSWSTrackNotes(track);
-}
-
-void NF_SetSWSTrackNotes(MediaTrack* track, const char* buf)
-{
-	NFDoSetSWSTrackNotes(track, buf);
-}
-
 const char* NF_GetSWSMarkerRegionSub(int mkrRgnIdx)
 {
 	return NFDoGetSWSMarkerRegionSub(mkrRgnIdx);

--- a/nofish/NF_ReaScript.h
+++ b/nofish/NF_ReaScript.h
@@ -45,8 +45,6 @@ bool            NF_AnalyzeTakeLoudness(MediaItem_Take* take, bool analyzeTruePea
 bool            NF_AnalyzeTakeLoudness2(MediaItem_Take* take, bool analyzeTruePeak, double* lufsOut, double* rangeOut, double* truePeakOut, double* truePeakPosOut, double* shorTermMaxOut, double* momentaryMaxOut, double* shortTermMaxPosOut, double* momentaryMaxPosOut);
 
 // #755
-const char*    NF_GetSWSTrackNotes(MediaTrack* track);
-void           NF_SetSWSTrackNotes(MediaTrack* track, const char* buf);
 const char*    NF_GetSWSMarkerRegionSub(int mkrRgnIdx);
 bool           NF_SetSWSMarkerRegionSub(const char* mkrRgnSub, int mkrRgnIdx);
 void           NF_UpdateSWSMarkerRegionSubWindow();


### PR DESCRIPTION
`TrackToGuid(track)` ensures that the track belongs to the current project and `g_SNM_TrackNotes.Get()` access only the notes in the current project, guaranteeing that there cannot be false positives from other projects.

Here's an optional patch that restores @Szapi's great idea of a track handle object, if cross-project comparisons becomes necessary in the future:

```diff
diff --git a/SnM/SnM_Notes.cpp b/SnM/SnM_Notes.cpp
index 4d64cf83..5d2e8b36 100644
--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -129,14 +129,11 @@ bool g_internalMkrRgnChange = false;
 
 SNM_TrackNotes *SNM_TrackNotes::find(MediaTrack *track)
 {
-	const GUID *guid = TrackToGuid(track);
-	if (!guid)
-		return nullptr;
-
+	const TrackHandle handle { track };
 	for (int i = 0; i < g_SNM_TrackNotes.Get()->GetSize(); ++i)
 	{
 		SNM_TrackNotes *notes = g_SNM_TrackNotes.Get()->Get(i);
-		if (GuidsEqual(guid, notes->GetGUID()))
+		if (notes->GetTrack() == handle)
 			return notes;
 	}
 	return nullptr;
@@ -1531,10 +1528,10 @@ static void SaveExtensionConfig(ProjectStateContext *ctx, bool isUndo, struct pr
 	{
 		if (SNM_TrackNotes* tn = g_SNM_TrackNotes.Get()->Get(i))
 		{
-			MediaTrack* tr = tn->GetTrack();
-			if (tr && tn->GetNotesLength() > 0)
+			const TrackHandle &tr = tn->GetTrack();
+			if (tr.resolve() && tn->GetNotesLength() > 0)
 			{
-				guidToString((GUID*)tn->GetGUID(), strId);
+				guidToString(const_cast<GUID*>(tr.guid()), strId);
 				if (snprintfStrict(line, sizeof(line), "<S&M_TRACKNOTES %s\n|", strId) > 0)
 					if (GetNotesChunkFromString(tn->GetNotes(), &formatedNotes, line))
 						StringToExtensionConfig(&formatedNotes, ctx);
diff --git a/SnM/SnM_Notes.h b/SnM/SnM_Notes.h
index 1858e0ce..dc7f1191 100644
--- a/SnM/SnM_Notes.h
+++ b/SnM/SnM_Notes.h
@@ -58,24 +58,19 @@ public:
 	static SNM_TrackNotes *find(MediaTrack *);
 
 	SNM_TrackNotes(ReaProject* project, const GUID* guid, const char* notes)
-		: m_project{project}, m_guid{*guid}, m_notes{notes}
+		: m_track{project, guid}, m_notes{notes}
 	{
 		// The current project (project == NULL) doen't always match
 		// the notes' project when saving in SaveExtensionConfig [#1141]
-
-		if (!project)
-			m_project = EnumProjects(-1, nullptr, 0);
 	}
 
-	MediaTrack* GetTrack() { return GuidToTrack(m_project, &m_guid); }
-	const GUID* GetGUID() { return &m_guid; }
+	const TrackHandle &GetTrack() { return m_track; }
 	const char *GetNotes() const { return m_notes.Get(); }
 	int GetNotesLength() const { return m_notes.GetLength(); }
 	void SetNotes(const char *notes) { m_notes.Set(notes); }
 
 private:
-	ReaProject *m_project;
-	GUID m_guid;
+	TrackHandle m_track;
 	WDL_FastString m_notes;
 };
 
diff --git a/sws_util.h b/sws_util.h
index acb08080..c52f9781 100644
--- a/sws_util.h
+++ b/sws_util.h
@@ -243,6 +243,39 @@ bool TrackMatchesGuid(ReaProject*, MediaTrack*, const GUID*);
 inline bool TrackMatchesGuid(MediaTrack* tr, const GUID* g) { return TrackMatchesGuid(nullptr, tr, g); }
 const char *stristr(const char* a, const char* b);
 
+class TrackHandle {
+public:
+	TrackHandle(ReaProject *proj, const GUID *guid)
+	  : m_project { proj }, m_guid { guid ? *guid : GUID_NULL }
+	{
+		if (!proj)
+			m_project = EnumProjects(-1, nullptr, 0);
+	}
+
+	TrackHandle(ReaProject *proj, MediaTrack *track)
+	  : TrackHandle { proj, TrackToGuid(proj, track) }
+	{}
+
+	TrackHandle(MediaTrack *track)
+	  : TrackHandle { nullptr, track }
+	{}
+
+	bool operator==(const TrackHandle &o) const
+	{
+		return m_project == o.m_project && GuidsEqual(&m_guid, &o.m_guid);
+	}
+	bool operator!=(const TrackHandle &o) const { return !(*this == o); }
+
+	const GUID *guid() const { return &m_guid; }
+
+	// scary slow-sounding method name
+	MediaTrack *resolve() const { return GuidToTrack(m_project, &m_guid); }
+
+private:
+	ReaProject *m_project;
+	GUID m_guid;
+};
+
 // adjust take start offset obeying play rate and its stretch markers
 // caller must check for take != NULL
 void AdjustTakesStartOffset(MediaItem *, double adjustment);
```