### PR TITLE
Release on tag pushes & ReaPack support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ for:
         $2 = "[arch=armhf,arm64]";
         $3 = "http://ports.ubuntu.com/ubuntu-ports/"
       } 1' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list > /dev/null
-      sudo sed -i 's/apt.postgresql.org/apt-archive-postgresql.org/' /etc/apt/sources.list
+      sudo sed -i 's/apt.postgresql.org/apt-archive.postgresql.org/' /etc/apt/sources.list
 
       install-deps() {
         local arch="$1"; shift
@@ -57,13 +57,14 @@ for:
       - cmake --build .
       - cpack
     deploy_script: |-
-      if [ "$APPVEYOR_REPO_BRANCH" = "master" ] && [ -n "$DEPLOY_KEY" ]; then
+      if [ "$APPVEYOR_REPO_TAG" = "true" ] && [ -n "$DEPLOY_KEY" ]; then
         echo "$DEPLOY_KEY" | base64 -d > deploy_key && chmod 600 deploy_key &&
         scp -i deploy_key -o StrictHostKeyChecking=NO -q sws*.tar.xz \
           swsci@sws-extension.org:/var/www/standingwaterstudios.com/download/pre-release
       fi
     artifacts:
       - path: build/sws*.tar.xz
+      - path: build/reaper_sws*.so
 
   - matrix: { only: [ appveyor_build_worker_image: macos, appveyor_build_worker_image: macos-mojave ] }
     install:
@@ -90,13 +91,14 @@ for:
       - cmake --build .
       - cpack
     deploy_script: |-
-      if [ "$APPVEYOR_REPO_BRANCH" = "master" ] && [ -n "$DEPLOY_KEY" ]; then
+      if [ "$APPVEYOR_REPO_TAG" = "true" ] && [ -n "$DEPLOY_KEY" ]; then
         echo "$DEPLOY_KEY" | base64 -D > deploy_key && chmod 600 deploy_key &&
         scp -i deploy_key -o StrictHostKeyChecking=NO -q sws*.dmg \
           swsci@sws-extension.org:/var/www/standingwaterstudios.com/download/pre-release
       fi
     artifacts:
       - path: build/sws*.dmg
+      - path: build/reaper_sws*.dylib
 
   - matrix: { only: [ appveyor_build_worker_image: &windows Visual Studio 2022 ] }
     install:
@@ -118,7 +120,7 @@ for:
       - '"C:\Program Files\CMake\bin\cpack"'
     deploy_script:
       - ps: |-
-          if($env:APPVEYOR_REPO_BRANCH -eq "master" -And $env:DEPLOY_KEY -ne $null) {
+          if($env:APPVEYOR_REPO_TAG -eq "true" -And $env:DEPLOY_KEY -ne $null) {
             $bytes = [System.Convert]::FromBase64String($env:DEPLOY_KEY)
             [System.IO.File]::WriteAllBytes("$($PWD)\deploy_key", $bytes)
             icacls deploy_key /c /t /Inheritance:d > $null
@@ -130,6 +132,8 @@ for:
           }
     artifacts:
       - path: build\sws*.exe
+      - path: build\sws_python*.py
+      - path: build\reaper_sws*.dll
       - path: build\reaper_sws*.pdb
       - path: build\BuildUtils\SWS_Template.ReaperLangPack
       - path: build\BuildUtils\whatsnew.html

--- a/Breeder/BR.cpp
+++ b/Breeder/BR.cpp
@@ -1251,7 +1251,7 @@ int BR_Init ()
 	LoudnessInitExit(true);
 	ProjectTrackSelInitExit(true);
 	ProjStateInitExit(true);
-	VersionCheckInitExit(true);
+	// VersionCheckInitExit(true); called from PackageInit in sws_about.cpp
 
 	// Load various global variables
 	COMMAND_T ct = {};

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,14 +250,16 @@ set_target_properties(sws PROPERTIES
   OUTPUT_NAME "reaper_sws-${ARCH_NAME}"
 )
 
-set(REAPER_USER_PLUGINS "UserPlugins")
+set(REAPER_DATA         "Data")
 set(REAPER_SCRIPTS      "Scripts")
+set(REAPER_USER_PLUGINS "UserPlugins")
 
 if(NO_INSTALL_PREFIX)
   # Used for .dmg generation to avoid getting directories
   # Maybe there's a better way?
-  set(REAPER_USER_PLUGINS ".")
+  set(REAPER_DATA         ".")
   set(REAPER_SCRIPTS      ".")
+  set(REAPER_USER_PLUGINS ".")
 endif()
 
 install(TARGETS sws
@@ -275,7 +277,7 @@ endif()
 
 install(DIRECTORY "FingersExtras/Grooves"
   COMPONENT   grooves
-  DESTINATION .
+  DESTINATION "${REAPER_DATA}"
   EXCLUDE_FROM_ALL
 )
 

--- a/Fingers/GrooveTemplates.cpp
+++ b/Fingers/GrooveTemplates.cpp
@@ -89,10 +89,9 @@ std::string GrooveTemplateHandler::GetGrooveDir()
 {
     std::string dir = getReaperProperty("groove_dir");
     if (dir.empty())
-    {        // Installer puts the grooves into the resource path under "Grooves"
-        dir.assign(GetResourcePath());
-        dir += PATH_SLASH_CHAR;
-        dir += "Grooves";
+    {   // Installer puts the grooves into the resource path under "Data/Grooves"
+        dir  = GetResourcePath();
+        dir += WDL_DIRCHAR_STR "Data" WDL_DIRCHAR_STR "Grooves";
     }
     return dir;
 }

--- a/reaper/sws_rpf_wrapper.h
+++ b/reaper/sws_rpf_wrapper.h
@@ -53,6 +53,10 @@ REAPER_EXTRA_API_DECL bool (*ListView_HeaderHitTest)(HWND, POINT);
 // jcsteh/osara#359
 REAPER_EXTRA_API_DECL bool (*osara_isShortcutHelpEnabled)();
 
+struct ReaPack_PackageEntry;
+REAPER_EXTRA_API_DECL ReaPack_PackageEntry *(*ReaPack_GetOwner)(const char *fn, char *errOut, int errOut_sz);
+REAPER_EXTRA_API_DECL void (*ReaPack_FreeEntry)(ReaPack_PackageEntry *);
+
 // Avoid VWnd collisions
 #define WDL_VirtualWnd_ScaledBlitBG WDL_VirtualWnd_ScaledBlitBG_fptr
 #define WDL_VirtualWnd_BGCfg WDL_VirtualWnd_BGCfg_stub

--- a/setup/win32/NSIS.template.in
+++ b/setup/win32/NSIS.template.in
@@ -53,6 +53,7 @@ Section "Python ReaScript support" sws_python
 SectionEnd
 
 Section "Grooves" grooves
+  Rename "$OUTDIR\Grooves" "$OUTDIR\Data\Grooves"
   !insertmacro ComponentFiles grooves
 SectionEnd
 
@@ -64,7 +65,7 @@ SectionEnd
     "Allow Python ReaScripts to use SWS functions. Installed in $OUTDIR\Scripts"
 
   !insertmacro MUI_DESCRIPTION_TEXT ${grooves} \
-    "Grooves are used with the groove tool. Installed in $OUTDIR."
+    "Grooves are used with the groove tool. Installed in $OUTDIR\Data."
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 Function .onInit

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -475,6 +475,11 @@ static void importExtensionAPI()
 
 	// import functions exposed by third-party extensions
 	osara_isShortcutHelpEnabled = (decltype(osara_isShortcutHelpEnabled))plugin_getapi("osara_isShortcutHelpEnabled");
+
+	ReaPack_GetOwner  = (decltype(ReaPack_GetOwner)) plugin_getapi("ReaPack_GetOwner");
+	ReaPack_FreeEntry = (decltype(ReaPack_FreeEntry))plugin_getapi("ReaPack_FreeEntry");
+
+	PackageInit();
 }
 
 // Fake control surface to get a low priority periodic time slice from Reaper

--- a/sws_util.h
+++ b/sws_util.h
@@ -232,6 +232,7 @@ int GetFolderDepth(MediaTrack* tr, int* iType, MediaTrack** nextTr);
 int GetTrackVis(MediaTrack* tr); // &1 == mcp, &2 == tcp
 void SetTrackVis(MediaTrack* tr, int vis); // &1 == mcp, &2 == tcp
 int AboutBoxInit(); // Not worth its own .h
+void PackageInit();
 HWND GetTrackWnd();
 HWND GetRulerWnd();
 const GUID* TrackToGuid(ReaProject*, MediaTrack*);


### PR DESCRIPTION
- Changes the CI script to upload to https://www.sws-extension.org/download/pre-release/ only when building tags
- Disables the built-in update checker when SWS has been installed using ReaPack
- Changes the default location of groove files to $resource_path/Data/Grooves
    - The NSIS installer automatically moves the old folder (including user custom files)
    - No intervention required if users did not manually set the path setting
    - macOS users are not impacted as they are already using a custom folder

Proof of concept ReaPack repository at https://cfillion.ca/files/sws/index.xml. Planning to upload the v2.14 package on ReaTeam Extensions repository as per #1827.

The bitness-specific wrapper is installed as `$resource_path/Scripts/$repository_name/API/sws.py` (instead of the separate sws_python.py, sws_python{32,64}.py files in Scripts of the legacy installers).

This has brought to light a 7 years old bug in ReaPack 1.2+ causing a crash when installing the SWS groove files because of the '%' in some of the filenames. Released ReaPack v1.2.4.4 to address that.

Fixes #1548, fixes #1827.