### PR TITLE
Contextual toolbars: fix inverted selection validation

### DIFF
--- a/Breeder/BR_ContextualToolbars.cpp
+++ b/Breeder/BR_ContextualToolbars.cpp
@@ -1732,7 +1732,7 @@ void BR_ContextualToolbarsView::GetItemList (SWS_ListItemList* pList)
 
 bool BR_ContextualToolbarsView::OnItemSelChanging (SWS_ListItem* item, bool bSel)
 {
-	return item && IsContextValid(*(int*)item);
+	return !item || !IsContextValid(*(int*)item); // true = prevent the change
 }
 
 void BR_ContextualToolbarsView::OnItemDblClk (SWS_ListItem* item, int iCol)


### PR DESCRIPTION
Regression from 64c07b64b19e1542fb6a05f25084c12e999f144f, the incorrect rewrite of `OnItemSelChanging` broke selection only on Windows.

https://forum.cockos.com/showpost.php?p=2757815