### PR TITLE
Add GetTrackHeightAndOffsetWithSpacers()

### DIFF
--- a/Breeder/BR_MouseUtil.cpp
+++ b/Breeder/BR_MouseUtil.cpp
@@ -101,7 +101,7 @@ static MediaTrack* GetTrackFromY (int y, int* trackHeight, int* offset, int* spa
 	MediaTrack* track = GetTrackAreaFromY(y, &trackOffset, &spacer);
 	if (track)
 	{
-		trackH = GetTrackHeight(track, NULL);
+		trackH = GetTrackHeightWithSpacer(track);
 		if (y < trackOffset || y >= trackOffset + trackH)
 			track = NULL;
 	}
@@ -1481,7 +1481,7 @@ void BR_MouseInfo::GetTrackOrEnvelopeFromY (int y, TrackEnvelope** _envelope, Me
 	TrackEnvelope* envelope = NULL;
 	if (track)
 	{
-		elementHeight = GetTrackHeight(track, NULL);
+		elementHeight = GetTrackHeightWithSpacer(track);
 		vector<pair<int,int>> envHeights;
 		bool yInTrack = (y < elementOffset + elementHeight) ? true : false;
 

--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -2119,9 +2119,9 @@ int GetTrackHeightFromVZoomIndex (MediaTrack* track, int vZoom)
 				// Calculate track height (method stolen from Zoom.cpp - Thanks Tim!)
 				int normalizedZoom = (vZoom < 30) ? (vZoom - 4) : (30 + 3*(vZoom - 30) - 4);
 				height = minHeight + ((maxHeight-minHeight)*normalizedZoom) / 56;
-				height += GetTrackSpacerSize(track);
 			}
 		}
+		height += GetTrackSpacerSize(track, false, &height);
 	}
 	return height;
 }
@@ -2274,7 +2274,7 @@ static int GetTrackFixedLanesFlags (MediaTrack* track)
 }
 
 // Same logic as REAPER v7.11
-static int LimitTrackSpacerSize (MediaTrack* track, const int maxgap, const bool isMCP)
+static int LimitTrackSpacerSize (MediaTrack* track, const int maxgap, const bool isMCP, const int* heightOverride)
 {
 	if (isMCP)
 		return maxgap;
@@ -2287,7 +2287,7 @@ static int LimitTrackSpacerSize (MediaTrack* track, const int maxgap, const bool
 	else
 		divisor = 1;
 
-	const int height = static_cast<int>(GetMediaTrackInfo_Value(track, "I_TCPH"));
+	const int height = heightOverride ? *heightOverride : static_cast<int>(GetMediaTrackInfo_Value(track, "I_TCPH"));
 	return std::min(height / divisor, maxgap);
 }
 
@@ -2305,7 +2305,7 @@ bool HasTrackSpacerBefore (MediaTrack* track, const bool isMCP)
 	return false;
 }
 
-int GetTrackSpacerSize (MediaTrack* track, const bool isMCP)
+int GetTrackSpacerSize (MediaTrack* track, const bool isMCP, const int* heightOverride)
 {
 	static const ConfigVar<int> trackgapmax("trackgapmax");
 
@@ -2314,7 +2314,7 @@ int GetTrackSpacerSize (MediaTrack* track, const bool isMCP)
 		if (!track)
 			return *trackgapmax;
 		else if (HasTrackSpacerBefore(track, isMCP))
-			return LimitTrackSpacerSize(track, *trackgapmax, isMCP);
+			return LimitTrackSpacerSize(track, *trackgapmax, isMCP, heightOverride);
 	}
 
 	return 0;

--- a/Breeder/BR_Util.h
+++ b/Breeder/BR_Util.h
@@ -233,7 +233,7 @@ int GetTakeHeight (MediaItem* item, int id, int* offsetY);
 int GetTakeEnvHeight (MediaItem_Take* take, int* offsetY);
 int GetTakeEnvHeight (MediaItem* item, int id, int* offsetY);
 int GetTrackEnvHeight (TrackEnvelope* envelope, int* offsetY, bool drawableRangeOnly, MediaTrack* parent = NULL);
-int GetTrackSpacerSize (MediaTrack* track);
+int GetTrackSpacerSize (MediaTrack* track, bool isMcp = false);
 
 /******************************************************************************
 * Arrange                                                                     *

--- a/Breeder/BR_Util.h
+++ b/Breeder/BR_Util.h
@@ -225,6 +225,7 @@ bool IsItemLocked (MediaItem* item);
 int GetTrackHeightFromVZoomIndex (MediaTrack* track, int vZoom); // also takes track compacting into account
 int GetEnvHeightFromTrackHeight (int trackHeight);               // what is envelope height in case its height override is 0 ?
 int GetMasterTcpGap ();
+int GetTrackHeightWithSpacer (MediaTrack* track, int* offsetY = NULL, int* topGap = NULL, int* bottomGap = NULL);
 int GetTrackHeight (MediaTrack* track, int* offsetY, int* topGap = NULL, int* bottomGap = NULL);
 int GetItemHeight (MediaItem* item, int* offsetY);
 int GetTakeHeight (MediaItem_Take* take, int* offsetY);

--- a/Breeder/BR_Util.h
+++ b/Breeder/BR_Util.h
@@ -222,7 +222,7 @@ bool IsItemLocked (MediaItem* item);
 /******************************************************************************
 * Height                                                                      *
 ******************************************************************************/
-int GetTrackHeightFromVZoomIndex (MediaTrack* track, int vZoom); // also takes track compacting into account
+int GetTrackHeightFromVZoomIndex (MediaTrack* track, int vZoom); // also takes track compacting and spacer into account
 int GetEnvHeightFromTrackHeight (int trackHeight);               // what is envelope height in case its height override is 0 ?
 int GetMasterTcpGap ();
 int GetTrackHeightWithSpacer (MediaTrack* track, int* offsetY = NULL, int* topGap = NULL, int* bottomGap = NULL);
@@ -233,7 +233,7 @@ int GetTakeHeight (MediaItem* item, int id, int* offsetY);
 int GetTakeEnvHeight (MediaItem_Take* take, int* offsetY);
 int GetTakeEnvHeight (MediaItem* item, int id, int* offsetY);
 int GetTrackEnvHeight (TrackEnvelope* envelope, int* offsetY, bool drawableRangeOnly, MediaTrack* parent = NULL);
-int GetTrackSpacerSize (MediaTrack* track, bool isMcp = false);
+int GetTrackSpacerSize (MediaTrack* track, bool isMcp = false, const int* heightOverride = NULL);
 
 /******************************************************************************
 * Arrange                                                                     *

--- a/SnM/SnM_Window.cpp
+++ b/SnM/SnM_Window.cpp
@@ -233,8 +233,7 @@ void GetVisibleTCPTracks(WDL_PtrList<MediaTrack>* _trList)
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
 		TCPY = static_cast<int>(GetMediaTrackInfo_Value(tr, "I_TCPY"));
-		TCPH = static_cast<int>(GetMediaTrackInfo_Value(tr, "I_TCPH"));
-		GetTrackGap(TCPH, &topGap, &bottomGap);
+		TCPH = GetTrackHeight(tr, nullptr, &topGap, &bottomGap);
 		if ((TCPY + TCPH - bottomGap > 0) && (TCPY + topGap < arrangeHeight))
 			_trList->Add(tr);
 	}

--- a/Wol/wol_Util.cpp
+++ b/Wol/wol_Util.cpp
@@ -178,7 +178,7 @@ void SetArrangeScroll(int offsetY, int height, VerticalZoomCenter center)
 void SetArrangeScrollTo(MediaTrack* track, VerticalZoomCenter center)
 {
 	int offsetY;
-	int height = GetTrackHeight(track, &offsetY);
+	int height = GetTrackHeightWithSpacer(track, &offsetY);
 	SetArrangeScroll(offsetY, height, center);
 }
 

--- a/Zoom.cpp
+++ b/Zoom.cpp
@@ -170,9 +170,12 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 				{
 					int trackHeight = 0;
 					if (obeyHeightLock && locked)
+					{
 						trackHeight = static_cast<int>(GetMediaTrackInfo_Value(tr, "I_HEIGHTOVERRIDE"));
+						trackHeight += GetTrackSpacerSize(tr);
+					}
 					else
-						trackHeight = GetTrackHeightFromVZoomIndex(tr, 0);
+						trackHeight = GetTrackHeightWithSpacer(tr);
 
 					trackHeight += CountTrackEnvelopePanels(tr) * GetEnvHeightFromTrackHeight(trackHeight);
 					iNotZoomedSize += trackHeight;
@@ -224,10 +227,13 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 			if (bZoomed[i])
 			{
 				if (i + 1 == iNum)
-					iEachHeight +=leftOverHeight;
+					iEachHeight += leftOverHeight;
 				MediaTrack* tr = CSurf_TrackFromID(i + iFirst, false);
 				if (!obeyHeightLock || !GetMediaTrackInfo_Value(tr, "B_HEIGHTLOCK"))
+				{
 					GetSetMediaTrackInfo(tr, "I_HEIGHTOVERRIDE", &iEachHeight);
+					iEachHeight += GetTrackSpacerSize(tr);
+				}
 			}
 		}
 		TrackList_AdjustWindows(false);
@@ -269,7 +275,10 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 				{
 					const bool locked = GetMediaTrackInfo_Value(tr, "B_HEIGHTLOCK");
 					if (obeyHeightLock && locked)
+					{
 						trackHeight = static_cast<int>(GetMediaTrackInfo_Value(tr, "I_HEIGHTOVERRIDE"));
+						trackHeight += GetTrackSpacerSize(tr);
+					}
 					else
 						trackHeight = GetTrackHeightFromVZoomIndex(tr, iZoom);
 

--- a/Zoom.cpp
+++ b/Zoom.cpp
@@ -193,7 +193,11 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 			for (int i = 0; i < iNum; i++)
 			{
 				if (bZoomed[i] && i + iFirst <= lastTrackId) // don't check envelope lanes height for the last track if includeEnvelopes == true
-					iLanesHeight += CountTrackEnvelopePanels(CSurf_TrackFromID(i + iFirst, false)) * GetEnvHeightFromTrackHeight(iEachHeight);
+				{
+					MediaTrack *track = CSurf_TrackFromID(i + iFirst, false);
+					iLanesHeight += CountTrackEnvelopePanels(track) * GetEnvHeightFromTrackHeight(iEachHeight);
+					iLanesHeight += GetTrackSpacerSize(track, false, &iEachHeight);
+				}
 			}
 			if (iEachHeight * iZoomed + iLanesHeight <= iTotalHeight)
 				break;
@@ -230,10 +234,7 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 					iEachHeight += leftOverHeight;
 				MediaTrack* tr = CSurf_TrackFromID(i + iFirst, false);
 				if (!obeyHeightLock || !GetMediaTrackInfo_Value(tr, "B_HEIGHTLOCK"))
-				{
 					GetSetMediaTrackInfo(tr, "I_HEIGHTOVERRIDE", &iEachHeight);
-					iEachHeight += GetTrackSpacerSize(tr);
-				}
 			}
 		}
 		TrackList_AdjustWindows(false);


### PR DESCRIPTION
GetTrackHeight() is now balanced to SetTrackHeight(), as previously -- it will get the 'content' portion height and offset of the track in the TCP. If you need the true track offset (- spacerSize) or height (+ spacerSize), use GetTrackHeightAndOffsetWithSpacers().

Updated a couple of Zoom.cpp functions to take the spacer size into account, missed on the first pass.