### PR TITLE
Fix high precision mousewheel shortcuts in multiple actions on REAPER v6.76+

### DIFF
--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -399,8 +399,8 @@ double GetMidiOscVal (double min, double max, double step, double currentVal, in
 	{
 		returnVal = TranslateRange(SetToBounds((double)(commandValhw | commandVal << 7), 0.0, 16383.0), 0, 16383, min, max);
 	}
-	// MIDI
-	else if (commandValhw == -1 && commandVal >= 0 && commandVal < 128)
+	// MIDI/mousewheel
+	else if (commandVal >= 0 && commandVal < 128)
 	{
 		// Absolute mode
 		if (!commandRelmode)

--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -1074,8 +1074,8 @@ void MidiOscActionJob::Init(ScheduledJob* _replacedJob)
 		else
 			m_absval = m_valhw||m_val ? BOUNDED(16384.0-(m_valhw|m_val<<7), 0.0, 16383.0) : 0.0; // see top remark!
 	}
-	// midi
-	else if (m_valhw==-1 && m_val>=0 && m_val<128)
+	// midi/mousewheel
+	else if (m_val>=0 && m_val<128)
 	{
 		// absolute mode
 		if (!m_relmode) m_absval = m_val;

--- a/Wol/wol_Zoom.cpp
+++ b/Wol/wol_Zoom.cpp
@@ -48,7 +48,7 @@ void AdjustSelectedEnvelopeOrTrackHeight(COMMAND_T* ct, int val, int valhw, int 
 		PreventUIRefresh(1);
 
 		VerticalZoomCenter scrollCenter = static_cast<VerticalZoomCenter>((int)ct->user > 2 ? (int)ct->user - 3 : (int)ct->user);
-		int height = AdjustRelative(relmode, (valhw == -1) ? BOUNDED(val, 0, 127) : (int)BOUNDED(16384.0 - (valhw | val << 7), 0.0, 16383.0));
+		int height = AdjustRelative(relmode, valhw < 0 ? BOUNDED(val, 0, 127) : (int)BOUNDED(16384.0 - (valhw | val << 7), 0.0, 16383.0));
 		if (TrackEnvelope* env = GetSelectedEnvelope(NULL))
 		{
 			BR_Envelope brEnv(env);
@@ -95,7 +95,7 @@ void AdjustEnvelopeOrTrackHeightUnderMouse(COMMAND_T* ct, int val, int valhw, in
 	{
 		PreventUIRefresh(1);
 
-		int height = AdjustRelative(relmode, (valhw == -1) ? BOUNDED(val, 0, 127) : (int)BOUNDED(16384.0 - (valhw | val << 7), 0.0, 16383.0));
+		int height = AdjustRelative(relmode, valhw < 0 ? BOUNDED(val, 0, 127) : (int)BOUNDED(16384.0 - (valhw | val << 7), 0.0, 16383.0));
 
 		TrackEnvelope* env = NULL;
 		MediaTrack* tr = NULL;


### PR DESCRIPTION
https://github.com/reaper-oss/sws/pull/1787#issuecomment-1934495777

> v6.76 - February 28 2023
> - Mouse: improve precision of mouse gestures and mousewheel when bound to actions

The [current SDK](https://github.com/justinfrankel/reaper-sdk/blob/02deb819c4ba0fc1bac001c8dfff7b9dbaf408ad/reaper-plugins/reaper_plugin.h#L218) does not specify negative values other than -1:
> ```
> val/val2 are used for actions triggered by MIDI/OSC/mousewheel
>    - val = [0..127] and val2 = -1 for MIDI CC,
>    - val2 >=0 for MIDI pitch or OSC with value = (val2|(val<<7))/16383.0
>    - relmode absolute(0) or 1/2/3 for relative adjust modes
> ```

```
v5.99 & v6.75
mwdown val=63 val2=-1 relmode=2
mwup   val=65 val2=-1 relmode=2

v6.76 & v7.11 (typical, macOS)
mwdown val=127 val2=-161 relmode=1
mwup   val=1   val2=-161 relmode=1
```

REAPER v7.11 computes `val2` (`valhw` in SWS) from `WM_MOUSEWHEEL`'s delta in `wParam` the following way:

```cpp
int MWDeltaToVal2(double delta)
{
#ifdef __APPLE__
  delta /= 16;
#elifdef _WIN32
  delta /= 8;
#endif
  delta = std::abs(delta);
  delta = std::ceil(delta) - delta;
  delta = delta * 256 + 0.5;
  return -1 - delta;
}
```

(On Linux, `WM_MOUSEWHEEL` with delta other than +-120 appear to be ignored.)

It then uses it like this in actions (validating that this PR is the correct approach for those values):

```cpp
double AdjustRelative(const int relmode, int val, const int val2)
{
  switch(relmode) {
  case 1:
    if(val >= 0x40)
      val |= ~0x3f;
    break;
  case 2:
    val -= 0x40;
    break;
  case 3:
    if(val & 0x40)
      val = -(val & 0x3f);
    break;
  default:
    return val;
  }

  if(val == 0 || val2 >= -1)
    return val;

  const double fraction = static_cast<double>(-1 - val2) / 256.0;
  return val >= 0 ? val - fraction : val + fraction;
}
```

The following actions are affected by this commit (although most of them do not officially support the mousewheel):

- SWS/BR: Adjust playrate
- SWS/S&M: Live Config #n - Apply config
- SWS/S&M: Live Config #n - Preload config
- SWS/S&M: Select project
- SWS/S&M: Trigger preset for FX n of selected track
- SWS/S&M: Trigger preset for selected FX of selected track
- SWS/wol: Adjust envelope or track height under mouse cursor
- SWS/wol: Adjust selected envelope height
- SWS/wol: Adjust selected envelope or last touched track height