### PR TITLE
Remove bogus range check in `SNM_SetDoubleConfigVarEx` when writing to floats

### DIFF
--- a/SnM/SnM_Misc.cpp
+++ b/SnM/SnM_Misc.cpp
@@ -249,12 +249,8 @@ bool SNM_SetDoubleConfigVarEx(ReaProject *proj, const char *varName, const doubl
 		*ConfigVar<int>("vzoom2", proj) = static_cast<int>(newValue);
 	if (ConfigVar<double> cv{varName, proj})
 		*cv = newValue;
-	else if (ConfigVar<float> cv{varName, proj}) {
-		if (newValue > std::numeric_limits<float>::max() || newValue < std::numeric_limits<float>::min())
-			return false;
-
+	else if (ConfigVar<float> cv{varName, proj})
 		*cv = static_cast<float>(newValue);
-	}
 	else
 		return false;
 


### PR DESCRIPTION
First it should have been `::lowest()` to let through < 1, but then the entire check shouldn't be there in the first place for inf/NaNs...

(Introduced in 876075e1823bcddbc1221712085605d61c4d7b22)