### PR TITLE
Fix "SWS: Vertical zoom to selected tracks, minimize others" in REAPER v6.76+

### DIFF
--- a/Zoom.cpp
+++ b/Zoom.cpp
@@ -145,6 +145,7 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 			}
 		}
 
+		TrackList_AdjustWindows(true); // required in v6.76+ to recompute zoom before action 40112
 		Main_OnCommand(40112, 0); // Zoom out vert to minimize envelope lanes too (since vZoom is now 0) (calls refresh)
 		if (iMinimizedTracks <= 1) // ignore master track since there can be no items on it
 			return;

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -107,7 +107,7 @@ MIDI Editor:
 Misc:
 +Fix left post-fx dual pan envelopes being detected as pre-fx (issue 1641)
 +Limit toolbars auto refresh to when a watched action's toggle state changes (post https://forum.cockos.com/showthread.php?p=2629385|2629385|)
-+Support REAPER 6.73+devXXXX floating-point vertical zooming (issue 1717)
++Support REAPER 6.76 floating-point vertical zooming (issue 1717)
 +Update TagLib to version https://github.com/taglib/taglib/releases/tag/v1.13|v1.13|
 
 Notes:


### PR DESCRIPTION
`Main_OnCommand(40112, 0)` was setting a wrong zoom level because it wasn't noticing `vzoom3` had been changed to 0.0 an instant earlier.

![Screencap](https://github.com/reaper-oss/sws/assets/4297676/562b748f-1c95-48b2-a6df-60afc18cb56c)
