### PR TITLE
Move the Extensions menu items into a SWS/S&M submenu

### DIFF
--- a/Menus.cpp
+++ b/Menus.cpp
@@ -30,6 +30,7 @@
 
 #include "stdafx.h"
 
+#include <SnM/SnM.h> // g_SNM_ExtSubmenu;
 #include <WDL/localize/localize.h>
 
 void AddToMenuOrdered(HMENU hMenu, const char* text, int id, int iInsertAfter, bool bPos, UINT uiSate)
@@ -239,12 +240,21 @@ int SWSGetMenuPosFromID(HMENU hMenu, UINT id)
 // *************************** MENU CREATION ***************************
 
 // Important: both __LOCALIZE() parameters MUST remain literal strings (see sws_build_sample_langpack tool)
-void SWSCreateExtensionsMenu(HMENU hMenu)
+void SWSCreateExtensionsMenu(HMENU hExtensionsMenu)
 {
-	if (GetMenuItemCount(hMenu))
-		AddToMenu(hMenu, SWS_SEPARATOR, 0);
+	HMENU hMenu;
+	if (g_SNM_ExtSubmenu)
+	{
+		hMenu = CreatePopupMenu();
+		AddSubMenuOrdered(hExtensionsMenu, hMenu, __LOCALIZE("&SWS/S&&M", "sws_ext_menu"));
+	}
+	else
+	{
+		hMenu = hExtensionsMenu;
+		if (GetMenuItemCount(hMenu))
+			AddToMenu(hMenu, SWS_SEPARATOR, 0);
+	}
 
-	AddToMenu(hMenu, __LOCALIZE("About SWS Extension", "sws_ext_menu"), NamedCommandLookup("_SWS_ABOUT"));
 	AddToMenu(hMenu, __LOCALIZE("Auto Color/Icon/Layout", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_OPEN"));
 
 	HMENU hAutoRenderSubMenu = CreatePopupMenu();
@@ -331,6 +341,7 @@ void SWSCreateExtensionsMenu(HMENU hMenu)
 	AddToMenu(hMenu, SWS_SEPARATOR, 0);
 	HMENU hOptionsSubMenu = CreatePopupMenu();
 	AddSubMenu(hMenu, hOptionsSubMenu, __LOCALIZE("SWS Options", "sws_ext_menu"));
+	AddToMenu(hMenu, __LOCALIZE("About SWS Extension", "sws_ext_menu"), NamedCommandLookup("_SWS_ABOUT"));
 
 	AddToMenu(hOptionsSubMenu, __LOCALIZE("Enable auto track coloring", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_ENABLE"));
 	AddToMenu(hOptionsSubMenu, __LOCALIZE("Enable auto marker coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_MKR_ENABLE"));

--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -1115,7 +1115,7 @@ int MidiOscActionJob::AdjustRelative(int _adjmode, int _reladj)
 WDL_FastString g_SNM_IniFn, g_SNM_CyclIniFn, g_SNM_DiffToolFn;
 int g_SNM_Beta=0, g_SNM_LearnPitchAndNormOSC=0;
 int g_SNM_MediaFlags=0, g_SNM_ToolbarRefreshFreq=SNM_DEF_TOOLBAR_RFRSH_FREQ;
-bool g_SNM_ToolbarRefresh = false;
+bool g_SNM_ToolbarRefresh = false, g_SNM_ExtSubmenu = true;
 
 
 void IniFileInit()
@@ -1144,6 +1144,7 @@ void IniFileInit()
 #endif
 	g_SNM_LearnPitchAndNormOSC = GetPrivateProfileInt("General", "LearnPitchAndNormOSC", 0, g_SNM_IniFn.Get());
 	g_SNM_Beta = GetPrivateProfileInt("General", "Beta", 0, g_SNM_IniFn.Get());
+	g_SNM_ExtSubmenu = GetPrivateProfileInt("General", "ExtensionsSubmenu", g_SNM_ExtSubmenu, g_SNM_IniFn.Get());
 }
 
 void IniFileExit()
@@ -1172,6 +1173,7 @@ void IniFileExit()
 #endif
 		<< "LearnPitchAndNormOSC=" << g_SNM_LearnPitchAndNormOSC << '\0'
 		<< "Beta=" << g_SNM_Beta << '\0'
+		<< "ExtensionsSubmenu=" << g_SNM_ExtSubmenu << '\0'
 	;
 
 	SaveIniSection("General", iniSection.str(), g_SNM_IniFn.Get());

--- a/SnM/SnM.h
+++ b/SnM/SnM.h
@@ -203,7 +203,7 @@ vezn/Q+t/AIQiCv/Q4iRxAAAAABJRU5ErkJggg==\n"
 
 extern int g_SNM_Beta, g_SNM_LearnPitchAndNormOSC, g_SNM_MediaFlags, g_SNM_ToolbarRefreshFreq;
 extern WDL_FastString g_SNM_IniFn, g_SNM_CyclIniFn, g_SNM_DiffToolFn;
-extern bool g_SNM_ToolbarRefresh;
+extern bool g_SNM_ToolbarRefresh, g_SNM_ExtSubmenu;
 
 
 class SNM_TrackInt {


### PR DESCRIPTION
The previous behavior can be restored via `[General] ExtensionsSubmenu=0` in S&M.ini