### PR TITLE
Fix divide by zero in "Vertical zoom to selected tracks, minimize others" if all selected tracks are locked

### DIFF
--- a/Zoom.cpp
+++ b/Zoom.cpp
@@ -179,6 +179,8 @@ void VertZoomRange(int iFirst, int iNum, bool* bZoomed, bool bMinimizeOthers, bo
 				}
 			}
 		}
+		if (iZoomed < 1)
+			return; // all selected tracks are locked, nothing to do
 		// Pixels we have to work with will all the sel tracks and their envelopes
 		iTotalHeight -= iNotZoomedSize;
 		int iEachHeight = iTotalHeight / iZoomed;


### PR DESCRIPTION
Similar to #1579 / https://github.com/reaper-oss/sws/issues/1577#issuecomment-968114970