### PR TITLE
Ignore tracks set to a record output mode when checking for duplicate recording inputs

### DIFF
--- a/Misc/RecCheck.cpp
+++ b/Misc/RecCheck.cpp
@@ -76,7 +76,8 @@ bool RecordInputCheck()
 	for (int i = 1; !bDupe && i <= GetNumTracks(); i++)
 	{
 		MediaTrack* tr = CSurf_TrackFromID(i, false);
-		if (*(int*)GetSetMediaTrackInfo(tr, "I_RECARM", NULL) && *(int*)GetSetMediaTrackInfo(tr, "I_RECMODE", NULL) != 2)
+		int iRecMode = *(int*)GetSetMediaTrackInfo(tr, "I_RECMODE", NULL);
+		if (*(int*)GetSetMediaTrackInfo(tr, "I_RECARM", NULL) && (iRecMode == 0 || iRecMode >= 7))
 		{
 			int iInput = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
 			// Ignore < 0 inputs


### PR DESCRIPTION
Currently, SWS warns when multiple tracks are about to record the same thing. However it doesn't take into account some of the recording modes. Here is the full list, with highlighted modes that depending on the track FX, volume, etc won't result in the same thing being recorded.

    
> ~~0 = input~~
> **1 = stereo out**
> **2 = none**
> **3 = stereo out w/latency compensation**
> **4 = midi output**
> **5 = mono out**
> **6 = mono out w/ latency compensation**
> ~~7 = midi overdub~~
> ~~8 = midi replace~~

Currently SWS only checks for `I_RECMODE != 2`

[Reported on the forum](https://forum.cockos.com/showthread.php?t=261948)