### PR TITLE
Fix running cycle actions and some other actions from the alt-recording and alt-{1..16} sections in REAPER 7.03+

### DIFF
--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -140,7 +140,10 @@ bool hookCommandProc2(KbdSectionInfo* sec, int cmdId, int val, int valhw, int re
 	// Ignore commands that don't have anything to do with us from this point forward
 	if (COMMAND_T* cmd = SWSGetCommandByID(cmdId))
 	{
-		if (cmd->uniqueSectionId==sec->uniqueID && cmd->cmdId==cmdId)
+		int secId = sec->uniqueID;
+		if(secId == 100 || (secId >= 1 && secId <= 16)) // for REAPER 7.03+, alt-recording & alt-{1,16}
+			secId = 0;
+		if (cmd->uniqueSectionId==secId && cmd->cmdId==cmdId)
 		{
 			// job for hookCommandProc?
 			// note: we could perform cmd->doCommand() here, but we'd loose the "flag" param value


### PR DESCRIPTION
Fixes #1803

Affected actions:

- SWS/FNG: Apply selected groove (use curent settings from opened groove tool)
- SWS/BR: Adjust playrate (MIDI CC only)
- SWS/BR: Adjust playrate options...
- SWS/BR: Play from mouse cursor position (perform until shortcut released)
- SWS/BR: Play from mouse cursor position and solo track under mouse for the duration (perform until shortcut released)
- SWS/BR: Play from mouse cursor position and solo item and track under mouse for the duration (perform until shortcut released)
- SWS/BR: Play from edit cursor position (perform until shortcut released)
- SWS/BR: Play from edit cursor position and solo track under mouse for the duration (perform until shortcut released)
- SWS/BR: Play from edit cursor position and solo item and track under mouse for the duration (perform until shortcut released)
- SWS/wol: Adjust selected envelope height (MIDI CC relative/mousewheel)
- SWS/wol: Adjust selected envelope height, zoom center to middle arrange (MIDI CC relative/mousewheel)
- SWS/wol: Adjust selected envelope height, zoom center to mouse cursor (MIDI CC relative/mousewheel)
- SWS/wol: Adjust selected envelope or last touched track height (MIDI CC relative/mousewheel)
- SWS/wol: Adjust selected envelope or last touched track height, zoom center to middle arrange (MIDI CC relative/mousewheel)
- SWS/wol: Adjust selected envelope or last touched track height, zoom center to mouse cursor (MIDI CC relative/mousewheel)
- SWS/wol: Adjust envelope or track height under mouse cursor (MIDI CC relative/mousewheel)
- SWS/wol: Adjust envelope or track height under mouse cursor, zoom center to mouse cursor (MIDI CC relative/mousewheel)
- SWS/S&M: Trigger preset for selected FX of selected track (MIDI/OSC only)
- SWS/S&M: Select project (MIDI/OSC only)
- SWS/S&M: Trigger preset for FX %d of selected track (MIDI/OSC only)
- SWS/S&M: Live Config #%d - Apply config (MIDI/OSC only)
- SWS/S&M: Live Config #%d - Preload config (MIDI/OSC only)