### PR TITLE
Fix a crash in various FNG MIDI actions when the active MIDI editor is empty

### DIFF
--- a/Breeder/BR_MidiEditor.cpp
+++ b/Breeder/BR_MidiEditor.cpp
@@ -845,7 +845,7 @@ void ME_CCToEnvPoints (COMMAND_T* ct, int val, int valhw, int relmode, HWND hwnd
 		return;
 	}
 
-	MediaItem_Take* take = MIDIEditor_GetTake(MIDIEditor_GetActive());
+	MediaItem_Take* take = midiEditor.GetActiveTake();
 	BR_Envelope envelope(GetSelectedEnvelope(NULL));
 	if ((int)ct->user < 0)
 		envelope.DeleteAllPoints();

--- a/Fingers/RprMidiCCLane.cpp
+++ b/Fingers/RprMidiCCLane.cpp
@@ -117,9 +117,11 @@ RprNode *RprMidiCCLane::RprMidiLane::toReaper()
 RprMidiCCLanePtr RprMidiCCLane::createFromMidiEditor(bool readOnly)
 {
     HWND midiEditor = MIDIEditor_GetActive();
-    if(midiEditor == NULL)
+    if(!midiEditor)
         throw RprLibException(__LOCALIZE("No active MIDI editor","sws_mbox"), true);
     RprTake take(MIDIEditor_GetTake(midiEditor));
+    if(!take)
+        throw RprLibException(__LOCALIZE("No take in active MIDI editor","sws_mbox"), true);
     RprMidiCCLanePtr laneViewPtr(new RprMidiCCLane(take, readOnly));
     return laneViewPtr;
 }

--- a/Fingers/RprMidiTake.cpp
+++ b/Fingers/RprMidiTake.cpp
@@ -1028,12 +1028,13 @@ void RprMidiTake::cleanup()
 RprMidiTakePtr RprMidiTake::createFromMidiEditor(bool readOnly)
 {
     HWND midiEditor = MIDIEditor_GetActive();
-    if(midiEditor == NULL)
-    {
+    if(!midiEditor)
         throw RprLibException(__LOCALIZE("No active MIDI editor","sws_mbox"), true);
-    }
 
     RprTake take(MIDIEditor_GetTake(midiEditor));
+    if(!take)
+        throw RprLibException(__LOCALIZE("No take in active MIDI editor","sws_mbox"), true);
+
     const char *sourceFilename = take.getSource()->GetFileName();
     if(!*sourceFilename)
     {

--- a/Fingers/RprTake.cpp
+++ b/Fingers/RprTake.cpp
@@ -85,9 +85,3 @@ const char *RprTake::getName()
 {
     return (const char *)GetSetMediaItemTakeInfo(mTake, "P_NAME", NULL);
 }
-
-RprTake RprTake::createFromMidiEditor()
-{
-    RprTake take(MIDIEditor_GetTake(MIDIEditor_GetActive()));
-    return take;
-}

--- a/Fingers/RprTake.h
+++ b/Fingers/RprTake.h
@@ -8,6 +8,7 @@ class PCM_source;
 class RprTake {
 public:
     RprTake(MediaItem_Take *take);
+    operator bool() const { return !!mTake; }
 
     double getPlayRate() const;
     void setPlayRate(double playRate);
@@ -26,8 +27,6 @@ public:
     
     void setName(const char *name);
     const char *getName();
-
-    static RprTake createFromMidiEditor();
 
     /* Conversion */
     MediaItem_Take *toReaper() const;


### PR DESCRIPTION
`MIDIEditor_GetTake` is null after deleting the MIDI editor's opened item if the editor is configured to be per-project and "Contents > Options when using one MIDI editor per project > Close editor when the active media item is deleted in arrange view" is disabled.

The following actions were affected:

- SWS/FNG: Apply groove to selected MIDI notes in active MIDI editor
- SWS/FNG: Cycle through CC lanes in active MIDI editor
- SWS/FNG: Get groove from selected MIDI notes in active MIDI editor
- SWS/FNG: Hide unused CC lanes in active MIDI editor
- SWS/FNG: Select muted MIDI notes
- SWS/FNG: Select notes nearest edit cursor in active MIDI editor
- SWS/FNG: Show only top CC lane in active MIDI editor
- SWS/FNG: Show only used CC lanes in active MIDI editor

Fixes #1869