### PR TITLE
Fix direct calls to previous window procedures

### DIFF
--- a/Breeder/BR_ContextualToolbars.cpp
+++ b/Breeder/BR_ContextualToolbars.cpp
@@ -1461,7 +1461,7 @@ LRESULT CALLBACK BR_ContextualToolbar::ToolbarWndCallback (HWND hwnd, UINT uMsg,
 			m_callbackToolbars.Delete(id, true);
 		}
 
-		return wndProc(hwnd, uMsg, wParam, lParam);
+		return CallWindowProc(wndProc, hwnd, uMsg, wParam, lParam);
 	}
 }
 

--- a/Breeder/BR_ContinuousActions.cpp
+++ b/Breeder/BR_ContinuousActions.cpp
@@ -288,7 +288,7 @@ static LRESULT CALLBACK GenericWndProc (HWND hwnd, UINT uMsg, WPARAM wParam, LPA
 		}
 	}
 
-	return wndProc(hwnd, uMsg, wParam, lParam);
+	return CallWindowProc(wndProc, hwnd, uMsg, wParam, lParam);
 }
 
 static int TranslateAccel (MSG* msg, accelerator_register_t* ctx)

--- a/Zoom.cpp
+++ b/Zoom.cpp
@@ -1107,7 +1107,7 @@ LRESULT CALLBACK ZoomWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		else if (uMsg == WM_PAINT)
 		{
 			// If there's a paint request then let std wnd handle, then get the data
-			g_ReaperTrackWndProc(hwnd, uMsg, wParam, lParam);
+			CallWindowProc(g_ReaperTrackWndProc, hwnd, uMsg, wParam, lParam);
 			delete bmStd;
 			PAINTSTRUCT ps;
 			HDC dc = BeginPaint(hwnd, &ps);
@@ -1295,7 +1295,7 @@ LRESULT CALLBACK ZoomWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		}
 	}
 
-	return g_ReaperTrackWndProc(hwnd, uMsg, wParam, lParam);
+	return CallWindowProc(g_ReaperTrackWndProc, hwnd, uMsg, wParam, lParam);
 }
 
 enum { UPPER = 1, LOWER = 2 }; // Part of time display where drag started
@@ -1397,7 +1397,7 @@ LRESULT CALLBACK DragZoomWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 				break;
 		}
 	}
-	return g_ReaperRulerWndProc(hwnd, uMsg, wParam, lParam);
+	return CallWindowProc(g_ReaperRulerWndProc, hwnd, uMsg, wParam, lParam);
 }
 
 void EnableDragZoom(COMMAND_T* _ct)


### PR DESCRIPTION
Prevents crashes if `Get/SetWindowLongPtr(GWLP_WNDPROC)` returns a thunk on Windows. Closes #1872.