### PR TITLE
Fix `NF_SetSWSTrackNotes` crashing when given a null track

### DIFF
--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -1704,6 +1704,9 @@ const char* NF_GetSWSTrackNotes(MediaTrack* track)
 
 void NF_SetSWSTrackNotes(MediaTrack* track, const char* buf)
 {
+	if (!track)
+		return;
+
 	MarkProjectDirty(NULL);
 
 	if (SNM_TrackNotes* notes = SNM_TrackNotes::find(track))


### PR DESCRIPTION
Fixes #1881