### PR TITLE
Always re-apply master track auto-icon rules when loading projects

### DIFF
--- a/Color/Autocolor.cpp
+++ b/Color/Autocolor.cpp
@@ -1204,7 +1204,8 @@ static bool ProcessExtensionLine(const char *line, ProjectStateContext *ctx, boo
 				GUID g;
 				stringToGuid(lp.gettoken_str(0), &g);
 				MediaTrack* tr = GuidToTrack(&g);
-				if (tr)
+				// not loading master track cache to always re-apply rules (icon isn't persisted in RPP)
+				if (tr && tr != GetMasterTrack(nullptr))
 				{
 					auto rt = g_pACTracks.Get()->insert(tr).first;
 					rt->m_col = ImportColor(lp.gettoken_int(1));


### PR DESCRIPTION
REAPER does not store master track icon in the project file. Icons on the master track might be a bug that SWS exploits(?).

Master track rules used to be applied on every project load from `SWSTimeSlice::SetTrackListChange` before AutoColor's `ProcessExtensionLine`.

b95beb0fc9d84d6a25fbd46cd62be47d7789b4c8 changed the timing to run auto-coloring only once asynchronously (on the next timer tick).