### PR TITLE
DoSelectFiles (Xenakios/SWS: Choose files for random insert...): fix multi-file return value processing

### DIFF
--- a/Xenakios/main.cpp
+++ b/Xenakios/main.cpp
@@ -107,7 +107,7 @@ void DoSelectFiles(COMMAND_T*)
 	if (cFiles)
 	{
 		g_filenames.clear();
-		char* pStr = cFiles;
+		char* pStr = cFiles + (*cFiles == '\0' ? 1 : 0);
 		while(*pStr)
 		{
 			g_filenames.push_back(pStr);


### PR DESCRIPTION
 Single-value processing was working. This is the only occurrence of BrowseForFiles() with multiple return values, as far as I could find.