### PR TITLE
Repair regression caused by the MIDI Editor HiDPI fix on Windows and macOS

### DIFF
--- a/Breeder/BR_MidiEditor.cpp
+++ b/Breeder/BR_MidiEditor.cpp
@@ -582,8 +582,8 @@ void ME_SetAllCCLanesHeight (COMMAND_T* ct, int val, int valhw, int relmode, HWN
 					int height = (int)ct->user + MIDI_LANE_DIVIDER_H; // so pixel height is drawable height
 					height = SetToBounds(height, MIDI_LANE_DIVIDER_H, GetMaxCCLanesFullHeight(editor) / lanesCount);
 
-					const auto dpi256 = hidpi::GetDpiForWindow(editor);
-					height = height * dpi256 / 256;
+					if (const auto dpi256 = hidpi::GetDpiForWindow(editor))
+						height = (height * dpi256) / 256;
 
 					LineParser lp(false);
 					WDL_FastString lineLane;

--- a/Breeder/BR_MouseUtil.cpp
+++ b/Breeder/BR_MouseUtil.cpp
@@ -774,8 +774,9 @@ bool BR_MouseInfo::GetContextMIDI (POINT p, HWND hwnd, BR_MouseInfo::MouseInfo& 
 		ScreenToClient(segmentHwnd, &p);
 		RECT r; GetClientRect(segmentHwnd, &r);
 
-		const auto dpi256 = hidpi::GetDpiForWindow(mouseInfo.midiEditor);
-		const LONG ruler_h = MIDI_RULER_H * dpi256 / 256;
+		LONG ruler_h = MIDI_RULER_H;
+		if (const auto dpi256 = hidpi::GetDpiForWindow(mouseInfo.midiEditor))
+			ruler_h = (ruler_h * dpi256) / 256;
 
 		// ignoring extra flags from GetPianoRoll() (eg. custom note order mode=0x10000)
 		mouseInfo.pianoRollMode = midiEditor.GetPianoRoll() & 0xffff;


### PR DESCRIPTION
Caused by 02ab3c941a8066336b6a3e7f535015161f7526b4.