### PR TITLE
Notes: clear cached previous text when closing the window

### DIFF
--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -254,6 +254,7 @@ void NotesWnd::OnDestroy()
 	g_prevNotesType = -1;
 	m_cbType.Empty();
 	m_edit = nullptr;
+	memset(g_lastText, 0, sizeof(g_lastText));
 }
 
 // note: no diff with current type, init would fail otherwise


### PR DESCRIPTION
Regression was caused by ed1cdadb48c3604235023751fbaf00f546b92349.