### PR TITLE
Preview: fix wrap around detection when position or loop is set without ever seeking

### DIFF
--- a/cfillion/pitchshiftsource.cpp
+++ b/cfillion/pitchshiftsource.cpp
@@ -386,11 +386,12 @@ bool PitchShiftSource_MIDI::requestStop()
   return false;
 }
 
-void PitchShiftSource::seekOrLoop(const bool looping)
+void PitchShiftSource::seekOrLoop(const bool isSeek, const bool looping)
 {
   WDL_MutexLockExclusive lock { &m_mutex };
   m_flags &= ~(Looping | WrappedAround);
-  m_flags |= ManualSeek;
+  if(isSeek)
+    m_flags |= ManualSeek;
   if(looping)
     m_flags |= Looping;
 }

--- a/cfillion/pitchshiftsource.hpp
+++ b/cfillion/pitchshiftsource.hpp
@@ -75,7 +75,7 @@ public:
   bool   startFadeOut();
   bool   readPeak(size_t, double *);
   virtual bool requestStop() { return true; }
-  void seekOrLoop(bool looping);
+  void seekOrLoop(bool isSeek, bool looping);
 
 protected:
   struct Block {

--- a/cfillion/preview.cpp
+++ b/cfillion/preview.cpp
@@ -207,8 +207,8 @@ double CF_Preview::getPosition()
 void CF_Preview::setPosition(const double newpos)
 {
   LockPreviewMutex lock { m_reg };
+  m_src->seekOrLoop(m_reg.curpos != newpos, m_reg.loop);
   m_reg.curpos = newpos;
-  m_src->seekOrLoop(m_reg.loop);
 }
 
 void CF_Preview::setOutput(const int channel)
@@ -254,6 +254,6 @@ void CF_Preview::setOutput(MediaTrack *track)
 void CF_Preview::setLoop(const bool loop)
 {
   LockPreviewMutex lock { m_reg };
+  m_src->seekOrLoop(false, m_reg.loop);
   m_reg.loop = loop;
-  m_src->seekOrLoop(m_reg.loop);
 }


### PR DESCRIPTION
`PitchShiftSource::GetSamples` only clears `ManualSeek` when it detect an actual seek, which never happens if:

- The position is set to 0.0 before starting playback
- Loop is toggled on and off before reaching the end of the source