### PR TITLE
Notes: fix empty notes after closing the window via an action

### DIFF
--- a/SnM/SnM_Notes.cpp
+++ b/SnM/SnM_Notes.cpp
@@ -1682,6 +1682,10 @@ void OpenNotes(COMMAND_T* _ct)
 			newType = g_notesType;
 
 		w->Show(g_notesType == newType /* i.e toggle */, true);
+
+		if (!w->GetHWND())
+			return;
+
 		w->SetType(newType);
 
 		if (!g_locked)


### PR DESCRIPTION
Fixes #1965, regression from .4-beta partially fixed in .5-beta's 21df087b90056f422bd4b30d682f0b90d17334c6.