### PR TITLE
Support running non-default verbs via `CF_ShellExecute` on Windows

### DIFF
--- a/cfillion/cfillion.cpp
+++ b/cfillion/cfillion.cpp
@@ -170,7 +170,7 @@ bool CF_ShellExecute(const char *file, const char *args)
 #ifdef _WIN32
   static_assert(&ShellExecute == &ShellExecuteUTF8,
     "ShellExecute is not aliased to ShellExecuteUTF8");
-  HINSTANCE ret { ShellExecute(nullptr, "open", file, args, nullptr, SW_SHOW) };
+  HINSTANCE ret { ShellExecute(nullptr, nullptr, file, args, nullptr, SW_SHOW) };
   return ret > reinterpret_cast<HINSTANCE>(32);
 #else
   return ShellExecute(nullptr, "open", file, args, nullptr, SW_SHOW);


### PR DESCRIPTION
NULL = "The default verb is used, if available. If not, the `open` verb is used. If neither verb is available, the system uses the first verb listed in the registry."

Most notably, REAPER associates its file extensions using a "open64" verb which lead to RPP failing to open using `CF_ShellExecute`.

![Screenshot](https://i.imgur.com/Qw8Scob.png)