### PR TITLE
Fix various WOL track/envelope vertical zoom actions with fixed item lanes

### DIFF
--- a/Breeder/BR_Util.cpp
+++ b/Breeder/BR_Util.cpp
@@ -2260,7 +2260,7 @@ enum TrackFixedLanesFlags
 	ShowBigLanes = 1<<3,
 };
 
-static char GetTrackFixedLanesFlags (MediaTrack* track)
+char GetTrackFixedLanesFlags (MediaTrack* track)
 {
 	if (void *settings = GetSetMediaTrackInfo(track, "C_LANESETTINGS", nullptr))
 		return *static_cast<char *>(settings); // v7.12+

--- a/Breeder/BR_Util.h
+++ b/Breeder/BR_Util.h
@@ -234,6 +234,7 @@ int GetTakeEnvHeight (MediaItem_Take* take, int* offsetY);
 int GetTakeEnvHeight (MediaItem* item, int id, int* offsetY);
 int GetTrackEnvHeight (TrackEnvelope* envelope, int* offsetY, bool drawableRangeOnly, MediaTrack* parent = NULL);
 int GetTrackSpacerSize (MediaTrack* track, bool isMcp = false, const int* heightOverride = NULL);
+char GetTrackFixedLanesFlags(MediaTrack* track);
 
 /******************************************************************************
 * Arrange                                                                     *

--- a/Wol/wol_Util.cpp
+++ b/Wol/wol_Util.cpp
@@ -69,6 +69,9 @@ bool RestoreSelectedTracks()
 
 void SetTrackHeight(MediaTrack* track, int height, bool useChunk)
 {
+	if (GetMediaTrackInfo_Value(track, "I_FREEMODE") == 2 && (GetTrackFixedLanesFlags(track) & 1 << 3) > 0)
+		height /= static_cast<int>(GetMediaTrackInfo_Value(track, "I_NUMFIXEDLANES"));
+
 	if (!useChunk)
 	{
 		GetSetMediaTrackInfo(track, "I_HEIGHTOVERRIDE", &height);

--- a/Wol/wol_Zoom.cpp
+++ b/Wol/wol_Zoom.cpp
@@ -125,7 +125,7 @@ void AdjustEnvelopeOrTrackHeightUnderMouse(COMMAND_T* ct, int val, int valhw, in
 			{
 				if (brEnv.IsTakeEnvelope())
 				{
-					SetTrackHeight(brEnv.GetParent(), SetToBounds(height + GetTrackHeight(brEnv.GetParent(), NULL), GetTcpTrackMinHeight(), GetCurrentTcpMaxHeight()), true);
+					SetTrackHeight(brEnv.GetParent(), SetToBounds(height + GetTrackHeight(brEnv.GetParent(), NULL), GetTcpTrackMinHeight(), GetCurrentTcpMaxHeight()));
 					SetArrangeScrollTo(brEnv.GetParent(), static_cast<VerticalZoomCenter>((int)ct->user));
 				}
 				else
@@ -137,13 +137,13 @@ void AdjustEnvelopeOrTrackHeightUnderMouse(COMMAND_T* ct, int val, int valhw, in
 			}
 			else
 			{
-				SetTrackHeight(brEnv.GetParent(), SetToBounds(height + GetTrackHeight(brEnv.GetParent(), NULL), GetTcpTrackMinHeight(), GetCurrentTcpMaxHeight()), true);
+				SetTrackHeight(brEnv.GetParent(), SetToBounds(height + GetTrackHeight(brEnv.GetParent(), NULL), GetTcpTrackMinHeight(), GetCurrentTcpMaxHeight()));
 				SetArrangeScrollTo(brEnv.GetParent(), static_cast<VerticalZoomCenter>((int)ct->user));
 			}
 		}
 		else if (tr)
 		{
-			SetTrackHeight(tr, SetToBounds(height + GetTrackHeight(tr, NULL), GetTcpTrackMinHeight(), GetCurrentTcpMaxHeight()), true);
+			SetTrackHeight(tr, SetToBounds(height + GetTrackHeight(tr, NULL), GetTcpTrackMinHeight(), GetCurrentTcpMaxHeight()));
 			SetArrangeScrollTo(tr, static_cast<VerticalZoomCenter>((int)ct->user));
 		}
 


### PR DESCRIPTION
Fixes track height going crazy when a track has big lanes set.