### PR TITLE
Add accessibility keyboard navigation toggle (Tab/arrows/typeahead)

### DIFF
--- a/Menus.cpp
+++ b/Menus.cpp
@@ -353,5 +353,6 @@ void SWSCreateExtensionsMenu(HMENU hExtensionsMenu)
 	AddToMenu(hOptionsSubMenu, __LOCALIZE("Enable record input check", "sws_ext_menu"), NamedCommandLookup("_SWS_TOGRECINCHECK"));
 	AddToMenu(hOptionsSubMenu, __LOCALIZE("Enable red ruler while recording", "sws_ext_menu"), NamedCommandLookup("_SWS_RECREDRULER"));
 	AddToMenu(hOptionsSubMenu, __LOCALIZE("Enable toolbars auto refresh", "sws_ext_menu"), NamedCommandLookup("_S&M_TOOLBAR_REFRESH_ENABLE"));
+	AddToMenu(hOptionsSubMenu, __LOCALIZE("Enabled deeper keyboard navigation in SWS dialogs (improves accessibility)", "sws_ext_menu"), NamedCommandLookup("_S&M_DOCKWND_TABNAV_TOGGLE"));
 }
 

--- a/SnM/SnM.cpp
+++ b/SnM/SnM.cpp
@@ -454,6 +454,7 @@ static COMMAND_T s_cmdTable[] =
 
 	// Toolbar ----------------------------------------------------------------
 	{ { DEFACCEL, "SWS/S&M: Toggle toolbars auto refresh enable" },	"S&M_TOOLBAR_REFRESH_ENABLE", EnableToolbarsAutoRefesh, NULL, 0, IsToolbarsAutoRefeshEnabled},
+	{ { DEFACCEL, "SWS/S&M: Toggle dock window tab navigation (for screen reader users)" }, "S&M_DOCKWND_TABNAV_TOGGLE", ToggleDockWndTabNavigation, NULL, 0, IsDockWndTabNavigationEnabled},
 	{ { DEFACCEL, "SWS/S&M: Toolbar - Toggle track envelopes in touch/latch/latch preview/write" }, "S&M_TOOLBAR_WRITE_ENV", ToggleWriteEnvExists, NULL, 0, WriteEnvExists},
 	{ { DEFACCEL, "SWS/S&M: Toolbar - Toggle offscreen item selection (left)" }, "S&M_TOOLBAR_ITEM_SEL0", ToggleOffscreenSelItems, NULL, SNM_ITEM_SEL_LEFT, HasOffscreenSelItems},
 	{ { DEFACCEL, "SWS/S&M: Toolbar - Toggle offscreen item selection (right)" },"S&M_TOOLBAR_ITEM_SEL1", ToggleOffscreenSelItems, NULL, SNM_ITEM_SEL_RIGHT, HasOffscreenSelItems},
@@ -1117,7 +1118,7 @@ int MidiOscActionJob::AdjustRelative(int _adjmode, int _reladj)
 WDL_FastString g_SNM_IniFn, g_SNM_CyclIniFn, g_SNM_DiffToolFn;
 int g_SNM_Beta=0, g_SNM_LearnPitchAndNormOSC=0;
 int g_SNM_MediaFlags=0, g_SNM_ToolbarRefreshFreq=SNM_DEF_TOOLBAR_RFRSH_FREQ;
-bool g_SNM_ToolbarRefresh = false, g_SNM_ExtSubmenu = true;
+bool g_SNM_ToolbarRefresh = false, g_SNM_ExtSubmenu = true, g_SNM_AccessibilityKeyboardNav = false;
 
 
 void IniFileInit()
@@ -1132,6 +1133,11 @@ void IniFileInit()
 	g_SNM_ToolbarRefresh = (GetPrivateProfileInt("General", "ToolbarsAutoRefresh", 1, g_SNM_IniFn.Get()) == 1);
 	g_SNM_ToolbarRefreshFreq = BOUNDED(GetPrivateProfileInt("General", "ToolbarsAutoRefreshFreq", SNM_DEF_TOOLBAR_RFRSH_FREQ, g_SNM_IniFn.Get()), 100, 5000);
 	g_SNM_SupportBuggyPlug = GetPrivateProfileInt("General", "BuggyPlugsSupport", 0, g_SNM_IniFn.Get());
+	const int accessibilityKeyNav = GetPrivateProfileInt("General", "AccessibilityKeyboardNav", -1, g_SNM_IniFn.Get());
+	if (accessibilityKeyNav >= 0)
+		g_SNM_AccessibilityKeyboardNav = (accessibilityKeyNav == 1);
+	else
+		g_SNM_AccessibilityKeyboardNav = (GetPrivateProfileInt("General", "DockWndTabNavigation", 0, g_SNM_IniFn.Get()) == 1);
 
 	// #1175, prompt by default, may be overridden
 	if (GetPrivateProfileInt("Misc", "RemoveAllEnvsSelTracksPrompt", -666, g_SNM_IniFn.Get()) == -666)
@@ -1169,6 +1175,7 @@ void IniFileExit()
 		<< "ToolbarsAutoRefresh=" << (g_SNM_ToolbarRefresh ? 1 : 0) << '\0'
 		<< "ToolbarsAutoRefreshFreq=" << g_SNM_ToolbarRefreshFreq << " ; in ms (min: 100, max: 5000)" << '\0'
 		<< "BuggyPlugsSupport=" << (g_SNM_SupportBuggyPlug ? 1 : 0) << '\0'
+		<< "AccessibilityKeyboardNav=" << (g_SNM_AccessibilityKeyboardNav ? 1 : 0) << '\0'
 #ifdef _WIN32
 		<< "ClearTypeFont=" << (g_SNM_ClearType ? 1 : 0) << '\0'
 		<< "DiffTool=\"" << g_SNM_DiffToolFn.Get() << '"' << '\0'

--- a/SnM/SnM.h
+++ b/SnM/SnM.h
@@ -203,7 +203,7 @@ vezn/Q+t/AIQiCv/Q4iRxAAAAABJRU5ErkJggg==\n"
 
 extern int g_SNM_Beta, g_SNM_LearnPitchAndNormOSC, g_SNM_MediaFlags, g_SNM_ToolbarRefreshFreq;
 extern WDL_FastString g_SNM_IniFn, g_SNM_CyclIniFn, g_SNM_DiffToolFn;
-extern bool g_SNM_ToolbarRefresh, g_SNM_ExtSubmenu;
+extern bool g_SNM_ToolbarRefresh, g_SNM_ExtSubmenu, g_SNM_AccessibilityKeyboardNav;
 
 
 class SNM_TrackInt {

--- a/SnM/SnM_Misc.cpp
+++ b/SnM/SnM_Misc.cpp
@@ -371,6 +371,16 @@ int IsToolbarsAutoRefeshEnabled(COMMAND_T* _ct) {
 	return g_SNM_ToolbarRefresh;
 }
 
+void ToggleDockWndTabNavigation(COMMAND_T* _ct)
+{
+	g_SNM_AccessibilityKeyboardNav = !g_SNM_AccessibilityKeyboardNav;
+}
+
+int IsDockWndTabNavigationEnabled(COMMAND_T* _ct)
+{
+	return g_SNM_AccessibilityKeyboardNav;
+}
+
 void SNM_RefreshToolbars()
 {
 	constexpr int (*watchStateGetters[])(COMMAND_T *)

--- a/SnM/SnM_Misc.h
+++ b/SnM/SnM_Misc.h
@@ -64,6 +64,8 @@ bool SNM_TagMediaFile(const char *fn, const char* tag, const char* tagval);
 // toolbar auto refresh
 void EnableToolbarsAutoRefesh(COMMAND_T*);
 int IsToolbarsAutoRefeshEnabled(COMMAND_T*);
+void ToggleDockWndTabNavigation(COMMAND_T*);
+int IsDockWndTabNavigationEnabled(COMMAND_T*);
 void AutoRefreshToolbarRun();
 
 // misc actions


### PR DESCRIPTION
In the Groove tool dialog (and most others), SWS passes keystrokes through to REAPER's main window. That makes sense for most folks who split their input between mouse and keyboard, but for screen reader users, it makes navigation in those dialogs difficult. This PR adds "Enabled deeper keyboard navigation in SWS dialogs (improves accessibility)" in the SWS Options menu. For now I've used the Groove tool dialog as proof of concept, hoping I can extend this wider if the approach I've taken is suitable. 

Here are the changes to test in the Groove tool dialog once the new option has been enabled:

- Tab and Shift+Tab work to navigate through controls
- Arrows work to change radiobuttons
- - Typeahead works in the list box, making it quicker for users to jump to grooves they know the names of
- - Space clicks buttons when those have focus, plays/stops when focus is on any other type of control
- - Control+Z passes through when focus is in the list of grooves so users can apply, undo and retry

FYI I had help from Codex on this. Have been proofing its output best I can and user testing every step along the way. I'll be happy to round up other screen reader users for wider testing too. In particular I'm aware this is all Win32 specific right now and I don't know how SWELL will handle things on Mac. It's easy for me to reach VoiceOver users who can find out though.

For now, I'd like to get feedback before spending any more time on it. All thoughts welcome.