### PR TITLE
Fix 'Set all FX (except 1) offline for selected tracks' _S&M_FXOFF_ALL_OFF_EXCPT1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,8 +30,6 @@ for:
         sudo aptitude install -yR ${native[@]} ${target[@]/%/:$arch} > /dev/null
       }
 
-      sudo update-alternatives --set gcc /usr/bin/gcc-7
-
       case $ARCH in
       x86_64)
         install-deps amd64

--- a/Breeder/BR.cpp
+++ b/Breeder/BR.cpp
@@ -157,6 +157,89 @@ void BR_CSurf_OnTrackSelection (MediaTrack* track)
 	ExecuteTrackSelAction();
 }
 
+void BR_CSurf_Run ()
+{
+	static std::map<std::pair<MediaTrack*, int>, bool> s_sendMutes;
+	static ReaProject* s_project = NULL;
+	static int s_projectState = -1;
+	static bool s_initialized = false;
+	std::map<std::pair<MediaTrack*, int>, bool> sendMutes;
+	ReaProject* project;
+	int projectState;
+	int trackCount;
+
+	project = EnumProjects(-1, NULL, 0);
+	projectState = GetProjectStateChangeCount(project);
+	if (project == s_project && projectState == s_projectState)
+		return;
+
+	// REAPER does not send a control surface callback for send mute changes.
+	// Compare mute states when the project changes, without treating send list edits as adjustments.
+	if (project != s_project)
+	{
+		s_sendMutes.clear();
+		s_project = project;
+		s_initialized = false;
+	}
+	s_projectState = projectState;
+	trackCount = CountTracks(project);
+
+	for (int trackId = -1; trackId < trackCount; ++trackId)
+	{
+		MediaTrack* track;
+		int sendCount;
+
+		track = (trackId == -1) ? GetMasterTrack(project) : GetTrack(project, trackId);
+		sendCount = GetTrackNumSends(track, 0);
+		for (int sendId = 0; sendId < sendCount; ++sendId)
+		{
+			std::pair<MediaTrack*, int> key;
+			bool mute;
+
+			key = std::make_pair(track, sendId);
+			mute = GetTrackSendInfo_Value(track, 0, sendId, "B_MUTE") != 0;
+			sendMutes[key] = mute;
+		}
+	}
+
+	if (s_initialized && sendMutes.size() == s_sendMutes.size())
+	{
+		bool sameLayout = true;
+
+		for (std::map<std::pair<MediaTrack*, int>, bool>::const_iterator current = sendMutes.begin(); current != sendMutes.end(); ++current)
+		{
+			if (s_sendMutes.find(current->first) == s_sendMutes.end())
+			{
+				sameLayout = false;
+				break;
+			}
+		}
+
+		if (sameLayout)
+		{
+			for (std::map<std::pair<MediaTrack*, int>, bool>::const_iterator current = sendMutes.begin(); current != sendMutes.end(); ++current)
+			{
+				std::map<std::pair<MediaTrack*, int>, bool>::const_iterator previous;
+
+				previous = s_sendMutes.find(current->first);
+				if (previous->second != current->second)
+				{
+					MediaTrack* track;
+					int sendId;
+					BR_EnvType type = VOLUME;
+
+					track = current->first.first;
+					sendId = current->first.second;
+					GetSetLastAdjustedSend(true, &track, &sendId, &type);
+				}
+			}
+		}
+	}
+
+	s_sendMutes.swap(sendMutes);
+	s_initialized = true;
+}
+
 int BR_CSurf_Extended(int call, void* parm1, void* parm2, void* parm3)
 {
 	if (call == CSURF_EXT_RESET)

--- a/Breeder/BR.h
+++ b/Breeder/BR.h
@@ -40,6 +40,7 @@ int  BR_GetNextActionToApply ();
 ******************************************************************************/
 void BR_CSurf_SetPlayState (bool play, bool pause, bool rec);
 void BR_CSurf_OnTrackSelection (MediaTrack* track);
+void BR_CSurf_Run ();
 int  BR_CSurf_Extended (int call, void* parm1, void* parm2, void* parm3);
 
 /******************************************************************************

--- a/Color/Autocolor.cpp
+++ b/Color/Autocolor.cpp
@@ -38,6 +38,8 @@
 #include <WDL/localize/localize.h>
 #include <WDL/projectcontext.h>
 
+
+
 // INI params
 #define AC_ENABLE_KEY  "AutoColorEnable"
 #define ACM_ENABLE_KEY "AutoColorMarkerEnable"
@@ -47,47 +49,35 @@
 #define AC_COUNT_KEY   "AutoColorCount"
 #define AC_ITEM_KEY    "AutoColor %d"
 
+
 enum { AC_ANY=0, AC_UNNAMED, AC_FOLDER, AC_CHILDREN, AC_RECEIVE, AC_MASTER, AC_REC_ARM, AC_VCA_MASTER, AC_INSTRUMENT, AC_AUDIOIN, AC_AUDIOOUT, AC_MIDIIN, AC_MIDIOUT, NUM_FILTERTYPES };
 enum { AC_RGNANY=0, AC_RGNUNNAMED, NUM_RGNFILTERTYPES };
 enum { AC_CUSTOM, AC_GRADIENT, AC_RANDOM, AC_NONE, AC_PARENT, AC_IGNORE, NUM_COLORTYPES };
-enum { 
-    COL_TYPE=0,
-    COL_FILTER, 
-    COL_COLOR, 
-    COL_ICON, 
-    COL_TCP_LAYOUT, 
-    COL_MCP_LAYOUT, 
-    COL_COUNT 
-};
-enum { AC_TRACK=0, AC_MARKER, AC_REGION, NUM_TYPETYPES };
+enum { COL_TYPE=0, COL_FILTER, COL_COLOR, COL_ICON, COL_TCP_LAYOUT, COL_MCP_LAYOUT, COL_COUNT };
+enum { AC_TRACK=0, AC_MARKER, AC_REGION, NUM_TYPETYPES }; // keep this order and 2^ values
+                                                          // (values used as masks => adding a 4th type would require another solution)
 
 enum Commands : WPARAM {
-    PRI_UP_MSG = 0x10000,
-    PRI_DOWN_MSG,
-    TYPETYPE_MSG,
-    FILTERTYPE_MSG = TYPETYPE_MSG   + NUM_TYPETYPES,
-    COLORTYPE_MSG  = FILTERTYPE_MSG + NUM_FILTERTYPES,
-    LOAD_ICON_MSG  = COLORTYPE_MSG  + NUM_COLORTYPES,
-    CLEAR_ICON_MSG,
-    LAYOUTTYPE_MSG      = 1<<17,
-    LAYOUTTYPE_MCP_FLAG = 1<<18,
+	PRI_UP_MSG = 0x10000,
+	PRI_DOWN_MSG,
+	TYPETYPE_MSG,
+	FILTERTYPE_MSG = TYPETYPE_MSG   + NUM_TYPETYPES,
+	COLORTYPE_MSG  = FILTERTYPE_MSG + NUM_FILTERTYPES,
+	LOAD_ICON_MSG  = COLORTYPE_MSG  + NUM_COLORTYPES,
+	CLEAR_ICON_MSG,
+	LAYOUTTYPE_MSG      = 1<<17, // all lower bits = layout index (0 = hide)
+	LAYOUTTYPE_MCP_FLAG = 1<<18,
 };
 
 // Larger allocs for localized strings..
 // !WANT_LOCALIZE_STRINGS_BEGIN:sws_DLG_115
-static SWS_LVColumn g_cols[] = { 
-    {25, 0, "Rule type"}, 
-    { 185, 1, "Filter" }, 
-    { 70, 1, "Color" }, 
-    { 200, 2, "Icon" }, 
-    { 100, 1, "TCP Layout" }, 
-    { 100, 1, "MCP Layout" }
-};
-static const char cTypes[][256] = {"Track", "Marker", "Region" };
+static SWS_LVColumn g_cols[] = { {25, 0, "Rule type"}, { 185, 1, "Filter" }, { 70, 1, "Color" }, { 200, 2, "Icon" }, { 100, 1, "TCP Layout" }, { 100, 1, "MCP Layout" }};
+static const char cTypes[][256] = {"Track", "Marker", "Region" }; // keep this order, see above
 static const char cFilterTypes[][256] = { "(any)", "(unnamed)", "(folder)", "(children)", "(receive)", "(master)", "(record armed)", "(vca master)", "(instrument)", "(audio input)", "(audio output)", "(MIDI input)", "(MIDI output)" };
 static const char cColorTypes[][256] = { "Custom", "Gradient", "Random", "None", "Parent", "Ignore" };
-static const char *cHideLayout = "(hide)";
+static const char *cHideLayout = "(hide)"; // #1008, additional '(hide)' layout, same for TCP and MCP
 // !WANT_LOCALIZE_STRINGS_END
+
 
 // Globals
 SWS_AutoColorWnd* g_pACWnd = NULL;
@@ -100,33 +90,1279 @@ static bool g_bAIEnabled = false;
 static bool g_bALEnabled = false;
 static WDL_String g_ACIni;
 static int s_ignore_update;
-static bool g_bApplyingRules = false;  // Добавляем флаг
-static int g_iLastTrackCount = -1;     // Для отслеживания изменений
 
-// Структура для информации о совпадениях
-struct MatchInfo {
-    SWS_RuleItem* rule;
-    int matchCount;
-    int totalWords;
-    double matchScore;
-    
-    MatchInfo(SWS_RuleItem* r, int count, int total) 
-        : rule(r), matchCount(count), totalWords(total) {
-        matchScore = totalWords > 0 ? (double)count / totalWords : 0;
-    }
-};
+// Prototypes for helper functions (ADD THIS)
+static int CountWords(const char* str);
+static int CountMatchingWords(const char* trackName, const char* ruleFilter);
 
 // Register to marker/region updates
 class AC_MarkerRegionListener : public SNM_MarkerRegionListener {
 public:
-    AC_MarkerRegionListener() : SNM_MarkerRegionListener() {}
-    void NotifyMarkerRegionUpdate(int _updateFlags) { AutoColorMarkerRegion(false, _updateFlags); }
+	AC_MarkerRegionListener() : SNM_MarkerRegionListener() {}
+	void NotifyMarkerRegionUpdate(int _updateFlags) { AutoColorMarkerRegion(false, _updateFlags); }
 };
 
 AC_MarkerRegionListener g_mkrRgnListener;
 
-// Вспомогательные функции для подсчета слов
-int CountWords(const char* str) {
+// Optimized/custom version of RegisterToMarkerRegionUpdates()
+// (to avoid useless polling behind the scene)
+bool ACRegisterUnregisterToMarkerRegionUpdates()
+{
+	if (g_bACMEnabled || g_bACREnabled)
+		for (int i = 0; i < g_pACItems.GetSize(); i++)
+			if (SWS_RuleItem* rule = (SWS_RuleItem*)g_pACItems.Get(i))
+				if ((g_bACMEnabled && rule->m_type == AC_MARKER) || (g_bACREnabled && rule->m_type == AC_REGION)) {
+					RegisterToMarkerRegionUpdates(&g_mkrRgnListener);
+					return true; // do not use the above returned value
+				}
+	UnregisterToMarkerRegionUpdates(&g_mkrRgnListener);
+	return false; // do not use the above returned value
+}
+
+// Prototypes
+void AutoColorSaveState();
+
+
+SWS_AutoColorView::SWS_AutoColorView(HWND hwndList, HWND hwndEdit)
+:SWS_ListView(hwndList, hwndEdit, COL_COUNT, g_cols, "AutoColorViewState", false, "sws_DLG_115")
+{
+}
+
+void SWS_AutoColorView::GetItemText(SWS_ListItem* item, int iCol, char* str, int iStrMax)
+{
+	if (str)
+		*str = '\0';
+
+	SWS_RuleItem* pItem = (SWS_RuleItem*)item;
+	if (!pItem)
+		return;
+
+	switch (iCol)
+	{	
+	case COL_TYPE:
+		lstrcpyn(str, __localizeFunc(cTypes[pItem->m_type],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
+		break;
+	case COL_FILTER:
+		{
+			// internal str? => localize for display
+			for (int i=0; i<NUM_FILTERTYPES; i++)
+				if (!strcmp(pItem->m_str_filter.Get(), cFilterTypes[i])) {
+					lstrcpyn(str, __localizeFunc(pItem->m_str_filter.Get(),"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
+					return;
+				}
+			// user defined?
+			lstrcpyn(str, pItem->m_str_filter.Get(), iStrMax);
+		}
+		break;
+	case COL_COLOR:
+		if (pItem->m_color<0 && (-pItem->m_color-1) < __ARRAY_SIZE(cColorTypes))
+			lstrcpyn(str, __localizeFunc(cColorTypes[-pItem->m_color-1],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
+		else
+			snprintf(str, iStrMax, "0x%06x", pItem->m_color);
+		break;
+	case COL_ICON:
+		if (pItem->m_type == AC_TRACK)
+			lstrcpyn(str, pItem->m_icon.Get(), iStrMax);
+		break;
+		case COL_TCP_LAYOUT:
+			if (pItem->m_type == AC_TRACK)
+				lstrcpyn(str, pItem->m_layout[0].Get(), iStrMax);
+			break;
+		case COL_MCP_LAYOUT:
+			if (pItem->m_type == AC_TRACK)
+				lstrcpyn(str, pItem->m_layout[1].Get(), iStrMax);
+			break;
+	}
+}
+
+//JFB: COL_TYPE must be edited via context menu, not by hand (prevent internal/localized strings mismatch)
+void SWS_AutoColorView::SetItemText(SWS_ListItem* item, int iCol, const char* str)
+{
+	SWS_RuleItem* pItem = (SWS_RuleItem*)item;
+	if (!pItem)
+		return;
+
+	switch(iCol)
+	{
+			case COL_FILTER:
+				for (int i = 0; i < g_pACItems.GetSize(); i++)
+					if (g_pACItems.Get(i) != pItem)
+						if (g_pACItems.Get(i)->m_type == pItem->m_type && !strcmp(g_pACItems.Get(i)->m_str_filter.Get(), str)){
+							MessageBox(GetParent(m_hwndList), __LOCALIZE("Autocolor entry with that name already exists.","sws_DLG_115"), __LOCALIZE("SWS - Error","sws_DLG_115"), MB_OK);
+							return;
+						}
+				if (strlen(str))
+					pItem->m_str_filter.Set(str);
+				break;
+			case COL_COLOR:
+				pItem->m_color = strtol(str, nullptr, 0) & 0xFFFFFF;
+				break;
+			case COL_TCP_LAYOUT:
+				pItem->m_layout[0].Set(str);
+				break;
+			case COL_MCP_LAYOUT:
+				pItem->m_layout[1].Set(str);
+				break;
+	}
+	g_pACWnd->Update();
+}
+
+void SWS_AutoColorView::GetItemList(SWS_ListItemList* pList)
+{
+	for (int i = 0; i < g_pACItems.GetSize(); i++)
+		pList->Add((SWS_ListItem*)g_pACItems.Get(i));
+}
+
+void SWS_AutoColorView::OnItemDblClk(SWS_ListItem* item, int iCol)
+{
+	SWS_RuleItem* pItem = (SWS_RuleItem*)item;
+	if (pItem && iCol == COL_ICON)
+		g_pACWnd->OnCommand(LOAD_ICON_MSG, (LPARAM)pItem);
+}
+
+void SWS_AutoColorView::OnItemSelChanged(SWS_ListItem* item, int iState)
+{
+	g_pACWnd->Update(false);
+}
+
+void SWS_AutoColorView::OnBeginDrag(SWS_ListItem* item)
+{
+	if (abs(m_iSortCol) == (COL_TYPE+1)) //1-based
+		SetCapture(GetParent(m_hwndList));
+}
+
+void SWS_AutoColorView::OnDrag()
+{
+	POINT p;
+	GetCursorPos(&p);
+	SWS_RuleItem* hitItem = (SWS_RuleItem*)GetHitItem(p.x, p.y, NULL);
+	if (hitItem)
+	{
+		int iNewPriority = g_pACItems.Find(hitItem);
+		int iSelPriority;
+
+		WDL_PtrList<SWS_RuleItem> draggedItems;
+		int x = 0;
+		SWS_RuleItem* selItem;
+		while((selItem = (SWS_RuleItem*)EnumSelected(&x)))
+		{
+			iSelPriority = g_pACItems.Find(selItem);
+			if (iNewPriority == iSelPriority)
+				return;
+			draggedItems.Add(selItem);
+		}
+
+		// Remove the dragged items and then readd them
+		// Switch order of add based on direction of drag & sort order
+		bool bDir = iNewPriority > iSelPriority;
+		if (m_iSortCol < 0)
+			bDir = !bDir;
+		for (int i = bDir ? 0 : draggedItems.GetSize()-1; bDir ? i < draggedItems.GetSize() : i >= 0; bDir ? i++ : i--)
+		{
+			int index = g_pACItems.Find(draggedItems.Get(i));
+			g_pACItems.Delete(index);
+			g_pACItems.Insert(iNewPriority, draggedItems.Get(i));
+		}
+
+		g_pACWnd->Update(false);
+
+		++s_ignore_update;
+		for (int i=0; i < draggedItems.GetSize(); i++)
+			SelectByItem((SWS_ListItem*)draggedItems.Get(i), i==0, i==0);
+		--s_ignore_update;
+	}
+}
+
+void SWS_AutoColorView::OnEndDrag()
+{
+	g_pACWnd->Update();
+}
+
+SWS_AutoColorWnd::SWS_AutoColorWnd()
+:SWS_DockWnd(IDD_AUTOCOLOR, __LOCALIZE("Auto Color/Icon/Layout","sws_DLG_115"), "SWSAutoColor")
+#ifdef __APPLE__
+	,m_bSettingColor(false)
+#endif
+{
+	// Must call SWS_DockWnd::Init() to restore parameters and open the window if necessary
+	Init();
+}
+
+void SWS_AutoColorWnd::Update(bool applyrules)
+{
+	if (s_ignore_update) return;
+
+	if (IsValidWindow())
+	{
+		SetDlgItemText(m_hwnd, IDC_APPLY, (g_bACEnabled||g_bACMEnabled||g_bACREnabled||g_bAIEnabled||g_bALEnabled) ? __LOCALIZE("Force","sws_DLG_115") : __LOCALIZE("Apply","sws_DLG_115"));
+
+		// Redraw the owner drawn button
+#ifdef _WIN32
+		RedrawWindow(GetDlgItem(m_hwnd, IDC_COLOR), NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
+#else
+		InvalidateRect(GetDlgItem(m_hwnd, IDC_COLOR), NULL, 0);
+#endif
+
+		if (m_pLists.GetSize())
+			m_pLists.Get(0)->Update();
+	}
+
+	if (applyrules)
+	{
+		AutoColorSaveState();
+		AutoColorTrack(false);
+		if (ACRegisterUnregisterToMarkerRegionUpdates())
+			AutoColorMarkerRegion(false);
+  }
+}
+
+void SWS_AutoColorWnd::OnInitDlg()
+{
+	m_resize.init_item(IDC_LIST,      0.0, 0.0, 1.0, 1.0);
+	m_resize.init_item(IDC_ADD,       0.0, 1.0, 0.0, 1.0);
+	m_resize.init_item(IDC_REMOVE,    0.0, 1.0, 0.0, 1.0);
+	m_resize.init_item(IDC_COLOR,     0.0, 1.0, 0.0, 1.0);
+	m_resize.init_item(IDC_OPTIONS,   1.0, 1.0, 1.0, 1.0);
+	m_resize.init_item(IDC_APPLY,     1.0, 1.0, 1.0, 1.0);
+	m_pView = new SWS_AutoColorView(GetDlgItem(m_hwnd, IDC_LIST), GetDlgItem(m_hwnd, IDC_EDIT));
+	m_pLists.Add(m_pView);
+	Update();
+}
+
+void SWS_AutoColorWnd::GetMinSize(int* w, int* h)
+{
+  *w=350; *h=MIN_DOCKWND_HEIGHT;
+}
+
+//JFB TODO? handle multi-selection
+void SWS_AutoColorWnd::OnCommand(WPARAM wParam, LPARAM lParam)
+{
+	switch (wParam)
+	{
+		case IDC_APPLY:
+			AutoColorTrack(true);
+			AutoColorMarkerRegion(true);
+			break;
+		case IDC_OPTIONS:
+		{
+			HWND hwnd = GetDlgItem(m_hwnd, IDC_OPTIONS);
+			RECT r;  GetClientRect(hwnd, &r);
+			ClientToScreen(hwnd, (LPPOINT)&r);
+			ClientToScreen(hwnd, ((LPPOINT)&r)+1);
+			SendMessage(m_hwnd, WM_CONTEXTMENU, 0, MAKELPARAM((UINT)(r.left), (UINT)(r.bottom+SNM_1PIXEL_Y)));
+			break;
+		}
+		case IDC_ADD:
+			// default options when we add a new row
+			g_pACItems.Add(new SWS_RuleItem(AC_TRACK, __LOCALIZE("(name)","sws_DLG_115"), -AC_NONE-1, "", "", ""));
+			Update();
+			break;
+		case IDC_REMOVE:
+		{
+			int x = 0;
+			SWS_RuleItem* item;
+			while((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+			{
+				int idx = g_pACItems.Find(item);
+				if (idx >= 0)
+					g_pACItems.Delete(idx);
+			}
+			Update();
+			break;
+		}
+		case IDC_COLOR:
+		{
+			SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+			if (item)
+			{
+				// Display the color picker
+#ifdef _WIN32
+				CHOOSECOLOR cc;
+				memset(&cc, 0, sizeof(CHOOSECOLOR));
+				cc.lStructSize = sizeof(CHOOSECOLOR);
+				cc.hwndOwner = m_hwnd;
+				UpdateCustomColors();
+				cc.lpCustColors = g_custColors;
+				cc.Flags = CC_FULLOPEN | CC_RGBINIT;
+				cc.rgbResult = SWS_ColorToNative(item->m_color);
+				if (ChooseColor(&cc))
+				{
+					cc.rgbResult = SWS_ColorFromNative(cc.rgbResult & 0xFFFFFF); // ANDing for issue 600
+					int x = 0;
+					while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+						item->m_color = cc.rgbResult;
+				}
+				Update();
+#elif defined(__APPLE__)
+				m_bSettingColor = true;
+				ShowColorChooser(item->m_color);
+				SetTimer(m_hwnd, 1, 50, NULL);
+#else
+				UpdateCustomColors();
+
+				COLORREF cc = item->m_color;
+				if (SWELL_ChooseColor(m_hwnd,&cc,16,g_custColors))
+				{
+					cc = SWS_ColorFromNative(cc & 0xFFFFFF);
+					int x = 0;
+					while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+						item->m_color = cc;
+				}
+				Update();
+#endif
+			}
+			break;
+		}
+		case PRI_UP_MSG:
+		{
+			int x = 0;
+			SWS_RuleItem* item;
+			while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+			{
+				int iPos = g_pACItems.Find(item);
+				if (iPos <= 0)
+					break;
+				g_pACItems.Delete(iPos, false);
+				g_pACItems.Insert(iPos-1, item);
+			}
+			Update();
+			break;
+		}
+		case PRI_DOWN_MSG:
+		{
+			// Go in reverse order
+			for (int i = m_pLists.Get(0)->GetListItemCount()-1; i >= 0; i--)
+			{
+				if (m_pLists.Get(0)->IsSelected(i))
+				{
+					SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->GetListItem(i);
+					int iPos = g_pACItems.Find(item);
+					if (iPos < 0)
+						break;
+					g_pACItems.Delete(iPos, false);
+					g_pACItems.Insert(iPos+1, item);
+				}
+			}
+			Update();
+			break;
+		}
+		case LOAD_ICON_MSG:
+		{
+			SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+			if (item)
+			{
+				char filename[SNM_MAX_PATH];
+				if (BrowseResourcePath(__LOCALIZE("Load icon","sws_DLG_115"), "Data" WDL_DIRCHAR_STR "track_icons" , "PNG files (*.PNG)\0*.PNG\0ICO files (*.ICO)\0*.ICO\0JPEG files (*.JPG)\0*.JPG\0BMP files (*.BMP)\0*.BMP\0PCX files (*.PCX)\0*.PCX\0",
+					filename, sizeof(filename)))
+				{
+					item->m_icon.Set(filename);
+				}
+			}
+			Update();
+			break;
+		}
+		case CLEAR_ICON_MSG:
+		{
+			SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+			if (item)
+				item->m_icon.Set("");
+			Update();
+			break;
+		}
+
+		default:
+			if (wParam >= TYPETYPE_MSG && wParam < TYPETYPE_MSG + NUM_TYPETYPES)
+			{
+				SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+				if (item)
+					item->m_type = (int)wParam-TYPETYPE_MSG;
+				Update();
+			}
+			else if (wParam >= FILTERTYPE_MSG && wParam < FILTERTYPE_MSG + NUM_FILTERTYPES)
+			{
+				SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+				if (item)
+				{
+					int iType = (int)wParam - FILTERTYPE_MSG;
+					for (int i = 0; i < g_pACItems.GetSize(); i++)
+						if (g_pACItems.Get(i) != item)
+							if (g_pACItems.Get(i)->m_type == item->m_type && !strcmp(g_pACItems.Get(i)->m_str_filter.Get(), cFilterTypes[iType])) {
+								MessageBox(m_hwnd, __LOCALIZE("Autocolor entry of that type already exists.","sws_DLG_115"), __LOCALIZE("SWS - Error","sws_DLG_115"), MB_OK);
+								return;
+							}
+					item->m_str_filter.Set(cFilterTypes[wParam-FILTERTYPE_MSG]);
+				}
+				Update();
+			}
+			else if (wParam >= COLORTYPE_MSG && wParam < COLORTYPE_MSG + NUM_COLORTYPES)
+			{
+				int x = 0;
+				SWS_RuleItem* item;
+				while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+					item->m_color = -1 - ((int)wParam - COLORTYPE_MSG);
+				Update();
+			}
+			else if (wParam & LAYOUTTYPE_MSG)
+			{
+				const bool isMCP   = wParam & LAYOUTTYPE_MCP_FLAG;
+				const int layoutId = wParam & (LAYOUTTYPE_MSG - 1);
+				char layoutName[255];
+				if (layoutId == 0)
+					strcpy(layoutName, cHideLayout);
+				else
+					ThemeLayout_GetLayout(isMCP ? "mcp" : "tcp", layoutId, layoutName, sizeof(layoutName));
+
+				int x = 0;
+				SWS_RuleItem* item;
+				while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+					item->m_layout[isMCP].Set(layoutName);
+				Update();
+			}
+			else
+				Main_OnCommand((int)wParam, (int)lParam);
+	}
+}
+
+#ifdef __APPLE__
+void SWS_AutoColorWnd::OnTimer(WPARAM wParam)
+{
+	COLORREF cr;
+	if (m_bSettingColor && GetChosenColor(&cr))
+	{
+		cr &= 0xFFFFFF;
+		int x = 0;
+		SWS_RuleItem* item;
+		while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+			item->m_color = cr;
+
+		KillTimer(m_hwnd, 1);
+		Update();
+	}
+}
+
+void SWS_AutoColorWnd::OnDestroy()
+{
+	if (m_bSettingColor)
+	{
+		HideColorChooser();
+		KillTimer(m_hwnd, 1);
+	}
+}
+#endif
+
+INT_PTR SWS_AutoColorWnd::OnUnhandledMsg(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	if (uMsg == WM_DRAWITEM)
+	{
+		LPDRAWITEMSTRUCT pDI = (LPDRAWITEMSTRUCT)lParam;
+		if (pDI->CtlID == IDC_COLOR)
+		{
+			// Dialog-box background grey for no selection, or multiple colors in selection
+			// Doesn't account for the "special colors" because they're less than zero and get trapped
+			// out below anyway.
+			int col = -1;
+			int x = 0;
+			SWS_RuleItem* item;
+			while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+			{
+				if (col < 0)
+					col = SWS_ColorToNative(item->m_color);
+				else if (col != item->m_color)
+				{
+					col = -1;
+					break;
+				}
+			}
+
+			if (col < 0)
+				col = GetSysColor(COLOR_3DHILIGHT);
+
+			HBRUSH hb = CreateSolidBrush(col);
+			FillRect(pDI->hDC, &pDI->rcItem, hb);
+			DeleteObject(hb);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+// must remain in sync with main menu > extensions > sws options
+void SWS_AutoColorWnd::AddOptionsMenu(HMENU _menu)
+{
+	if (GetMenuItemCount(_menu))
+		AddToMenu(_menu, SWS_SEPARATOR, 0);
+	AddToMenu(_menu, __LOCALIZE("Enable auto track coloring", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_ENABLE"), -1, false, g_bACEnabled ?  MF_CHECKED : MF_UNCHECKED);
+	AddToMenu(_menu, __LOCALIZE("Enable auto marker coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_MKR_ENABLE"), -1, false, g_bACMEnabled ?  MF_CHECKED : MF_UNCHECKED);
+	AddToMenu(_menu, __LOCALIZE("Enable auto region coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_RGN_ENABLE"), -1, false, g_bACREnabled ?  MF_CHECKED : MF_UNCHECKED);
+	AddToMenu(_menu, __LOCALIZE("Enable auto track icon", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOICON_ENABLE"), -1, false, g_bAIEnabled ?  MF_CHECKED : MF_UNCHECKED);
+	AddToMenu(_menu, __LOCALIZE("Enable auto track layout", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOLAYOUT_ENABLE"), -1, false, g_bALEnabled ?  MF_CHECKED : MF_UNCHECKED);
+}
+
+HMENU SWS_AutoColorWnd::OnContextMenu(int x, int y, bool* wantDefaultItems)
+{
+	HMENU hMenu = CreatePopupMenu();
+
+	// specific context menu for the button "options"
+	{
+		POINT pt = {x, y + 3*(SNM_1PIXEL_Y*(-1))}; // +/- 3: tiny trick, see OnCommand()
+		RECT r;	GetWindowRect(GetDlgItem(m_hwnd, IDC_OPTIONS), &r);
+		if (PtInRect(&r, pt))
+		{
+			*wantDefaultItems = false;
+			AddOptionsMenu(hMenu);
+			return hMenu;
+		}
+	}
+
+	// "standard" context menu
+	int iCol;
+	if (SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->GetHitItem(x, y, &iCol))
+	{
+		*wantDefaultItems = false;
+
+		switch (iCol)
+		{
+			case COL_TYPE:
+			{
+				for (int i = 0; i < NUM_TYPETYPES; i++)
+					AddToMenu(hMenu, __localizeFunc(cTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), TYPETYPE_MSG + i);
+				AddToMenu(hMenu, SWS_SEPARATOR, 0);
+				break;
+			}
+			case COL_FILTER:
+			{
+				int numFilters = 0;
+				if (item->m_type == AC_TRACK)
+					numFilters= NUM_FILTERTYPES;
+				else if (item->m_type == AC_MARKER || item->m_type == AC_REGION)
+					numFilters = NUM_RGNFILTERTYPES;
+				if (numFilters)
+				{
+					for (int i=0; i<numFilters; i++)
+						AddToMenu(hMenu, __localizeFunc(cFilterTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), FILTERTYPE_MSG + i);
+					AddToMenu(hMenu, SWS_SEPARATOR, 0);
+				}
+				break;
+			}
+			case COL_COLOR:
+			{
+				AddToMenu(hMenu, __LOCALIZE("Set color...","sws_DLG_115"), IDC_COLOR);
+				AddToMenu(hMenu, SWS_SEPARATOR, 0);
+
+				if (item->m_type == AC_TRACK)
+				{
+					for (int i = 0; i < NUM_COLORTYPES; i++)
+						AddToMenu(hMenu, __localizeFunc(cColorTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), COLORTYPE_MSG + i);
+				}
+				else if (item->m_type == AC_MARKER || item->m_type == AC_REGION)
+					AddToMenu(hMenu, __localizeFunc(cColorTypes[AC_NONE],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), COLORTYPE_MSG + AC_NONE);
+				AddToMenu(hMenu, SWS_SEPARATOR, 0);
+				break;
+			}
+			case COL_ICON:
+			{
+				AddToMenu(hMenu, __LOCALIZE("Load icon...","sws_DLG_115"), LOAD_ICON_MSG, -1, false, item->m_type == AC_TRACK ? MF_ENABLED : MF_GRAYED);
+				AddToMenu(hMenu, __LOCALIZE("Clear icon","sws_DLG_115"), CLEAR_ICON_MSG, -1, false, item->m_type == AC_TRACK ? MF_ENABLED : MF_GRAYED);
+				AddToMenu(hMenu, SWS_SEPARATOR, 0);
+				break;
+			}
+			case COL_TCP_LAYOUT:
+			case COL_MCP_LAYOUT:
+				AddToMenu(hMenu, __LOCALIZE("(Double-click to edit layout name)", "sws_DLG_115"), 0, -1, false, MF_GRAYED);
+				const char *section = "tcp";
+				int command = LAYOUTTYPE_MSG;
+				if (iCol == COL_MCP_LAYOUT)
+				{
+					command |= LAYOUTTYPE_MCP_FLAG;
+					section = "mcp";
+				}
+				AddToMenu(hMenu, __localizeFunc(cHideLayout, "sws_DLG_115", 0), command);
+				char layout[255];
+				// starting from 1 to skip "global layout default"
+				for (int i = 1; i < LAYOUTTYPE_MSG && ThemeLayout_GetLayout(section, i, layout, sizeof(layout)); ++i)
+				{
+					if (!layout[0])
+						snprintf(layout, sizeof(layout), "Layout %d", i);
+					AddToMenu(hMenu, layout, command | i);
+				}
+
+				AddToMenu(hMenu, SWS_SEPARATOR, 0);
+				break;
+		}
+		AddToMenu(hMenu, __LOCALIZE("Up in priority","sws_DLG_115"), PRI_UP_MSG);
+		AddToMenu(hMenu, __LOCALIZE("Down in priority","sws_DLG_115"), PRI_DOWN_MSG);
+	}
+	else
+	{
+		AddToMenu(hMenu, __LOCALIZE("Show color management window","sws_DLG_115"), SWSGetCommandID(ShowColorDialog));
+		AddToMenu(hMenu, SWS_SEPARATOR, 0);
+
+		HMENU hOptionsSubMenu = CreatePopupMenu();
+		AddSubMenu(hMenu, hOptionsSubMenu, __LOCALIZE("Options", "sws_menu"));
+		AddOptionsMenu(hOptionsSubMenu);
+	}
+	return hMenu;
+}
+
+int SWS_AutoColorWnd::OnKey(MSG* msg, int iKeyState)
+{
+	if (msg->message == WM_KEYDOWN && msg->wParam == VK_DELETE && !iKeyState)
+	{
+		OnCommand(IDC_REMOVE, 0);
+		return 1;
+	}
+	return 0;
+}
+
+void OpenAutoColor(COMMAND_T*)
+{
+	g_pACWnd->Show(true, true);
+}
+
+void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* rule, bool bDoColors, bool bDoIcons, bool bDoLayout, bool bForce)
+{
+	if(rule->m_type == AC_TRACK)
+	{
+		if (!bDoColors && !bDoIcons && !bDoLayout)
+			return;
+
+		PreventUIRefresh(1);
+
+		int iCount = 0;
+		WDL_PtrList<MediaTrack> gradientTracks;
+
+		if (rule->m_color == -AC_CUSTOM-1)
+			UpdateCustomColors();
+
+		MediaTrack* temp = NULL;
+		const int numTracks = GetNumTracks();
+		activeRules->reserve(numTracks);
+		
+		for (int i = 0; i <= numTracks; i++)
+		{
+			MediaTrack* tr = i ? GetTrack(nullptr, i - 1) : GetMasterTrack(nullptr);			
+			
+			struct RuleMatch {
+				SWS_RuleItem* rule;
+				int totalWords;
+				bool isSpecial;
+			};
+			WDL_PtrList<RuleMatch> matches;			
+			
+			for (int r = 0; r < g_pACItems.GetSize(); r++) {
+				SWS_RuleItem* currentRule = g_pACItems.Get(r);
+				if (currentRule->m_type != AC_TRACK) continue;
+				
+				bool bMatch = false;
+				bool isSpecial = false;
+				int totalWords = 0;
+				
+				if (i) 
+				{					
+					if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_FOLDER]) == 0) {
+						int iType;
+						GetFolderDepth(tr, &iType, &temp);
+						if (iType == 1) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_CHILDREN]) == 0) {
+						temp = CSurf_TrackFromID(0, false);
+						if (GetFolderDepth(tr, NULL, &temp) >= 1) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_RECEIVE]) == 0) {
+						if (GetSetTrackSendInfo(tr, -1, 0, "P_SRCTRACK", NULL)) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_UNNAMED]) == 0) {
+						char* cName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
+						if (!cName || !cName[0]) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_REC_ARM]) == 0) {
+						int* ra = (int*)GetSetMediaTrackInfo(tr, "I_RECARM", NULL);
+						if (ra && *ra) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_VCA_MASTER]) == 0) {
+						int iVcaMaster = GetSetTrackGroupMembership(tr, "VOLUME_VCA_MASTER", 0, 0);
+						int iVcaMasterHigh = GetSetTrackGroupMembershipHigh(tr, "VOLUME_VCA_MASTER", 0, 0);
+						if (iVcaMaster || iVcaMasterHigh) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_AUDIOIN]) == 0) {
+						int input = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
+						if (input >= 0 && !(input & 4096)) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_AUDIOOUT]) == 0) {
+						int hwouts = GetTrackNumSends(tr, 1);
+						if (hwouts) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_INSTRUMENT]) == 0) {
+						if (TrackFX_GetInstrument(tr) >= 0) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_MIDIIN]) == 0) {
+						int input = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
+						if (input >= 0 && (input & 4096)) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_MIDIOUT]) == 0) {
+						int midihw = *(int*)GetSetMediaTrackInfo(tr, "I_MIDIHWOUT", NULL);
+						int mididv = midihw >> 5;
+						if (mididv >= 0) {
+							bMatch = true;
+							isSpecial = true;
+						}
+					}
+					else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_ANY]) == 0) {
+						bMatch = true;
+						isSpecial = true;
+					}
+					else // Check for name match with multi-word support
+					{
+						char* cName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
+						if (cName && cName[0]) {
+							int wordCount = CountWords(currentRule->m_str_filter.Get());
+							int matchCount = CountMatchingWords(cName, currentRule->m_str_filter.Get());							
+							if (matchCount > 0 && matchCount == wordCount) {
+								bMatch = true;
+								totalWords = wordCount;
+							}
+						}
+					}
+				}
+				else if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_MASTER]) == 0) {
+					bMatch = true;
+					isSpecial = true;
+				}
+				
+				if (bMatch) {
+					RuleMatch* rm = new RuleMatch();
+					rm->rule = currentRule;
+					rm->totalWords = isSpecial ? 999 : totalWords;
+					rm->isSpecial = isSpecial;
+					matches.Add(rm);
+				}
+			}			
+			
+			SWS_RuleItem* bestRule = NULL;
+			int bestTotalWords = -1;
+			
+			for (int m = 0; m < matches.GetSize(); m++) {
+				RuleMatch* rm = matches.Get(m);
+				if (rm->totalWords > bestTotalWords) {
+					bestTotalWords = rm->totalWords;
+					bestRule = rm->rule;
+				}
+			}			
+			
+			if (bestRule) {
+				auto pACTrack = activeRules->find(tr);
+				if (pACTrack == activeRules->end()) {
+					pACTrack = activeRules->insert(tr).first;
+				}
+				
+				bool bColor = bDoColors && !pACTrack->m_bColored && bestRule->m_color != -AC_IGNORE-1;
+				bool bIcon = bDoIcons && !pACTrack->m_bIconed && bestRule->m_icon.Get()[0];
+				bool bLayout[2] = {
+					bDoLayout && !pACTrack->m_bLayouted[0] && bestRule->m_layout[0].Get()[0],
+					bDoLayout && !pACTrack->m_bLayouted[1] && bestRule->m_layout[1].Get()[0]
+				};
+				
+				if (bColor || bIcon || bLayout[0] || bLayout[1]) {					
+					if (bColor) {
+						int iCurColor = *(int*)GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", NULL);
+						if (!(iCurColor & 0x1000000)) iCurColor = 0;
+						int newCol = iCurColor;
+
+						if (bestRule->m_color == -AC_RANDOM-1) {
+							if (!(iCurColor & 0x1000000))
+								newCol = RGB(rand() % 256, rand() % 256, rand() % 256) | 0x1000000;
+						}
+						else if (bestRule->m_color == -AC_CUSTOM-1) {
+							if (!AllBlack())
+								while(!(newCol = g_custColors[iCount++ % 16]));
+							newCol |= 0x1000000;
+						}
+						else if (bestRule->m_color == -AC_GRADIENT-1)
+							gradientTracks.Add(tr);
+						else if (bestRule->m_color == -AC_NONE-1)
+							newCol = 0;
+						else if (bestRule->m_color == -AC_PARENT-1) {
+							MediaTrack* parent = (MediaTrack*)GetSetMediaTrackInfo(tr, "P_PARTRACK", NULL);
+							if (parent) {
+								int pcol = *(int*)GetSetMediaTrackInfo(parent, "I_CUSTOMCOLOR", NULL);
+								if (pcol & 0x1000000)
+									newCol = pcol;
+							}
+						}
+						else
+							newCol = SWS_ColorToNative(bestRule->m_color | 0x1000000);
+
+						if ((bForce || iCurColor == SWS_ColorToNative(pACTrack->m_col)) && newCol != iCurColor) {
+							GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", &newCol);
+						}
+						pACTrack->m_col = SWS_ColorFromNative(newCol);
+						pACTrack->m_bColored = true;
+					}
+					
+					if (bIcon) {
+						if (_stricmp(bestRule->m_icon.Get(), pACTrack->m_icon.Get())) {
+							const char *cur = (const char*)GetSetMediaTrackInfo(tr, "P_ICON", NULL);
+							cur = GetShortResourcePath("Data" WDL_DIRCHAR_STR "track_icons", cur);
+							if (cur && _stricmp(cur, bestRule->m_icon.Get())) {
+								if (bForce || !_stricmp(cur, pACTrack->m_icon.Get())) {
+									GetSetMediaTrackInfo(tr, "P_ICON", (void*)bestRule->m_icon.Get());
+								}
+							}
+							pACTrack->m_icon.Set(bestRule->m_icon.Get());
+						}
+						pACTrack->m_bIconed = true;
+					}
+					
+					for (int k=0; k<2; k++) if (bLayout[k]) {
+						pACTrack->m_bLayouted[k] = true;
+						if (!_stricmp(bestRule->m_layout[k].Get(), pACTrack->m_layout[k].Get()))
+							continue;
+
+						if (_stricmp(bestRule->m_layout[k].Get(), cHideLayout)) {
+							const bool needUnhide = !_stricmp(pACTrack->m_layout[k].Get(), cHideLayout) && !IsTrackVisible(tr, k ? true : false);
+							const char *curlayout = (const char*)GetSetMediaTrackInfo(tr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", NULL);
+							if (curlayout && _stricmp(curlayout, bestRule->m_layout[k].Get())) {
+								if (bForce || needUnhide || !_stricmp(curlayout, pACTrack->m_layout[k].Get()))
+									GetSetMediaTrackInfo(tr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", (void*)bestRule->m_layout[k].Get());
+							}
+							if (needUnhide) {
+								GetSetMediaTrackInfo(tr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i1);
+								TrackList_AdjustWindows(k ? false : true);
+							}
+						}
+						else if (IsTrackVisible(tr, k ? true : false)) {
+							if (bForce || IsTrackVisible(pACTrack->m_pTr, k ? true : false)) {
+								GetSetMediaTrackInfo(tr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i0);
+								TrackList_AdjustWindows(k ? false : true);
+							}
+						}
+						pACTrack->m_layout[k].Set(bestRule->m_layout[k].Get());
+					}
+				}
+			}			
+			
+			for (int m = 0; m < matches.GetSize(); m++) {
+				delete matches.Get(m);
+			}
+			matches.Empty();
+		}
+
+		// Handle gradients
+		for (int i = 0; i < gradientTracks.GetSize(); i++) {
+			int newCol = g_crGradStart | 0x1000000;
+			if (i && gradientTracks.GetSize() > 1)
+				newCol = CalcGradient(g_crGradStart, g_crGradEnd, (double)i / (gradientTracks.GetSize()-1)) | 0x1000000;
+			auto match = activeRules->find(gradientTracks.Get(i));
+			if (match != activeRules->end())
+				match->m_col = newCol;
+			SetMediaTrackInfo_Value(gradientTracks.Get(i), "I_CUSTOMCOLOR", SWS_ColorToNative(newCol));
+		}
+
+		PreventUIRefresh(-1);
+	}
+}
+
+// Here's the meat and potatoes, apply the colors/icons!
+void AutoColorTrack(bool bForce)
+{
+	static bool bRecurse = false;
+	if (bRecurse || (!g_bACEnabled && !g_bAIEnabled && !g_bALEnabled && !bForce))
+		return;
+	bRecurse = true;
+
+	auto *activeRules = g_pACTracks.Get();
+
+	// If forcing, start over with the saved track list
+	if (bForce)
+		activeRules->clear();
+
+	// Clear the applied bits and cleanup entries belonging to deleted tracks
+	for (auto it = activeRules->begin(); it != activeRules->end();)
+	{
+		if (!ValidatePtr(it->m_pTr, "MediaTrack*"))
+		{
+			it = activeRules->erase(it);
+			continue;
+		}
+
+		it->m_bColored = false;
+		it->m_bIconed  = false;
+		it->m_bLayouted[0] = false;
+		it->m_bLayouted[1] = false;
+		++it;
+	}
+
+	// Apply the rules
+	bool bDoColors  = g_bACEnabled || bForce;
+	bool bDoIcons   = g_bAIEnabled || bForce;
+	bool bDoLayouts = g_bALEnabled || bForce;
+
+	PreventUIRefresh(1);
+
+	for (int i = 0; i < g_pACItems.GetSize(); i++)
+		ApplyColorRuleToTrack(activeRules, g_pACItems.Get(i), bDoColors, bDoIcons, bDoLayouts, bForce);
+
+	// Remove colors/icons if necessary
+	for (auto pACTrack = activeRules->begin(); pACTrack != activeRules->end(); ++pACTrack)
+	{
+		if (bDoColors && !pACTrack->m_bColored && pACTrack->m_col)
+		{
+			int iCurColor = *(int*)GetSetMediaTrackInfo(pACTrack->m_pTr, "I_CUSTOMCOLOR", NULL);
+			if (!(iCurColor & 0x1000000))
+				iCurColor = 0;
+
+			// Only remove color on tracks that we colored ourselves
+			if (SWS_ColorToNative(pACTrack->m_col) == iCurColor)
+			{
+				GetSetMediaTrackInfo(pACTrack->m_pTr, "I_CUSTOMCOLOR", &g_i0);
+			}
+			pACTrack->m_col = 0;
+		}
+
+		// There's an icon set, but there shouldn't be!
+		if (bDoIcons && !pACTrack->m_bIconed && pACTrack->m_icon.GetLength())
+		{
+			// Only remove the icon on the track if we set it ourselves
+			const char *cur = (const char*)GetSetMediaTrackInfo(pACTrack->m_pTr, "P_ICON", NULL); // requires REAPER v5.15pre6+
+			cur = GetShortResourcePath("Data" WDL_DIRCHAR_STR "track_icons", cur);
+			if (cur && !_stricmp(pACTrack->m_icon.Get(), cur))
+			{
+				GetSetMediaTrackInfo(pACTrack->m_pTr, "P_ICON", (void*)"");
+			}
+			pACTrack->m_icon.Set("");
+		}
+
+		if (bDoLayouts) for (int k=0; k<2; k++) if (!pACTrack->m_bLayouted[k] && pACTrack->m_layout[k].GetLength())
+		{
+			// There's a layout set, but there shouldn't be!
+			// 'normal' track layout
+			if (_stricmp(pACTrack->m_layout[k].Get(), cHideLayout))
+			{
+				// Only remove the layout if we set it ourselves
+				const char *curlayout = (const char*)GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", NULL);
+				if (curlayout && !_stricmp(pACTrack->m_layout[k].Get(), curlayout))
+					GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", (void*)"");
+			}
+			// '(hide)' layout
+			// Only unhide the track if we hid it ourselves
+			else if (!IsTrackVisible(pACTrack->m_pTr, k ? true : false))
+			{
+				GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i1); // show the track
+				TrackList_AdjustWindows(k ? false : true);
+			}
+			pACTrack->m_layout[k].Set("");
+		}
+	}
+
+	if (bForce)
+		Undo_OnStateChangeEx(__LOCALIZE("Apply auto color/icon/layout","sws_undo"), UNDO_STATE_TRACKCFG | UNDO_STATE_MISCCFG, -1);
+	UpdateArrange();
+	PreventUIRefresh(-1);
+
+	bRecurse = false;
+}
+
+void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
+{
+	ColorTheme* ct = SNM_GetColorTheme();
+	if (!_rule || !_flags || !ct)
+		return;
+
+	double pos, end;
+	int x=0, num, color;
+	bool isRgn;
+	const char* name;
+
+	PreventUIRefresh(1);
+	if(_rule->m_type & _flags)
+	{
+		// Collect all marker/region rules
+		WDL_PtrList<SWS_RuleItem> markerRegionRules;
+		for (int i = 0; i < g_pACItems.GetSize(); i++) {
+			SWS_RuleItem* rule = g_pACItems.Get(i);
+			if (rule->m_type == AC_MARKER || rule->m_type == AC_REGION) {
+				markerRegionRules.Add(rule);
+			}
+		}
+
+		while ((x = EnumProjectMarkers3(NULL, x, &isRgn, &pos, &end, &name, &num, &color)))
+		{
+			struct RuleMatch {
+				SWS_RuleItem* rule;
+				int totalWords;
+				bool isSpecial;
+			};
+			WDL_PtrList<RuleMatch> matches;
+
+			for (int r = 0; r < markerRegionRules.GetSize(); r++) {
+				SWS_RuleItem* currentRule = markerRegionRules.Get(r);
+
+				// Check type (marker or region)
+				if ((isRgn && currentRule->m_type != AC_REGION) ||
+				    (!isRgn && currentRule->m_type != AC_MARKER)) {
+					continue;
+				}
+
+				bool bMatch = false;
+				bool isSpecial = false;
+				int totalWords = 0;
+
+				if (!strcmp(cFilterTypes[AC_RGNANY], currentRule->m_str_filter.Get())) {
+					bMatch = true;
+					isSpecial = true;
+				}
+				else if (!strcmp(cFilterTypes[AC_RGNUNNAMED], currentRule->m_str_filter.Get()) && (!name || !*name)) {
+					bMatch = true;
+					isSpecial = true;
+				}
+				else if (name && name[0]) {
+					int wordCount = CountWords(currentRule->m_str_filter.Get());
+					int matchCount = CountMatchingWords(name, currentRule->m_str_filter.Get());
+					// Match only if ALL words are present (100%)
+					if (matchCount > 0 && matchCount == wordCount) {
+						bMatch = true;
+						totalWords = wordCount;
+					}
+				}
+
+				if (bMatch) {
+					RuleMatch* rm = new RuleMatch();
+					rm->rule = currentRule;
+					rm->totalWords = isSpecial ? 999 : totalWords;
+					rm->isSpecial = isSpecial;
+					matches.Add(rm);
+				}
+			}
+
+			// Select rule with most words (most specific)
+			SWS_RuleItem* bestRule = NULL;
+			int bestTotalWords = -1;
+
+			for (int m = 0; m < matches.GetSize(); m++) {
+				RuleMatch* rm = matches.Get(m);
+				if (rm->totalWords > bestTotalWords) {
+					bestTotalWords = rm->totalWords;
+					bestRule = rm->rule;
+				}
+			}
+
+			if (bestRule) {
+				SetProjectMarkerByIndex(NULL, x-1, isRgn, pos, end, num, NULL, 
+					bestRule->m_color==-AC_NONE-1 ? (isRgn?ct->marker:ct->region) : 
+					SWS_ColorToNative(bestRule->m_color | 0x1000000));
+			}
+
+			// Cleanup
+			for (int m = 0; m < matches.GetSize(); m++) {
+				delete matches.Get(m);
+			}
+			matches.Empty();
+		}
+	}
+	PreventUIRefresh(-1);
+}
+
+void AutoColorMarkerRegion(bool _force, int _flags)
+{
+	static bool bRecurse = false;
+	if (bRecurse || (!g_bACREnabled && !g_bACMEnabled && !_force))
+		return;
+	bRecurse = true;
+
+	int newFlags = 0;
+	if (_flags&AC_MARKER && (g_bACMEnabled || _force))
+		newFlags |= AC_MARKER;
+	if (_flags&AC_REGION && (g_bACREnabled || _force))
+		newFlags |= AC_REGION;
+
+	if (newFlags)
+	{
+		PreventUIRefresh(1);
+
+		// Apply rules using the new logic
+		// We need to pass all rules, not just one
+		// Create a dummy rule that will trigger the full processing
+		SWS_RuleItem dummyRule(AC_MARKER, "", 0, "", "", "");
+		dummyRule.m_type = AC_MARKER | AC_REGION; // Process all types
+		ApplyColorRuleToMarkerRegion(&dummyRule, newFlags);
+
+		PreventUIRefresh(-1);
+	}
+
+	if (_force)
+		Undo_OnStateChangeEx(__LOCALIZE("Apply auto marker/region color","sws_undo"), UNDO_STATE_MISCCFG, -1);
+	bRecurse = false;
+}
+
+void EnableAutoColor(COMMAND_T* ct)
+{
+	switch((int)ct->user)
+	{
+		case 0: g_bACEnabled = !g_bACEnabled; break;
+		case 1: g_bACMEnabled = !g_bACMEnabled; break;
+		case 2: g_bACREnabled = !g_bACREnabled; break;
+	}
+	g_pACWnd->Update();
+}
+
+void EnableAutoIcon(COMMAND_T*)
+{
+	g_bAIEnabled = !g_bAIEnabled;
+	g_pACWnd->Update();
+}
+
+void EnableAutoLayout(COMMAND_T*)
+{
+	g_bALEnabled = !g_bALEnabled;
+	g_pACWnd->Update();
+}
+
+void ApplyAutoColor(COMMAND_T*)
+{
+	AutoColorTrack(true);
+	AutoColorMarkerRegion(true);
+}
+
+int IsAutoColorOpen(COMMAND_T*)		{ return g_pACWnd->IsWndVisible(); }
+int IsAutoIconEnabled(COMMAND_T*)	{ return g_bAIEnabled; }
+int IsAutoLayoutEnabled(COMMAND_T*)	{ return g_bALEnabled; }
+
+int IsAutoColorEnabled(COMMAND_T* ct)
+{
+	switch((int)ct->user) {
+		case 0: return g_bACEnabled;
+		case 1: return g_bACMEnabled;
+		case 2: return g_bACREnabled;
+	}
+	return false;
+ }
+
+static bool ProcessExtensionLine(const char *line, ProjectStateContext *ctx, bool isUndo, struct project_config_extension_t *reg)
+{
+	LineParser lp(false);
+	if (lp.parse(line) || lp.getnumtokens() < 1)
+		return false;
+	if (strcmp(lp.gettoken_str(0), "<SWSAUTOCOLOR") == 0)
+	{
+		char linebuf[4096];
+		while(true)
+		{
+			if (!ctx->GetLine(linebuf,sizeof(linebuf)) && !lp.parse(linebuf))
+			{
+				if (lp.gettoken_str(0)[0] == '>')
+					break;
+
+				GUID g;
+				stringToGuid(lp.gettoken_str(0), &g);
+				MediaTrack* tr = GuidToTrack(&g);
+				// not loading master track cache to always re-apply rules (icon isn't persisted in RPP)
+				if (tr && tr != GetMasterTrack(nullptr))
+				{
+					auto rt = g_pACTracks.Get()->insert(tr).first;
+					rt->m_col = ImportColor(lp.gettoken_int(1));
+					rt->m_icon.Set(lp.gettoken_str(2));
+					rt->m_layout[0].Set(lp.gettoken_str(3));
+					rt->m_layout[1].Set(lp.gettoken_str(4));
+				}
+			}
+			else
+				break;
+		}
+		return true;
+	}
+	return false;
+}
+
+static void SaveExtensionConfig(ProjectStateContext *ctx, bool isUndo, struct project_config_extension_t *reg)
+{
+	auto *activeRules = g_pACTracks.Get();
+	activeRules->erase_if([](const SWS_RuleTrack &rt) { return !ValidatePtr(rt.m_pTr, "MediaTrack*"); });
+	if (activeRules->empty())
+		return;
+
+	// serialize in track project order instead of track address order
+	std::vector<const SWS_RuleTrack *> sortedRules;
+	sortedRules.reserve(activeRules->size());
+	std::transform(activeRules->begin(), activeRules->end(),
+		std::back_inserter(sortedRules), [](const SWS_RuleTrack &rt) { return &rt; }); // std::addressof is C++11
+	std::sort(sortedRules.begin(), sortedRules.end(), [](const SWS_RuleTrack *a, const SWS_RuleTrack *b) {
+		return GetMediaTrackInfo_Value(a->m_pTr, "IP_TRACKNUMBER") < GetMediaTrackInfo_Value(b->m_pTr, "IP_TRACKNUMBER");
+	});
+
+	ctx->AddLine("<SWSAUTOCOLOR");
+	for (const SWS_RuleTrack *rt : sortedRules)
+	{
+
+		char str[256];
+		GUID g = GUID_NULL;
+		if (CSurf_TrackToID(rt->m_pTr, false))
+			g = *(GUID*)GetSetMediaTrackInfo(rt->m_pTr, "GUID", NULL);
+		guidToString(&g, str);
+		ctx->AddLine("%s %d \"%s\" \"%s\" \"%s\"", str, ExportColor(rt->m_col), rt->m_icon.Get(), rt->m_layout[0].Get(), rt->m_layout[1].Get());
+
+		++rt;
+	}
+	ctx->AddLine(">");
+}
+
+static void BeginLoadProjectState(bool isUndo, struct project_config_extension_t *reg)
+{
+	g_pACTracks.Cleanup();
+	g_pACTracks.Get()->clear();
+}
+
+static project_config_extension_t g_projectconfig = { ProcessExtensionLine, SaveExtensionConfig, BeginLoadProjectState, NULL };
+
+//!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
+static COMMAND_T g_commandTable[] =
+{
+	{ { DEFACCEL, "SWS: Open auto color/icon/layout window" },				"SWSAUTOCOLOR_OPEN",		OpenAutoColor,		"SWS Auto color/icon/layout",			0, IsAutoColorOpen },
+	{ { DEFACCEL, "SWS: Toggle auto track coloring enable" },		"SWSAUTOCOLOR_ENABLE",		EnableAutoColor,	"Enable auto track coloring",	0, IsAutoColorEnabled },
+	{ { DEFACCEL, "SWS/S&M: Toggle auto marker coloring enable" },	"S&MAUTOCOLOR_MKR_ENABLE",	EnableAutoColor,	"Enable auto marker coloring",	1, IsAutoColorEnabled },
+	{ { DEFACCEL, "SWS/S&M: Toggle auto region coloring enable" },	"S&MAUTOCOLOR_RGN_ENABLE",	EnableAutoColor,	"Enable auto region coloring",	2, IsAutoColorEnabled },
+	{ { DEFACCEL, "SWS/S&M: Toggle auto track icon enable" },		"S&MAUTOICON_ENABLE",		EnableAutoIcon,		"Enable auto icon",				0, IsAutoIconEnabled },
+	{ { DEFACCEL, "SWS/S&M: Toggle auto track layout enable" },		"S&MAUTOLAYOUT_ENABLE",		EnableAutoLayout,		"Enable auto layout",				0, IsAutoLayoutEnabled },
+	{ { DEFACCEL, "SWS: Apply auto coloring" },						"SWSAUTOCOLOR_APPLY",		ApplyAutoColor,	},
+	{ {}, LAST_COMMAND, }, // Denote end of table
+};
+//!WANT_LOCALIZE_1ST_STRING_END
+
+// ============================================================================
+// Helper functions for word splitting
+// ============================================================================
+
+static int CountWords(const char* str)
+{
     if (!str || !str[0]) return 0;
     int count = 0;
     bool inWord = false;
@@ -141,1345 +1377,148 @@ int CountWords(const char* str) {
     return count;
 }
 
-int CountMatchingWords(const char* trackName, const char* ruleFilter) {
+static int CountMatchingWords(const char* trackName, const char* ruleFilter)
+{
     if (!trackName || !trackName[0] || !ruleFilter || !ruleFilter[0]) return 0;
-    
+
     char trackLower[256];
     char ruleLower[256];
     strncpy(trackLower, trackName, 255);
     strncpy(ruleLower, ruleFilter, 255);
     trackLower[255] = '\0';
     ruleLower[255] = '\0';
-    
+
     for (char* p = trackLower; *p; ++p) *p = tolower(*p);
     for (char* p = ruleLower; *p; ++p) *p = tolower(*p);
-    
-    char ruleWords[256];
-    strncpy(ruleWords, ruleLower, 255);
-    ruleWords[255] = '\0';
-    
-    char* tokens[64];
-    int tokenCount = 0;
-    char* token = strtok(ruleWords, " ");
-    while (token && tokenCount < 64) {
-        if (strlen(token) > 0)
-            tokens[tokenCount++] = token;
-        token = strtok(NULL, " ");
+
+    char words[64][64];
+    int wordCount = 0;
+    int i = 0;
+    int j = 0;
+
+    while (ruleLower[i] != '\0' && wordCount < 64) {
+        while (ruleLower[i] == ' ') i++;
+        if (ruleLower[i] == '\0') break;
+
+        j = 0;
+        while (ruleLower[i] != '\0' && ruleLower[i] != ' ' && j < 63) {
+            words[wordCount][j++] = ruleLower[i++];
+        }
+        words[wordCount][j] = '\0';
+        wordCount++;
     }
-    
+
     int matches = 0;
-    for (int i = 0; i < tokenCount; i++) {
-        if (strstr(trackLower, tokens[i]) != NULL) {
+    for (int w = 0; w < wordCount; w++) {
+        if (strstr(trackLower, words[w]) != NULL) {
             matches++;
         }
     }
-    
+
     return matches;
 }
 
-bool ACRegisterUnregisterToMarkerRegionUpdates()
-{
-    if (g_bACMEnabled || g_bACREnabled)
-        for (int i = 0; i < g_pACItems.GetSize(); i++)
-            if (SWS_RuleItem* rule = (SWS_RuleItem*)g_pACItems.Get(i))
-                if ((g_bACMEnabled && rule->m_type == AC_MARKER) || (g_bACREnabled && rule->m_type == AC_REGION)) {
-                    RegisterToMarkerRegionUpdates(&g_mkrRgnListener);
-                    return true;
-                }
-    UnregisterToMarkerRegionUpdates(&g_mkrRgnListener);
-    return false;
-}
-
-// Prototypes
-void AutoColorSaveState();
-
-SWS_AutoColorView::SWS_AutoColorView(HWND hwndList, HWND hwndEdit)
-:SWS_ListView(hwndList, hwndEdit, COL_COUNT, g_cols, "AutoColorViewState", false, "sws_DLG_115")
-{
-}
-
-void SWS_AutoColorView::GetItemText(SWS_ListItem* item, int iCol, char* str, int iStrMax)
-{
-    if (str)
-        *str = '\0';
-
-    SWS_RuleItem* pItem = (SWS_RuleItem*)item;
-    if (!pItem)
-        return;
-
-    switch (iCol)
-    {
-    case COL_TYPE:
-        lstrcpyn(str, __localizeFunc(cTypes[pItem->m_type],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
-        break;
-    case COL_FILTER:
-        {
-            for (int i=0; i<NUM_FILTERTYPES; i++)
-                if (!strcmp(pItem->m_str_filter.Get(), cFilterTypes[i])) {
-                    lstrcpyn(str, __localizeFunc(pItem->m_str_filter.Get(),"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
-                    return;
-                }
-            lstrcpyn(str, pItem->m_str_filter.Get(), iStrMax);
-        }
-        break;
-    case COL_COLOR:
-        if (pItem->m_color<0 && (-pItem->m_color-1) < __ARRAY_SIZE(cColorTypes))
-            lstrcpyn(str, __localizeFunc(cColorTypes[-pItem->m_color-1],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
-        else
-            snprintf(str, iStrMax, "0x%06x", pItem->m_color);
-        break;
-    case COL_ICON:
-        if (pItem->m_type == AC_TRACK)
-            lstrcpyn(str, pItem->m_icon.Get(), iStrMax);
-        break;
-    case COL_TCP_LAYOUT:
-        if (pItem->m_type == AC_TRACK)
-            lstrcpyn(str, pItem->m_layout[0].Get(), iStrMax);
-        break;
-    case COL_MCP_LAYOUT:
-        if (pItem->m_type == AC_TRACK)
-            lstrcpyn(str, pItem->m_layout[1].Get(), iStrMax);
-        break;
-    }
-}
-
-void SWS_AutoColorView::SetItemText(SWS_ListItem* item, int iCol, const char* str)
-{
-    SWS_RuleItem* pItem = (SWS_RuleItem*)item;
-    if (!pItem)
-        return;
-
-    switch(iCol)
-    {
-        case COL_FILTER:
-            for (int i = 0; i < g_pACItems.GetSize(); i++)
-                if (g_pACItems.Get(i) != pItem)
-                    if (g_pACItems.Get(i)->m_type == pItem->m_type && !strcmp(g_pACItems.Get(i)->m_str_filter.Get(), str)){
-                        MessageBox(GetParent(m_hwndList), __LOCALIZE("Autocolor entry with that name already exists.","sws_DLG_115"), __LOCALIZE("SWS - Error","sws_DLG_115"), MB_OK);
-                        return;
-                    }
-            if (strlen(str))
-                pItem->m_str_filter.Set(str);
-            break;
-        case COL_COLOR:
-            pItem->m_color = strtol(str, nullptr, 0) & 0xFFFFFF;
-            break;
-        case COL_TCP_LAYOUT:
-            pItem->m_layout[0].Set(str);
-            break;
-        case COL_MCP_LAYOUT:
-            pItem->m_layout[1].Set(str);
-            break;
-    }
-    g_pACWnd->Update();
-}
-
-void SWS_AutoColorView::GetItemList(SWS_ListItemList* pList)
-{
-    for (int i = 0; i < g_pACItems.GetSize(); i++)
-        pList->Add((SWS_ListItem*)g_pACItems.Get(i));
-}
-
-void SWS_AutoColorView::OnItemDblClk(SWS_ListItem* item, int iCol)
-{
-    SWS_RuleItem* pItem = (SWS_RuleItem*)item;
-    if (pItem && iCol == COL_ICON)
-        g_pACWnd->OnCommand(LOAD_ICON_MSG, (LPARAM)pItem);
-}
-
-void SWS_AutoColorView::OnItemSelChanged(SWS_ListItem* item, int iState)
-{
-    g_pACWnd->Update(false);
-}
-
-void SWS_AutoColorView::OnBeginDrag(SWS_ListItem* item)
-{
-    if (abs(m_iSortCol) == (COL_TYPE+1))
-        SetCapture(GetParent(m_hwndList));
-}
-
-void SWS_AutoColorView::OnDrag()
-{
-    POINT p;
-    GetCursorPos(&p);
-    SWS_RuleItem* hitItem = (SWS_RuleItem*)GetHitItem(p.x, p.y, NULL);
-    if (hitItem)
-    {
-        int iNewPriority = g_pACItems.Find(hitItem);
-        int iSelPriority;
-
-        WDL_PtrList<SWS_RuleItem> draggedItems;
-        int x = 0;
-        SWS_RuleItem* selItem;
-        while((selItem = (SWS_RuleItem*)EnumSelected(&x)))
-        {
-            iSelPriority = g_pACItems.Find(selItem);
-            if (iNewPriority == iSelPriority)
-                return;
-            draggedItems.Add(selItem);
-        }
-
-        bool bDir = iNewPriority > iSelPriority;
-        if (m_iSortCol < 0)
-            bDir = !bDir;
-        for (int i = bDir ? 0 : draggedItems.GetSize()-1; bDir ? i < draggedItems.GetSize() : i >= 0; bDir ? i++ : i--)
-        {
-            int index = g_pACItems.Find(draggedItems.Get(i));
-            g_pACItems.Delete(index);
-            g_pACItems.Insert(iNewPriority, draggedItems.Get(i));
-        }
-
-        g_pACWnd->Update(false);
-
-        ++s_ignore_update;
-        for (int i=0; i < draggedItems.GetSize(); i++)
-            SelectByItem((SWS_ListItem*)draggedItems.Get(i), i==0, i==0);
-        --s_ignore_update;
-    }
-}
-
-void SWS_AutoColorView::OnEndDrag()
-{
-    g_pACWnd->Update();
-}
-
-SWS_AutoColorWnd::SWS_AutoColorWnd()
-:SWS_DockWnd(IDD_AUTOCOLOR, __LOCALIZE("Auto Color/Icon/Layout","sws_DLG_115"), "SWSAutoColor")
-#ifdef __APPLE__
-    ,m_bSettingColor(false)
-#endif
-{
-    Init();
-}
-
-void SWS_AutoColorWnd::Update(bool applyrules)
-{
-    if (s_ignore_update) return;
-
-    if (IsValidWindow())
-    {
-        SetDlgItemText(m_hwnd, IDC_APPLY, (g_bACEnabled||g_bACMEnabled||g_bACREnabled||g_bAIEnabled||g_bALEnabled) ? __LOCALIZE("Force","sws_DLG_115") : __LOCALIZE("Apply","sws_DLG_115"));
-
-#ifdef _WIN32
-        RedrawWindow(GetDlgItem(m_hwnd, IDC_COLOR), NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
-#else
-        InvalidateRect(GetDlgItem(m_hwnd, IDC_COLOR), NULL, 0);
-#endif
-
-        if (m_pLists.GetSize())
-            m_pLists.Get(0)->Update();
-    }
-
-    // Убираем автоматическое применение - только по кнопке Apply!
-    if (applyrules && false)  // Отключаем автоматическое применение
-    {
-        AutoColorSaveState();
-        AutoColorTrack(false);
-        if (ACRegisterUnregisterToMarkerRegionUpdates())
-            AutoColorMarkerRegion(false);
-    }
-}
-
-void SWS_AutoColorWnd::OnInitDlg()
-{
-    m_resize.init_item(IDC_LIST,      0.0, 0.0, 1.0, 1.0);
-    m_resize.init_item(IDC_ADD,       0.0, 1.0, 0.0, 1.0);
-    m_resize.init_item(IDC_REMOVE,    0.0, 1.0, 0.0, 1.0);
-    m_resize.init_item(IDC_COLOR,     0.0, 1.0, 0.0, 1.0);
-    m_resize.init_item(IDC_OPTIONS,   1.0, 1.0, 1.0, 1.0);
-    m_resize.init_item(IDC_APPLY,     1.0, 1.0, 1.0, 1.0);
-    m_pView = new SWS_AutoColorView(GetDlgItem(m_hwnd, IDC_LIST), GetDlgItem(m_hwnd, IDC_EDIT));
-    m_pLists.Add(m_pView);
-    Update();
-}
-
-void SWS_AutoColorWnd::GetMinSize(int* w, int* h)
-{
-    *w=350; *h=MIN_DOCKWND_HEIGHT;
-}
-
-void SWS_AutoColorWnd::OnCommand(WPARAM wParam, LPARAM lParam)
-{
-    switch (wParam)
-    {
-        case IDC_APPLY:
-            AutoColorTrack(true);
-            AutoColorMarkerRegion(true);
-            break;
-        case IDC_OPTIONS:
-        {
-            HWND hwnd = GetDlgItem(m_hwnd, IDC_OPTIONS);
-            RECT r;  GetClientRect(hwnd, &r);
-            ClientToScreen(hwnd, (LPPOINT)&r);
-            ClientToScreen(hwnd, ((LPPOINT)&r)+1);
-            SendMessage(m_hwnd, WM_CONTEXTMENU, 0, MAKELPARAM((UINT)(r.left), (UINT)(r.bottom+SNM_1PIXEL_Y)));
-            break;
-        }
-        case IDC_ADD:
-            g_pACItems.Add(new SWS_RuleItem(AC_TRACK, __LOCALIZE("(name)","sws_DLG_115"), -AC_NONE-1, "", "", ""));
-            Update();
-            break;
-        case IDC_REMOVE:
-        {
-            int x = 0;
-            SWS_RuleItem* item;
-            while((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-            {
-                int idx = g_pACItems.Find(item);
-                if (idx >= 0)
-                    g_pACItems.Delete(idx);
-            }
-            Update();
-            break;
-        }
-        case IDC_COLOR:
-        {
-            SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-            if (item)
-            {
-#ifdef _WIN32
-                CHOOSECOLOR cc;
-                memset(&cc, 0, sizeof(CHOOSECOLOR));
-                cc.lStructSize = sizeof(CHOOSECOLOR);
-                cc.hwndOwner = m_hwnd;
-                UpdateCustomColors();
-                cc.lpCustColors = g_custColors;
-                cc.Flags = CC_FULLOPEN | CC_RGBINIT;
-                cc.rgbResult = SWS_ColorToNative(item->m_color);
-                if (ChooseColor(&cc))
-                {
-                    cc.rgbResult = SWS_ColorFromNative(cc.rgbResult & 0xFFFFFF);
-                    int x = 0;
-                    while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-                        item->m_color = cc.rgbResult;
-                }
-                Update();
-#elif defined(__APPLE__)
-                m_bSettingColor = true;
-                ShowColorChooser(item->m_color);
-                SetTimer(m_hwnd, 1, 50, NULL);
-#else
-                UpdateCustomColors();
-                COLORREF cc = item->m_color;
-                if (SWELL_ChooseColor(m_hwnd,&cc,16,g_custColors))
-                {
-                    cc = SWS_ColorFromNative(cc & 0xFFFFFF);
-                    int x = 0;
-                    while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-                        item->m_color = cc;
-                }
-                Update();
-#endif
-            }
-            break;
-        }
-        case PRI_UP_MSG:
-        {
-            int x = 0;
-            SWS_RuleItem* item;
-            while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-            {
-                int iPos = g_pACItems.Find(item);
-                if (iPos <= 0)
-                    break;
-                g_pACItems.Delete(iPos, false);
-                g_pACItems.Insert(iPos-1, item);
-            }
-            Update();
-            break;
-        }
-        case PRI_DOWN_MSG:
-        {
-            for (int i = m_pLists.Get(0)->GetListItemCount()-1; i >= 0; i--)
-            {
-                if (m_pLists.Get(0)->IsSelected(i))
-                {
-                    SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->GetListItem(i);
-                    int iPos = g_pACItems.Find(item);
-                    if (iPos < 0)
-                        break;
-                    g_pACItems.Delete(iPos, false);
-                    g_pACItems.Insert(iPos+1, item);
-                }
-            }
-            Update();
-            break;
-        }
-        case LOAD_ICON_MSG:
-        {
-            SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-            if (item)
-            {
-                char filename[SNM_MAX_PATH];
-                if (BrowseResourcePath(__LOCALIZE("Load icon","sws_DLG_115"), "Data" WDL_DIRCHAR_STR "track_icons" , "PNG files (*.PNG)\0*.PNG\0ICO files (*.ICO)\0*.ICO\0JPEG files (*.JPG)\0*.JPG\0BMP files (*.BMP)\0*.BMP\0PCX files (*.PCX)\0*.PCX\0",
-                    filename, sizeof(filename)))
-                {
-                    item->m_icon.Set(filename);
-                }
-            }
-            Update();
-            break;
-        }
-        case CLEAR_ICON_MSG:
-        {
-            SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-            if (item)
-                item->m_icon.Set("");
-            Update();
-            break;
-        }
-
-        default:
-            if (wParam >= TYPETYPE_MSG && wParam < TYPETYPE_MSG + NUM_TYPETYPES)
-            {
-                SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-                if (item)
-                    item->m_type = (int)wParam-TYPETYPE_MSG;
-                Update();
-            }
-            else if (wParam >= FILTERTYPE_MSG && wParam < FILTERTYPE_MSG + NUM_FILTERTYPES)
-            {
-                SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-                if (item)
-                {
-                    int iType = (int)wParam - FILTERTYPE_MSG;
-                    for (int i = 0; i < g_pACItems.GetSize(); i++)
-                        if (g_pACItems.Get(i) != item)
-                            if (g_pACItems.Get(i)->m_type == item->m_type && !strcmp(g_pACItems.Get(i)->m_str_filter.Get(), cFilterTypes[iType])) {
-                                MessageBox(m_hwnd, __LOCALIZE("Autocolor entry of that type already exists.","sws_DLG_115"), __LOCALIZE("SWS - Error","sws_DLG_115"), MB_OK);
-                                return;
-                            }
-                    item->m_str_filter.Set(cFilterTypes[wParam-FILTERTYPE_MSG]);
-                }
-                Update();
-            }
-            else if (wParam >= COLORTYPE_MSG && wParam < COLORTYPE_MSG + NUM_COLORTYPES)
-            {
-                int x = 0;
-                SWS_RuleItem* item;
-                while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-                    item->m_color = -1 - ((int)wParam - COLORTYPE_MSG);
-                Update();
-            }
-            else if (wParam & LAYOUTTYPE_MSG)
-            {
-                const bool isMCP   = wParam & LAYOUTTYPE_MCP_FLAG;
-                const int layoutId = wParam & (LAYOUTTYPE_MSG - 1);
-                char layoutName[255];
-                if (layoutId == 0)
-                    strcpy(layoutName, cHideLayout);
-                else
-                    ThemeLayout_GetLayout(isMCP ? "mcp" : "tcp", layoutId, layoutName, sizeof(layoutName));
-
-                int x = 0;
-                SWS_RuleItem* item;
-                while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-                    item->m_layout[isMCP].Set(layoutName);
-                Update();
-            }
-            else
-                Main_OnCommand((int)wParam, (int)lParam);
-    }
-}
-
-#ifdef __APPLE__
-void SWS_AutoColorWnd::OnTimer(WPARAM wParam)
-{
-    COLORREF cr;
-    if (m_bSettingColor && GetChosenColor(&cr))
-    {
-        cr &= 0xFFFFFF;
-        int x = 0;
-        SWS_RuleItem* item;
-        while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-            item->m_color = cr;
-
-        KillTimer(m_hwnd, 1);
-        Update();
-    }
-}
-
-void SWS_AutoColorWnd::OnDestroy()
-{
-    if (m_bSettingColor)
-    {
-        HideColorChooser();
-        KillTimer(m_hwnd, 1);
-    }
-}
-#endif
-
-INT_PTR SWS_AutoColorWnd::OnUnhandledMsg(UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-    if (uMsg == WM_DRAWITEM)
-    {
-        LPDRAWITEMSTRUCT pDI = (LPDRAWITEMSTRUCT)lParam;
-        if (pDI->CtlID == IDC_COLOR)
-        {
-            int col = -1;
-            int x = 0;
-            SWS_RuleItem* item;
-            while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-            {
-                if (col < 0)
-                    col = SWS_ColorToNative(item->m_color);
-                else if (col != item->m_color)
-                {
-                    col = -1;
-                    break;
-                }
-            }
-
-            if (col < 0)
-                col = GetSysColor(COLOR_3DHILIGHT);
-
-            HBRUSH hb = CreateSolidBrush(col);
-            FillRect(pDI->hDC, &pDI->rcItem, hb);
-            DeleteObject(hb);
-            return 1;
-        }
-    }
-    return 0;
-}
-
-void SWS_AutoColorWnd::AddOptionsMenu(HMENU _menu)
-{
-    if (GetMenuItemCount(_menu))
-        AddToMenu(_menu, SWS_SEPARATOR, 0);
-    AddToMenu(_menu, __LOCALIZE("Enable auto track coloring", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_ENABLE"), -1, false, g_bACEnabled ?  MF_CHECKED : MF_UNCHECKED);
-    AddToMenu(_menu, __LOCALIZE("Enable auto marker coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_MKR_ENABLE"), -1, false, g_bACMEnabled ?  MF_CHECKED : MF_UNCHECKED);
-    AddToMenu(_menu, __LOCALIZE("Enable auto region coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_RGN_ENABLE"), -1, false, g_bACREnabled ?  MF_CHECKED : MF_UNCHECKED);
-    AddToMenu(_menu, __LOCALIZE("Enable auto track icon", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOICON_ENABLE"), -1, false, g_bAIEnabled ?  MF_CHECKED : MF_UNCHECKED);
-    AddToMenu(_menu, __LOCALIZE("Enable auto track layout", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOLAYOUT_ENABLE"), -1, false, g_bALEnabled ?  MF_CHECKED : MF_UNCHECKED);
-}
-
-HMENU SWS_AutoColorWnd::OnContextMenu(int x, int y, bool* wantDefaultItems)
-{
-    HMENU hMenu = CreatePopupMenu();
-
-    {
-        POINT pt = {x, y + 3*(SNM_1PIXEL_Y*(-1))};
-        RECT r; GetWindowRect(GetDlgItem(m_hwnd, IDC_OPTIONS), &r);
-        if (PtInRect(&r, pt))
-        {
-            *wantDefaultItems = false;
-            AddOptionsMenu(hMenu);
-            return hMenu;
-        }
-    }
-
-    int iCol;
-    if (SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->GetHitItem(x, y, &iCol))
-    {
-        *wantDefaultItems = false;
-
-        switch (iCol)
-        {
-            case COL_TYPE:
-            {
-                for (int i = 0; i < NUM_TYPETYPES; i++)
-                    AddToMenu(hMenu, __localizeFunc(cTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), TYPETYPE_MSG + i);
-                AddToMenu(hMenu, SWS_SEPARATOR, 0);
-                break;
-            }
-            case COL_FILTER:
-            {
-                int numFilters = 0;
-                if (item->m_type == AC_TRACK)
-                    numFilters= NUM_FILTERTYPES;
-                else if (item->m_type == AC_MARKER || item->m_type == AC_REGION)
-                    numFilters = NUM_RGNFILTERTYPES;
-                if (numFilters)
-                {
-                    for (int i=0; i<numFilters; i++)
-                        AddToMenu(hMenu, __localizeFunc(cFilterTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), FILTERTYPE_MSG + i);
-                    AddToMenu(hMenu, SWS_SEPARATOR, 0);
-                }
-                break;
-            }
-            case COL_COLOR:
-            {
-                AddToMenu(hMenu, __LOCALIZE("Set color...","sws_DLG_115"), IDC_COLOR);
-                AddToMenu(hMenu, SWS_SEPARATOR, 0);
-
-                if (item->m_type == AC_TRACK)
-                {
-                    for (int i = 0; i < NUM_COLORTYPES; i++)
-                        AddToMenu(hMenu, __localizeFunc(cColorTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), COLORTYPE_MSG + i);
-                }
-                else if (item->m_type == AC_MARKER || item->m_type == AC_REGION)
-                    AddToMenu(hMenu, __localizeFunc(cColorTypes[AC_NONE],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), COLORTYPE_MSG + AC_NONE);
-                AddToMenu(hMenu, SWS_SEPARATOR, 0);
-                break;
-            }
-            case COL_ICON:
-            {
-                AddToMenu(hMenu, __LOCALIZE("Load icon...","sws_DLG_115"), LOAD_ICON_MSG, -1, false, item->m_type == AC_TRACK ? MF_ENABLED : MF_GRAYED);
-                AddToMenu(hMenu, __LOCALIZE("Clear icon","sws_DLG_115"), CLEAR_ICON_MSG, -1, false, item->m_type == AC_TRACK ? MF_ENABLED : MF_GRAYED);
-                AddToMenu(hMenu, SWS_SEPARATOR, 0);
-                break;
-            }
-            case COL_TCP_LAYOUT:
-            case COL_MCP_LAYOUT:
-                AddToMenu(hMenu, __LOCALIZE("(Double-click to edit layout name)", "sws_DLG_115"), 0, -1, false, MF_GRAYED);
-                const char *section = "tcp";
-                int command = LAYOUTTYPE_MSG;
-                if (iCol == COL_MCP_LAYOUT)
-                {
-                    command |= LAYOUTTYPE_MCP_FLAG;
-                    section = "mcp";
-                }
-                AddToMenu(hMenu, __localizeFunc(cHideLayout, "sws_DLG_115", 0), command);
-                char layout[255];
-                for (int i = 1; i < LAYOUTTYPE_MSG && ThemeLayout_GetLayout(section, i, layout, sizeof(layout)); ++i)
-                {
-                    if (!layout[0])
-                        snprintf(layout, sizeof(layout), "Layout %d", i);
-                    AddToMenu(hMenu, layout, command | i);
-                }
-
-                AddToMenu(hMenu, SWS_SEPARATOR, 0);
-                break;
-        }
-        AddToMenu(hMenu, __LOCALIZE("Up in priority","sws_DLG_115"), PRI_UP_MSG);
-        AddToMenu(hMenu, __LOCALIZE("Down in priority","sws_DLG_115"), PRI_DOWN_MSG);
-    }
-    else
-    {
-        AddToMenu(hMenu, __LOCALIZE("Show color management window","sws_DLG_115"), SWSGetCommandID(ShowColorDialog));
-        AddToMenu(hMenu, SWS_SEPARATOR, 0);
-
-        HMENU hOptionsSubMenu = CreatePopupMenu();
-        AddSubMenu(hMenu, hOptionsSubMenu, __LOCALIZE("Options", "sws_menu"));
-        AddOptionsMenu(hOptionsSubMenu);
-    }
-    return hMenu;
-}
-
-int SWS_AutoColorWnd::OnKey(MSG* msg, int iKeyState)
-{
-    if (msg->message == WM_KEYDOWN && msg->wParam == VK_DELETE && !iKeyState)
-    {
-        OnCommand(IDC_REMOVE, 0);
-        return 1;
-    }
-    return 0;
-}
-
-void OpenAutoColor(COMMAND_T*)
-{
-    g_pACWnd->Show(true, true);
-}
-
-void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, bool bDoColors, bool bDoIcons, bool bDoLayout, bool bForce)
-{
-    if (!bDoColors && !bDoIcons && !bDoLayout)
-        return;
-
-    // Собираем все правила для треков
-    WDL_PtrList<SWS_RuleItem> trackRules;
-    for (int i = 0; i < g_pACItems.GetSize(); i++) {
-        SWS_RuleItem* rule = g_pACItems.Get(i);
-        if (rule->m_type == AC_TRACK) {
-            trackRules.Add(rule);
-        }
-    }
-
-    if (trackRules.GetSize() == 0) {
-        return;
-    }
-
-    int iCount = 0;
-    WDL_PtrList<MediaTrack> gradientTracks;
-
-    if (trackRules.Get(0)->m_color == -AC_CUSTOM-1)
-        UpdateCustomColors();
-
-    MediaTrack* temp = NULL;
-    const int numTracks = GetNumTracks();
-    activeRules->reserve(numTracks);
-    
-    // Предварительно разбираем все правила на слова
-    struct ParsedRule {
-        SWS_RuleItem* rule;
-        int wordCount;
-        char words[64][64];
-        bool isSpecial;
-        bool isAny;
-        int specialIndex;
-    };
-    
-    WDL_PtrList<ParsedRule> parsedRules;
-    for (int r = 0; r < trackRules.GetSize(); r++) {
-        SWS_RuleItem* rule = trackRules.Get(r);
-        ParsedRule* pr = new ParsedRule();
-        pr->rule = rule;
-        pr->wordCount = 0;
-        pr->isSpecial = false;
-        pr->isAny = false;
-        pr->specialIndex = -1;
-        
-        // Проверяем специальные правила
-        for (int s = 0; s < NUM_FILTERTYPES; s++) {
-            if (strcmp(rule->m_str_filter.Get(), cFilterTypes[s]) == 0) {
-                pr->isSpecial = true;
-                pr->specialIndex = s;
-                if (s == AC_ANY) pr->isAny = true;
-                break;
-            }
-        }
-        
-        if (!pr->isSpecial) {
-            // Разбиваем на слова
-            char filterLower[256];
-            strncpy(filterLower, rule->m_str_filter.Get(), 255);
-            filterLower[255] = '\0';
-            for (char* p = filterLower; *p; ++p) *p = tolower(*p);
-            
-            char* token = strtok(filterLower, " ");
-            while (token && pr->wordCount < 64) {
-                if (strlen(token) > 0) {
-                    strcpy(pr->words[pr->wordCount], token);
-                    pr->wordCount++;
-                }
-                token = strtok(NULL, " ");
-            }
-        }
-        
-        parsedRules.Add(pr);
-    }
-    
-    for (int i = 0; i <= numTracks; i++) {
-        MediaTrack* tr = i ? GetTrack(nullptr, i - 1) : GetMasterTrack(nullptr);
-        
-        // Получаем имя трека один раз
-        char trackLower[256] = "";
-        if (i) {
-            char* cName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
-            if (cName && cName[0]) {
-                strncpy(trackLower, cName, 255);
-                trackLower[255] = '\0';
-                for (char* p = trackLower; *p; ++p) *p = tolower(*p);
-            }
-        }
-        
-        // Ищем лучшее совпадение
-        SWS_RuleItem* bestRule = NULL;
-        int bestMatchCount = -1;
-        double bestScore = 0;
-        
-        for (int r = 0; r < parsedRules.GetSize(); r++) {
-            ParsedRule* pr = parsedRules.Get(r);
-            SWS_RuleItem* rule = pr->rule;
-            bool bMatch = false;
-            int matchCount = 0;
-            
-            if (i) { // не мастер
-                // Проверяем специальные правила
-                if (pr->isSpecial) {
-                    switch(pr->specialIndex) {
-                        case AC_FOLDER: {
-                            int iType;
-                            GetFolderDepth(tr, &iType, &temp);
-                            if (iType == 1) bMatch = true;
-                            break;
-                        }
-                        case AC_CHILDREN: {
-                            temp = CSurf_TrackFromID(0, false);
-                            if (GetFolderDepth(tr, NULL, &temp) >= 1) bMatch = true;
-                            break;
-                        }
-                        case AC_RECEIVE: {
-                            if (GetSetTrackSendInfo(tr, -1, 0, "P_SRCTRACK", NULL)) bMatch = true;
-                            break;
-                        }
-                        case AC_UNNAMED: {
-                            if (!trackLower[0]) bMatch = true;
-                            break;
-                        }
-                        case AC_REC_ARM: {
-                            int* ra = (int*)GetSetMediaTrackInfo(tr, "I_RECARM", NULL);
-                            if (ra && *ra) bMatch = true;
-                            break;
-                        }
-                        case AC_VCA_MASTER: {
-                            int iVcaMaster = GetSetTrackGroupMembership(tr, "VOLUME_VCA_MASTER", 0, 0);
-                            int iVcaMasterHigh = GetSetTrackGroupMembershipHigh(tr, "VOLUME_VCA_MASTER", 0, 0);
-                            if (iVcaMaster || iVcaMasterHigh) bMatch = true;
-                            break;
-                        }
-                        case AC_AUDIOIN: {
-                            int input = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
-                            if (input >= 0 && !(input & 4096)) bMatch = true;
-                            break;
-                        }
-                        case AC_AUDIOOUT: {
-                            int hwouts = GetTrackNumSends(tr, 1);
-                            if (hwouts) bMatch = true;
-                            break;
-                        }
-                        case AC_INSTRUMENT: {
-                            if (TrackFX_GetInstrument(tr) >= 0) bMatch = true;
-                            break;
-                        }
-                        case AC_MIDIIN: {
-                            int input = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
-                            if (input >= 0 && (input & 4096)) bMatch = true;
-                            break;
-                        }
-                        case AC_MIDIOUT: {
-                            int midihw = *(int*)GetSetMediaTrackInfo(tr, "I_MIDIHWOUT", NULL);
-                            int mididv = midihw >> 5;
-                            if (mididv >= 0) bMatch = true;
-                            break;
-                        }
-                        case AC_ANY: {
-                            bMatch = true;
-                            break;
-                        }
-                    }
-                    
-                    if (bMatch) {
-                        matchCount = 999;
-                    }
-                }
-                else if (trackLower[0]) {
-                    // Многословное совпадение
-                    matchCount = 0;
-                    for (int w = 0; w < pr->wordCount; w++) {
-                        if (strstr(trackLower, pr->words[w]) != NULL) {
-                            matchCount++;
-                        }
-                    }
-                    bMatch = (matchCount > 0);
-                }
-            }
-            else if (pr->specialIndex == AC_MASTER) {
-                bMatch = true;
-                matchCount = 999;
-            }
-            
-            if (bMatch) {
-                double score = pr->wordCount > 0 ? (double)matchCount / pr->wordCount : 0;
-                
-                if (matchCount > bestMatchCount || 
-                    (matchCount == bestMatchCount && score > bestScore)) {
-                    bestMatchCount = matchCount;
-                    bestScore = score;
-                    bestRule = rule;
-                }
-            }
-        }
-        
-        // Применяем лучшее правило
-        if (bestRule) {
-            auto pACTrack = activeRules->find(tr);
-            if (pACTrack == activeRules->end()) {
-                pACTrack = activeRules->insert(tr).first;
-            }
-            
-            bool bColor = bDoColors && !pACTrack->m_bColored && bestRule->m_color != -AC_IGNORE-1;
-            bool bIcon = bDoIcons && !pACTrack->m_bIconed && bestRule->m_icon.Get()[0];
-            bool bLayout[2] = {
-                bDoLayout && !pACTrack->m_bLayouted[0] && bestRule->m_layout[0].Get()[0],
-                bDoLayout && !pACTrack->m_bLayouted[1] && bestRule->m_layout[1].Get()[0]
-            };
-            
-            if (bColor || bIcon || bLayout[0] || bLayout[1]) {
-                // Применяем правило
-                if (bColor) {
-                    int iCurColor = *(int*)GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", NULL);
-                    if (!(iCurColor & 0x1000000)) iCurColor = 0;
-                    int newCol = iCurColor;
-
-                    if (bestRule->m_color == -AC_RANDOM-1) {
-                        if (!(iCurColor & 0x1000000))
-                            newCol = RGB(rand() % 256, rand() % 256, rand() % 256) | 0x1000000;
-                    }
-                    else if (bestRule->m_color == -AC_CUSTOM-1) {
-                        if (!AllBlack())
-                            while(!(newCol = g_custColors[iCount++ % 16]));
-                        newCol |= 0x1000000;
-                    }
-                    else if (bestRule->m_color == -AC_GRADIENT-1)
-                        gradientTracks.Add(tr);
-                    else if (bestRule->m_color == -AC_NONE-1)
-                        newCol = 0;
-                    else if (bestRule->m_color == -AC_PARENT-1) {
-                        MediaTrack* parent = (MediaTrack*)GetSetMediaTrackInfo(tr, "P_PARTRACK", NULL);
-                        if (parent) {
-                            int pcol = *(int*)GetSetMediaTrackInfo(parent, "I_CUSTOMCOLOR", NULL);
-                            if (pcol & 0x1000000)
-                                newCol = pcol;
-                        }
-                    }
-                    else
-                        newCol = SWS_ColorToNative(bestRule->m_color | 0x1000000);
-
-                    if ((bForce || iCurColor == SWS_ColorToNative(pACTrack->m_col)) && newCol != iCurColor) {
-                        GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", &newCol);
-                    }
-                    pACTrack->m_col = SWS_ColorFromNative(newCol);
-                    pACTrack->m_bColored = true;
-                }
-
-                if (bIcon) {
-                    if (_stricmp(bestRule->m_icon.Get(), pACTrack->m_icon.Get())) {
-                        const char *cur = (const char*)GetSetMediaTrackInfo(tr, "P_ICON", NULL);
-                        cur = GetShortResourcePath("Data" WDL_DIRCHAR_STR "track_icons", cur);
-                        if (cur && _stricmp(cur, bestRule->m_icon.Get())) {
-                            if (bForce || !_stricmp(cur, pACTrack->m_icon.Get())) {
-                                GetSetMediaTrackInfo(tr, "P_ICON", (void*)bestRule->m_icon.Get());
-                            }
-                        }
-                        pACTrack->m_icon.Set(bestRule->m_icon.Get());
-                    }
-                    pACTrack->m_bIconed = true;
-                }
-
-                for (int k=0; k<2; k++) if (bLayout[k]) {
-                    pACTrack->m_bLayouted[k] = true;
-                    if (!_stricmp(bestRule->m_layout[k].Get(), pACTrack->m_layout[k].Get()))
-                        continue;
-
-                    if (_stricmp(bestRule->m_layout[k].Get(), cHideLayout)) {
-                        const bool needUnhide = !_stricmp(pACTrack->m_layout[k].Get(), cHideLayout) && !IsTrackVisible(tr, k ? true : false);
-                        const char *curlayout = (const char*)GetSetMediaTrackInfo(tr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", NULL);
-                        if (curlayout && _stricmp(curlayout, bestRule->m_layout[k].Get())) {
-                            if (bForce || needUnhide || !_stricmp(curlayout, pACTrack->m_layout[k].Get()))
-                                GetSetMediaTrackInfo(tr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", (void*)bestRule->m_layout[k].Get());
-                        }
-                        if (needUnhide) {
-                            GetSetMediaTrackInfo(tr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i1);
-                            TrackList_AdjustWindows(k ? false : true);
-                        }
-                    }
-                    else if (IsTrackVisible(tr, k ? true : false)) {
-                        if (bForce || IsTrackVisible(pACTrack->m_pTr, k ? true : false)) {
-                            GetSetMediaTrackInfo(tr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i0);
-                            TrackList_AdjustWindows(k ? false : true);
-                        }
-                    }
-                    pACTrack->m_layout[k].Set(bestRule->m_layout[k].Get());
-                }
-            }
-        }
-    }
-    
-    // Очищаем временные данные
-    for (int r = 0; r < parsedRules.GetSize(); r++) {
-        delete parsedRules.Get(r);
-    }
-    parsedRules.Empty();
-
-    // Handle gradients
-    for (int i = 0; i < gradientTracks.GetSize(); i++) {
-        int newCol = g_crGradStart | 0x1000000;
-        if (i && gradientTracks.GetSize() > 1)
-            newCol = CalcGradient(g_crGradStart, g_crGradEnd, (double)i / (gradientTracks.GetSize()-1)) | 0x1000000;
-        auto match = activeRules->find(gradientTracks.Get(i));
-        if (match != activeRules->end())
-            match->m_col = newCol;
-        SetMediaTrackInfo_Value(gradientTracks.Get(i), "I_CUSTOMCOLOR", SWS_ColorToNative(newCol));
-    }
-}
-
-void AutoColorTrack(bool bForce)
-{
-    // Защита от рекурсии
-    if (g_bApplyingRules) return;
-    
-    // Если не форсируем, проверяем нужно ли обновлять
-    if (!bForce) {
-        // Проверяем изменилось ли количество треков
-        int currentTrackCount = GetNumTracks();
-        if (currentTrackCount == g_iLastTrackCount && !g_bACEnabled && !g_bAIEnabled && !g_bALEnabled) {
-            return;
-        }
-        g_iLastTrackCount = currentTrackCount;
-    }
-    
-    g_bApplyingRules = true;
-
-    auto *activeRules = g_pACTracks.Get();
-
-    if (bForce)
-        activeRules->clear();
-
-    // Clear the applied bits and cleanup entries belonging to deleted tracks
-    for (auto it = activeRules->begin(); it != activeRules->end();) {
-        if (!ValidatePtr(it->m_pTr, "MediaTrack*")) {
-            it = activeRules->erase(it);
-            continue;
-        }
-        it->m_bColored = false;
-        it->m_bIconed  = false;
-        it->m_bLayouted[0] = false;
-        it->m_bLayouted[1] = false;
-        ++it;
-    }
-
-    bool bDoColors  = g_bACEnabled || bForce;
-    bool bDoIcons   = g_bAIEnabled || bForce;
-    bool bDoLayouts = g_bALEnabled || bForce;
-
-    // Проверяем, нужно ли вообще что-то делать
-    bool hasRules = false;
-    for (int i = 0; i < g_pACItems.GetSize(); i++) {
-        if (g_pACItems.Get(i)->m_type == AC_TRACK) {
-            hasRules = true;
-            break;
-        }
-    }
-    
-    if (hasRules && (bDoColors || bDoIcons || bDoLayouts)) {
-        ApplyColorRuleToTrack(activeRules, bDoColors, bDoIcons, bDoLayouts, bForce);
-    }
-
-    // Remove colors/icons if necessary
-    for (auto pACTrack = activeRules->begin(); pACTrack != activeRules->end(); ++pACTrack)
-    {
-        if (bDoColors && !pACTrack->m_bColored && pACTrack->m_col)
-        {
-            int iCurColor = *(int*)GetSetMediaTrackInfo(pACTrack->m_pTr, "I_CUSTOMCOLOR", NULL);
-            if (!(iCurColor & 0x1000000))
-                iCurColor = 0;
-
-            if (SWS_ColorToNative(pACTrack->m_col) == iCurColor)
-            {
-                GetSetMediaTrackInfo(pACTrack->m_pTr, "I_CUSTOMCOLOR", &g_i0);
-            }
-            pACTrack->m_col = 0;
-        }
-
-        if (bDoIcons && !pACTrack->m_bIconed && pACTrack->m_icon.GetLength())
-        {
-            const char *cur = (const char*)GetSetMediaTrackInfo(pACTrack->m_pTr, "P_ICON", NULL);
-            cur = GetShortResourcePath("Data" WDL_DIRCHAR_STR "track_icons", cur);
-            if (cur && !_stricmp(pACTrack->m_icon.Get(), cur))
-            {
-                GetSetMediaTrackInfo(pACTrack->m_pTr, "P_ICON", (void*)"");
-            }
-            pACTrack->m_icon.Set("");
-        }
-
-        if (bDoLayouts) for (int k=0; k<2; k++) if (!pACTrack->m_bLayouted[k] && pACTrack->m_layout[k].GetLength())
-        {
-            if (_stricmp(pACTrack->m_layout[k].Get(), cHideLayout))
-            {
-                const char *curlayout = (const char*)GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", NULL);
-                if (curlayout && !_stricmp(pACTrack->m_layout[k].Get(), curlayout))
-                    GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", (void*)"");
-            }
-            else if (!IsTrackVisible(pACTrack->m_pTr, k ? true : false))
-            {
-                GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i1);
-                TrackList_AdjustWindows(k ? false : true);
-            }
-            pACTrack->m_layout[k].Set("");
-        }
-    }
-
-    if (bForce)
-        Undo_OnStateChangeEx(__LOCALIZE("Apply auto color/icon/layout","sws_undo"), UNDO_STATE_TRACKCFG | UNDO_STATE_MISCCFG, -1);
-    
-    UpdateArrange();
-    g_bApplyingRules = false;
-}
-
-void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
-{
-    ColorTheme* ct = SNM_GetColorTheme();
-    if (!_rule || !_flags || !ct)
-        return;
-
-    double pos, end;
-    int x=0, num, color;
-    bool isRgn;
-    const char* name;
-
-    PreventUIRefresh(1);
-    if(_rule->m_type & _flags)
-    {
-        while ((x = EnumProjectMarkers3(NULL, x, &isRgn, &pos, &end, &name, &num, &color)))
-        {
-            bool bMatch = false;
-            
-            if (!strcmp(cFilterTypes[AC_RGNANY], _rule->m_str_filter.Get()))
-                bMatch = true;
-            else if (!strcmp(cFilterTypes[AC_RGNUNNAMED], _rule->m_str_filter.Get()) && (!name || !*name))
-                bMatch = true;
-            else if (name && name[0])
-            {
-                // Многословное совпадение для маркеров и регионов
-                int matchCount = CountMatchingWords(name, _rule->m_str_filter.Get());
-                bMatch = (matchCount > 0);
-            }
-            
-            if (bMatch && ((_flags&AC_REGION && isRgn && _rule->m_type==AC_REGION) ||
-                           (_flags&AC_MARKER && !isRgn && _rule->m_type==AC_MARKER)))
-            {
-                SetProjectMarkerByIndex(NULL, x-1, isRgn, pos, end, num, NULL, _rule->m_color==-AC_NONE-1 ? (isRgn?ct->marker:ct->region) : SWS_ColorToNative(_rule->m_color | 0x1000000));
-            }
-        }
-    }
-    PreventUIRefresh(-1);
-}
-
-void AutoColorMarkerRegion(bool _force, int _flags)
-{
-    static bool bRecurse = false;
-    if (bRecurse || (!g_bACREnabled && !g_bACMEnabled && !_force))
-        return;
-    bRecurse = true;
-
-    int newFlags = 0;
-    if (_flags&AC_MARKER && (g_bACMEnabled || _force))
-        newFlags |= AC_MARKER;
-    if (_flags&AC_REGION && (g_bACREnabled || _force))
-        newFlags |= AC_REGION;
-
-    if (newFlags)
-    {
-        PreventUIRefresh(1);
-
-        for (int i=g_pACItems.GetSize()-1; i>=0; i--)
-            ApplyColorRuleToMarkerRegion(g_pACItems.Get(i), newFlags);
-
-        PreventUIRefresh(-1);
-    }
-
-    if (_force)
-        Undo_OnStateChangeEx(__LOCALIZE("Apply auto marker/region color","sws_undo"), UNDO_STATE_MISCCFG, -1);
-    bRecurse = false;
-}
-
-void EnableAutoColor(COMMAND_T* ct)
-{
-    switch((int)ct->user)
-    {
-        case 0: g_bACEnabled = !g_bACEnabled; break;
-        case 1: g_bACMEnabled = !g_bACMEnabled; break;
-        case 2: g_bACREnabled = !g_bACREnabled; break;
-    }
-    g_pACWnd->Update();
-}
-
-void EnableAutoIcon(COMMAND_T*)
-{
-    g_bAIEnabled = !g_bAIEnabled;
-    g_pACWnd->Update();
-}
-
-void EnableAutoLayout(COMMAND_T*)
-{
-    g_bALEnabled = !g_bALEnabled;
-    g_pACWnd->Update();
-}
-
-void ApplyAutoColor(COMMAND_T*)
-{
-    AutoColorTrack(true);
-    AutoColorMarkerRegion(true);
-}
-
-int IsAutoColorOpen(COMMAND_T*)        { return g_pACWnd->IsWndVisible(); }
-int IsAutoIconEnabled(COMMAND_T*)    { return g_bAIEnabled; }
-int IsAutoLayoutEnabled(COMMAND_T*)    { return g_bALEnabled; }
-
-int IsAutoColorEnabled(COMMAND_T* ct)
-{
-    switch((int)ct->user) {
-        case 0: return g_bACEnabled;
-        case 1: return g_bACMEnabled;
-        case 2: return g_bACREnabled;
-    }
-    return false;
- }
-
-static bool ProcessExtensionLine(const char *line, ProjectStateContext *ctx, bool isUndo, struct project_config_extension_t *reg)
-{
-    LineParser lp(false);
-    if (lp.parse(line) || lp.getnumtokens() < 1)
-        return false;
-    if (strcmp(lp.gettoken_str(0), "<SWSAUTOCOLOR") == 0)
-    {
-        char linebuf[4096];
-        while(true)
-        {
-            if (!ctx->GetLine(linebuf,sizeof(linebuf)) && !lp.parse(linebuf))
-            {
-                if (lp.gettoken_str(0)[0] == '>')
-                    break;
-
-                GUID g;
-                stringToGuid(lp.gettoken_str(0), &g);
-                MediaTrack* tr = GuidToTrack(&g);
-                if (tr && tr != GetMasterTrack(nullptr))
-                {
-                    auto rt = g_pACTracks.Get()->insert(tr).first;
-                    rt->m_col = ImportColor(lp.gettoken_int(1));
-                    rt->m_icon.Set(lp.gettoken_str(2));
-                    rt->m_layout[0].Set(lp.gettoken_str(3));
-                    rt->m_layout[1].Set(lp.gettoken_str(4));
-                }
-            }
-            else
-                break;
-        }
-        return true;
-    }
-    return false;
-}
-
-static void SaveExtensionConfig(ProjectStateContext *ctx, bool isUndo, struct project_config_extension_t *reg)
-{
-    auto *activeRules = g_pACTracks.Get();
-    activeRules->erase_if([](const SWS_RuleTrack &rt) { return !ValidatePtr(rt.m_pTr, "MediaTrack*"); });
-    if (activeRules->empty())
-        return;
-
-    std::vector<const SWS_RuleTrack *> sortedRules;
-    sortedRules.reserve(activeRules->size());
-    std::transform(activeRules->begin(), activeRules->end(),
-        std::back_inserter(sortedRules), [](const SWS_RuleTrack &rt) { return &rt; });
-    std::sort(sortedRules.begin(), sortedRules.end(), [](const SWS_RuleTrack *a, const SWS_RuleTrack *b) {
-        return GetMediaTrackInfo_Value(a->m_pTr, "IP_TRACKNUMBER") < GetMediaTrackInfo_Value(b->m_pTr, "IP_TRACKNUMBER");
-    });
-
-    ctx->AddLine("<SWSAUTOCOLOR");
-    for (const SWS_RuleTrack *rt : sortedRules)
-    {
-        char str[256];
-        GUID g = GUID_NULL;
-        if (CSurf_TrackToID(rt->m_pTr, false))
-            g = *(GUID*)GetSetMediaTrackInfo(rt->m_pTr, "GUID", NULL);
-        guidToString(&g, str);
-        ctx->AddLine("%s %d \"%s\" \"%s\" \"%s\"", str, ExportColor(rt->m_col), rt->m_icon.Get(), rt->m_layout[0].Get(), rt->m_layout[1].Get());
-
-        ++rt;
-    }
-    ctx->AddLine(">");
-}
-
-static void BeginLoadProjectState(bool isUndo, struct project_config_extension_t *reg)
-{
-    g_pACTracks.Cleanup();
-    g_pACTracks.Get()->clear();
-}
-
-static project_config_extension_t g_projectconfig = { ProcessExtensionLine, SaveExtensionConfig, BeginLoadProjectState, NULL };
-
-//!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
-static COMMAND_T g_commandTable[] =
-{
-    { { DEFACCEL, "SWS: Open auto color/icon/layout window" },                "SWSAUTOCOLOR_OPEN",        OpenAutoColor,        "SWS Auto color/icon/layout",            0, IsAutoColorOpen },
-    { { DEFACCEL, "SWS: Toggle auto track coloring enable" },        "SWSAUTOCOLOR_ENABLE",        EnableAutoColor,    "Enable auto track coloring",    0, IsAutoColorEnabled },
-    { { DEFACCEL, "SWS/S&M: Toggle auto marker coloring enable" },    "S&MAUTOCOLOR_MKR_ENABLE",    EnableAutoColor,    "Enable auto marker coloring",    1, IsAutoColorEnabled },
-    { { DEFACCEL, "SWS/S&M: Toggle auto region coloring enable" },    "S&MAUTOCOLOR_RGN_ENABLE",    EnableAutoColor,    "Enable auto region coloring",    2, IsAutoColorEnabled },
-    { { DEFACCEL, "SWS/S&M: Toggle auto track icon enable" },        "S&MAUTOICON_ENABLE",        EnableAutoIcon,        "Enable auto icon",                0, IsAutoIconEnabled },
-    { { DEFACCEL, "SWS/S&M: Toggle auto track layout enable" },        "S&MAUTOLAYOUT_ENABLE",        EnableAutoLayout,        "Enable auto layout",                0, IsAutoLayoutEnabled },
-    { { DEFACCEL, "SWS: Apply auto coloring" },                        "SWSAUTOCOLOR_APPLY",        ApplyAutoColor,    },
-    { {}, LAST_COMMAND, },
-};
-//!WANT_LOCALIZE_1ST_STRING_END
+// ============================================================================
+// End of helper functions
+// ============================================================================
 
 int AutoColorInit()
 {
-    if (!plugin_register("projectconfig",&g_projectconfig))
-        return 0;
+	if (!plugin_register("projectconfig",&g_projectconfig))
+		return 0;
 
-    SWSRegisterCommands(g_commandTable);
+	SWSRegisterCommands(g_commandTable);
 
-    g_ACIni.SetFormatted(MAX_PATH, "%s%csws-autocoloricon.ini", GetResourcePath(), PATH_SLASH_CHAR);
+	g_ACIni.SetFormatted(MAX_PATH, "%s%csws-autocoloricon.ini", GetResourcePath(), PATH_SLASH_CHAR);
 
-    WDL_String ini(g_ACIni);
-    bool bUpgrade = false;
-    int iCount = GetPrivateProfileInt(SWS_INI, AC_COUNT_KEY, 0, get_ini_file());
-    if (iCount)
-    {
-        bUpgrade = true;
-        ini.Set(get_ini_file());
-    }
-    else
-        iCount = GetPrivateProfileInt(SWS_INI, AC_COUNT_KEY, 0, ini.Get());
+	// "Upgrade" to the new ini file for just the auto color stuff if necessary
+	WDL_String ini(g_ACIni);
+	bool bUpgrade = false;
+	int iCount = GetPrivateProfileInt(SWS_INI, AC_COUNT_KEY, 0, get_ini_file());
+	if (iCount)
+	{
+		bUpgrade = true;
+		ini.Set(get_ini_file());
+	}
+	else
+		iCount = GetPrivateProfileInt(SWS_INI, AC_COUNT_KEY, 0, ini.Get());
 
-    char str[BUFFER_SIZE];
-    g_bACEnabled = GetPrivateProfileInt(SWS_INI, AC_ENABLE_KEY, 0, ini.Get()) ? true : false;
-    g_bACMEnabled = GetPrivateProfileInt(SWS_INI, ACM_ENABLE_KEY, 0, ini.Get()) ? true : false;
-    g_bACREnabled = GetPrivateProfileInt(SWS_INI, ACR_ENABLE_KEY, 0, ini.Get()) ? true : false;
-    g_bAIEnabled = GetPrivateProfileInt(SWS_INI, AI_ENABLE_KEY, 0, ini.Get()) ? true : false;
-    g_bALEnabled = GetPrivateProfileInt(SWS_INI, AL_ENABLE_KEY, 0, ini.Get()) ? true : false;
+	// Restore state
+	char str[BUFFER_SIZE];
+	g_bACEnabled = GetPrivateProfileInt(SWS_INI, AC_ENABLE_KEY, 0, ini.Get()) ? true : false;
+	g_bACMEnabled = GetPrivateProfileInt(SWS_INI, ACM_ENABLE_KEY, 0, ini.Get()) ? true : false;
+	g_bACREnabled = GetPrivateProfileInt(SWS_INI, ACR_ENABLE_KEY, 0, ini.Get()) ? true : false;
+	g_bAIEnabled = GetPrivateProfileInt(SWS_INI, AI_ENABLE_KEY, 0, ini.Get()) ? true : false;
+	g_bALEnabled = GetPrivateProfileInt(SWS_INI, AL_ENABLE_KEY, 0, ini.Get()) ? true : false;
 
-    char key[32];
-    for (int i = 0; i < iCount; i++)
-    {
-        snprintf(key, 32, AC_ITEM_KEY, i+1);
-        GetPrivateProfileString(SWS_INI, key, "", str, BUFFER_SIZE, ini.Get());
-        if (bUpgrade)
-            WritePrivateProfileString(SWS_INI, key, NULL, get_ini_file());
-        LineParser lp(false);
-        if (!lp.parse(str) && lp.getnumtokens() >= 4)
-            g_pACItems.Add(new SWS_RuleItem(lp.gettoken_int(0), lp.gettoken_str(1), ImportColor(lp.gettoken_int(2)), lp.gettoken_str(3), lp.gettoken_str(4), lp.gettoken_str(5)));
-        else if(!lp.parse(str) && lp.getnumtokens() == 3)
-            g_pACItems.Add(new SWS_RuleItem(AC_TRACK, lp.gettoken_str(0), lp.gettoken_int(1), lp.gettoken_str(2), "", ""));
-    }
+	char key[32];
+	for (int i = 0; i < iCount; i++)
+	{
+		snprintf(key, 32, AC_ITEM_KEY, i+1);
+		GetPrivateProfileString(SWS_INI, key, "", str, BUFFER_SIZE, ini.Get()); // Read in AutoColor line (stored in str)
+		if (bUpgrade) // Remove old lines
+			WritePrivateProfileString(SWS_INI, key, NULL, get_ini_file());
+		LineParser lp(false);
+		if (!lp.parse(str) && lp.getnumtokens() >= 4)
+			g_pACItems.Add(new SWS_RuleItem(lp.gettoken_int(0), lp.gettoken_str(1), ImportColor(lp.gettoken_int(2)), lp.gettoken_str(3), lp.gettoken_str(4), lp.gettoken_str(5)));
+		else if(!lp.parse(str) && lp.getnumtokens() == 3) //Reformat old format Autocolor line to new format (i.e. region + marker)
+			g_pACItems.Add(new SWS_RuleItem(AC_TRACK, lp.gettoken_str(0), lp.gettoken_int(1), lp.gettoken_str(2), "", ""));
+	}
 
-    if (bUpgrade)
-    {
-        WritePrivateProfileString(SWS_INI, AC_ENABLE_KEY, NULL, get_ini_file());
-        WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, NULL, get_ini_file());
-        WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, NULL, get_ini_file());
-        AutoColorSaveState();
-    }
+	if (bUpgrade)
+	{	// Remove old stuff
+		WritePrivateProfileString(SWS_INI, AC_ENABLE_KEY, NULL, get_ini_file());
+		WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, NULL, get_ini_file());
+		WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, NULL, get_ini_file());
+		AutoColorSaveState();
+	}
 
-    ACRegisterUnregisterToMarkerRegionUpdates();
+	ACRegisterUnregisterToMarkerRegionUpdates();
 
-    g_pACWnd = new SWS_AutoColorWnd();
+	g_pACWnd = new SWS_AutoColorWnd();
 
-    // Применяем правила только один раз при загрузке
-    AutoColorTrack(false);
-
-    return 1;
+	return 1;
 }
 
 void AutoColorSaveState()
 {
-    char str[BUFFER_SIZE];
-    sprintf(str, "%d", g_bACEnabled ? 1 : 0);
-    WritePrivateProfileString(SWS_INI, AC_ENABLE_KEY, str, g_ACIni.Get());
-    sprintf(str, "%d", g_bACMEnabled ? 1 : 0);
-    WritePrivateProfileString(SWS_INI, ACM_ENABLE_KEY, str, g_ACIni.Get());
-    sprintf(str, "%d", g_bACREnabled ? 1 : 0);
-    WritePrivateProfileString(SWS_INI, ACR_ENABLE_KEY, str, g_ACIni.Get());
-    sprintf(str, "%d", g_bAIEnabled ? 1 : 0);
-    WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, str, g_ACIni.Get());
-    sprintf(str, "%d", g_bALEnabled ? 1 : 0);
-    WritePrivateProfileString(SWS_INI, AL_ENABLE_KEY, str, g_ACIni.Get());
-    sprintf(str, "%d", g_pACItems.GetSize());
-    WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, str, g_ACIni.Get());
+	// Save state
+	char str[BUFFER_SIZE];
+	sprintf(str, "%d", g_bACEnabled ? 1 : 0);
+	WritePrivateProfileString(SWS_INI, AC_ENABLE_KEY, str, g_ACIni.Get());
+	sprintf(str, "%d", g_bACMEnabled ? 1 : 0);
+	WritePrivateProfileString(SWS_INI, ACM_ENABLE_KEY, str, g_ACIni.Get());
+	sprintf(str, "%d", g_bACREnabled ? 1 : 0);
+	WritePrivateProfileString(SWS_INI, ACR_ENABLE_KEY, str, g_ACIni.Get());
+	sprintf(str, "%d", g_bAIEnabled ? 1 : 0);
+	WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, str, g_ACIni.Get());
+	sprintf(str, "%d", g_bALEnabled ? 1 : 0);
+	WritePrivateProfileString(SWS_INI, AL_ENABLE_KEY, str, g_ACIni.Get());
+	sprintf(str, "%d", g_pACItems.GetSize());
+	WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, str, g_ACIni.Get());
 
-    char key[32];
-    WDL_FastString tmp[4];
-    for (int i = 0; i < g_pACItems.GetSize(); i++)
-    {
-        makeEscapedConfigString(g_pACItems.Get(i)->m_str_filter.Get(), &tmp[0]);
-        makeEscapedConfigString(g_pACItems.Get(i)->m_icon.Get(), &tmp[1]);
-        makeEscapedConfigString(g_pACItems.Get(i)->m_layout[0].Get(), &tmp[2]);
-        makeEscapedConfigString(g_pACItems.Get(i)->m_layout[1].Get(), &tmp[3]);
-        snprintf(str, BUFFER_SIZE, "%d %s %d %s %s %s", g_pACItems.Get(i)->m_type, tmp[0].Get(), ExportColor(g_pACItems.Get(i)->m_color), tmp[1].Get(), tmp[2].Get(), tmp[3].Get());
+	char key[32];
+	WDL_FastString tmp[4];
+	for (int i = 0; i < g_pACItems.GetSize(); i++)
+	{
+		makeEscapedConfigString(g_pACItems.Get(i)->m_str_filter.Get(), &tmp[0]);
+		makeEscapedConfigString(g_pACItems.Get(i)->m_icon.Get(), &tmp[1]);
+		makeEscapedConfigString(g_pACItems.Get(i)->m_layout[0].Get(), &tmp[2]);
+		makeEscapedConfigString(g_pACItems.Get(i)->m_layout[1].Get(), &tmp[3]);
+		snprintf(str, BUFFER_SIZE, "%d %s %d %s %s %s", g_pACItems.Get(i)->m_type, tmp[0].Get(), ExportColor(g_pACItems.Get(i)->m_color), tmp[1].Get(), tmp[2].Get(), tmp[3].Get());
 
-        snprintf(key, 32, AC_ITEM_KEY, i+1);
-        WritePrivateProfileString(SWS_INI, key, str, g_ACIni.Get());
-    }
-    snprintf(key, 32, AC_ITEM_KEY, g_pACItems.GetSize() + 1);
-    WritePrivateProfileString(SWS_INI, key, NULL, g_ACIni.Get());
+		snprintf(key, 32, AC_ITEM_KEY, i+1);
+		WritePrivateProfileString(SWS_INI, key, str, g_ACIni.Get());
+	}
+	// Erase the n+1 entry
+	snprintf(key, 32, AC_ITEM_KEY, g_pACItems.GetSize() + 1);
+	WritePrivateProfileString(SWS_INI, key, NULL, g_ACIni.Get());
 }
 
 void AutoColorExit()
 {
-    plugin_register("-projectconfig",&g_projectconfig);
-    UnregisterToMarkerRegionUpdates(&g_mkrRgnListener);
-    AutoColorSaveState();
-    DELETE_NULL(g_pACWnd);
+	plugin_register("-projectconfig",&g_projectconfig);
+	UnregisterToMarkerRegionUpdates(&g_mkrRgnListener);
+	AutoColorSaveState();
+	DELETE_NULL(g_pACWnd);
 }

--- a/Color/Autocolor.cpp
+++ b/Color/Autocolor.cpp
@@ -46,6 +46,7 @@
 #define ACR_ENABLE_KEY "AutoColorRegionEnable"
 #define AI_ENABLE_KEY  "AutoIconEnable"
 #define AL_ENABLE_KEY  "AutoLayoutEnable"
+#define AC_CASE_SENSITIVE_KEY "AutoColorCaseSensitive"
 #define AC_COUNT_KEY   "AutoColorCount"
 #define AC_ITEM_KEY    "AutoColor %d"
 
@@ -88,6 +89,7 @@ static bool g_bACREnabled = false;
 static bool g_bACMEnabled = false;
 static bool g_bAIEnabled = false;
 static bool g_bALEnabled = false;
+static bool g_bACCaseSensitive = false;
 static WDL_String g_ACIni;
 static int s_ignore_update;
 
@@ -596,6 +598,8 @@ void SWS_AutoColorWnd::AddOptionsMenu(HMENU _menu)
 	AddToMenu(_menu, __LOCALIZE("Enable auto region coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_RGN_ENABLE"), -1, false, g_bACREnabled ?  MF_CHECKED : MF_UNCHECKED);
 	AddToMenu(_menu, __LOCALIZE("Enable auto track icon", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOICON_ENABLE"), -1, false, g_bAIEnabled ?  MF_CHECKED : MF_UNCHECKED);
 	AddToMenu(_menu, __LOCALIZE("Enable auto track layout", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOLAYOUT_ENABLE"), -1, false, g_bALEnabled ?  MF_CHECKED : MF_UNCHECKED);
+	AddToMenu(_menu, SWS_SEPARATOR, 0);
+	AddToMenu(_menu, __LOCALIZE("Case sensitive", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_CASE_SENSITIVE"), -1, false, g_bACCaseSensitive ? MF_CHECKED : MF_UNCHECKED);
 }
 
 HMENU SWS_AutoColorWnd::OnContextMenu(int x, int y, bool* wantDefaultItems)
@@ -1247,6 +1251,12 @@ void EnableAutoLayout(COMMAND_T*)
 	g_pACWnd->Update();
 }
 
+void ToggleAutoColorCaseSensitive(COMMAND_T*)
+{
+	g_bACCaseSensitive = !g_bACCaseSensitive;
+	g_pACWnd->Update();
+}
+
 void ApplyAutoColor(COMMAND_T*)
 {
 	AutoColorTrack(true);
@@ -1256,6 +1266,7 @@ void ApplyAutoColor(COMMAND_T*)
 int IsAutoColorOpen(COMMAND_T*)		{ return g_pACWnd->IsWndVisible(); }
 int IsAutoIconEnabled(COMMAND_T*)	{ return g_bAIEnabled; }
 int IsAutoLayoutEnabled(COMMAND_T*)	{ return g_bALEnabled; }
+int IsAutoColorCaseSensitive(COMMAND_T*) { return g_bACCaseSensitive; }
 
 int IsAutoColorEnabled(COMMAND_T* ct)
 {
@@ -1352,6 +1363,7 @@ static COMMAND_T g_commandTable[] =
 	{ { DEFACCEL, "SWS/S&M: Toggle auto region coloring enable" },	"S&MAUTOCOLOR_RGN_ENABLE",	EnableAutoColor,	"Enable auto region coloring",	2, IsAutoColorEnabled },
 	{ { DEFACCEL, "SWS/S&M: Toggle auto track icon enable" },		"S&MAUTOICON_ENABLE",		EnableAutoIcon,		"Enable auto icon",				0, IsAutoIconEnabled },
 	{ { DEFACCEL, "SWS/S&M: Toggle auto track layout enable" },		"S&MAUTOLAYOUT_ENABLE",		EnableAutoLayout,		"Enable auto layout",				0, IsAutoLayoutEnabled },
+	{ { DEFACCEL, "SWS: Toggle case-sensitive auto color matching" }, "SWSAUTOCOLOR_CASE_SENSITIVE", ToggleAutoColorCaseSensitive, "Case sensitive", 0, IsAutoColorCaseSensitive },
 	{ { DEFACCEL, "SWS: Apply auto coloring" },						"SWSAUTOCOLOR_APPLY",		ApplyAutoColor,	},
 	{ {}, LAST_COMMAND, }, // Denote end of table
 };
@@ -1388,8 +1400,10 @@ static int CountMatchingWords(const char* trackName, const char* ruleFilter)
     trackLower[255] = '\0';
     ruleLower[255] = '\0';
 
-    for (char* p = trackLower; *p; ++p) *p = tolower(*p);
-    for (char* p = ruleLower; *p; ++p) *p = tolower(*p);
+    if (!g_bACCaseSensitive) {
+        for (char* p = trackLower; *p; ++p) *p = tolower(static_cast<unsigned char>(*p));
+        for (char* p = ruleLower; *p; ++p) *p = tolower(static_cast<unsigned char>(*p));
+    }
 
     char words[64][64];
     int wordCount = 0;
@@ -1450,6 +1464,7 @@ int AutoColorInit()
 	g_bACREnabled = GetPrivateProfileInt(SWS_INI, ACR_ENABLE_KEY, 0, ini.Get()) ? true : false;
 	g_bAIEnabled = GetPrivateProfileInt(SWS_INI, AI_ENABLE_KEY, 0, ini.Get()) ? true : false;
 	g_bALEnabled = GetPrivateProfileInt(SWS_INI, AL_ENABLE_KEY, 0, ini.Get()) ? true : false;
+	g_bACCaseSensitive = GetPrivateProfileInt(SWS_INI, AC_CASE_SENSITIVE_KEY, 0, ini.Get()) ? true : false;
 
 	char key[32];
 	for (int i = 0; i < iCount; i++)
@@ -1494,6 +1509,8 @@ void AutoColorSaveState()
 	WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, str, g_ACIni.Get());
 	sprintf(str, "%d", g_bALEnabled ? 1 : 0);
 	WritePrivateProfileString(SWS_INI, AL_ENABLE_KEY, str, g_ACIni.Get());
+	sprintf(str, "%d", g_bACCaseSensitive ? 1 : 0);
+	WritePrivateProfileString(SWS_INI, AC_CASE_SENSITIVE_KEY, str, g_ACIni.Get());
 	sprintf(str, "%d", g_pACItems.GetSize());
 	WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, str, g_ACIni.Get());
 

--- a/Color/Autocolor.cpp
+++ b/Color/Autocolor.cpp
@@ -38,8 +38,6 @@
 #include <WDL/localize/localize.h>
 #include <WDL/projectcontext.h>
 
-
-
 // INI params
 #define AC_ENABLE_KEY  "AutoColorEnable"
 #define ACM_ENABLE_KEY "AutoColorMarkerEnable"
@@ -49,35 +47,47 @@
 #define AC_COUNT_KEY   "AutoColorCount"
 #define AC_ITEM_KEY    "AutoColor %d"
 
-
 enum { AC_ANY=0, AC_UNNAMED, AC_FOLDER, AC_CHILDREN, AC_RECEIVE, AC_MASTER, AC_REC_ARM, AC_VCA_MASTER, AC_INSTRUMENT, AC_AUDIOIN, AC_AUDIOOUT, AC_MIDIIN, AC_MIDIOUT, NUM_FILTERTYPES };
 enum { AC_RGNANY=0, AC_RGNUNNAMED, NUM_RGNFILTERTYPES };
 enum { AC_CUSTOM, AC_GRADIENT, AC_RANDOM, AC_NONE, AC_PARENT, AC_IGNORE, NUM_COLORTYPES };
-enum { COL_ID=0, COL_TYPE, COL_FILTER, COL_COLOR, COL_ICON, COL_TCP_LAYOUT, COL_MCP_LAYOUT, COL_COUNT };
-enum { AC_TRACK=0, AC_MARKER, AC_REGION, NUM_TYPETYPES }; // keep this order and 2^ values
-                                                          // (values used as masks => adding a 4th type would require another solution)
+enum { 
+    COL_TYPE=0,
+    COL_FILTER, 
+    COL_COLOR, 
+    COL_ICON, 
+    COL_TCP_LAYOUT, 
+    COL_MCP_LAYOUT, 
+    COL_COUNT 
+};
+enum { AC_TRACK=0, AC_MARKER, AC_REGION, NUM_TYPETYPES };
 
 enum Commands : WPARAM {
-	PRI_UP_MSG = 0x10000,
-	PRI_DOWN_MSG,
-	TYPETYPE_MSG,
-	FILTERTYPE_MSG = TYPETYPE_MSG   + NUM_TYPETYPES,
-	COLORTYPE_MSG  = FILTERTYPE_MSG + NUM_FILTERTYPES,
-	LOAD_ICON_MSG  = COLORTYPE_MSG  + NUM_COLORTYPES,
-	CLEAR_ICON_MSG,
-	LAYOUTTYPE_MSG      = 1<<17, // all lower bits = layout index (0 = hide)
-	LAYOUTTYPE_MCP_FLAG = 1<<18,
+    PRI_UP_MSG = 0x10000,
+    PRI_DOWN_MSG,
+    TYPETYPE_MSG,
+    FILTERTYPE_MSG = TYPETYPE_MSG   + NUM_TYPETYPES,
+    COLORTYPE_MSG  = FILTERTYPE_MSG + NUM_FILTERTYPES,
+    LOAD_ICON_MSG  = COLORTYPE_MSG  + NUM_COLORTYPES,
+    CLEAR_ICON_MSG,
+    LAYOUTTYPE_MSG      = 1<<17,
+    LAYOUTTYPE_MCP_FLAG = 1<<18,
 };
 
 // Larger allocs for localized strings..
 // !WANT_LOCALIZE_STRINGS_BEGIN:sws_DLG_115
-static SWS_LVColumn g_cols[] = { {25, 0, "#" }, {25, 0, "Rule type"}, { 185, 1, "Filter" }, { 70, 1, "Color" }, { 200, 2, "Icon" }, { 100, 1, "TCP Layout" }, { 100, 1, "MCP Layout" }};
-static const char cTypes[][256] = {"Track", "Marker", "Region" }; // keep this order, see above
+static SWS_LVColumn g_cols[] = { 
+    {25, 0, "Rule type"}, 
+    { 185, 1, "Filter" }, 
+    { 70, 1, "Color" }, 
+    { 200, 2, "Icon" }, 
+    { 100, 1, "TCP Layout" }, 
+    { 100, 1, "MCP Layout" }
+};
+static const char cTypes[][256] = {"Track", "Marker", "Region" };
 static const char cFilterTypes[][256] = { "(any)", "(unnamed)", "(folder)", "(children)", "(receive)", "(master)", "(record armed)", "(vca master)", "(instrument)", "(audio input)", "(audio output)", "(MIDI input)", "(MIDI output)" };
 static const char cColorTypes[][256] = { "Custom", "Gradient", "Random", "None", "Parent", "Ignore" };
-static const char *cHideLayout = "(hide)"; // #1008, additional '(hide)' layout, same for TCP and MCP
+static const char *cHideLayout = "(hide)";
 // !WANT_LOCALIZE_STRINGS_END
-
 
 // Globals
 SWS_AutoColorWnd* g_pACWnd = NULL;
@@ -90,35 +100,98 @@ static bool g_bAIEnabled = false;
 static bool g_bALEnabled = false;
 static WDL_String g_ACIni;
 static int s_ignore_update;
+static bool g_bApplyingRules = false;  // Добавляем флаг
+static int g_iLastTrackCount = -1;     // Для отслеживания изменений
 
+// Структура для информации о совпадениях
+struct MatchInfo {
+    SWS_RuleItem* rule;
+    int matchCount;
+    int totalWords;
+    double matchScore;
+    
+    MatchInfo(SWS_RuleItem* r, int count, int total) 
+        : rule(r), matchCount(count), totalWords(total) {
+        matchScore = totalWords > 0 ? (double)count / totalWords : 0;
+    }
+};
 
 // Register to marker/region updates
 class AC_MarkerRegionListener : public SNM_MarkerRegionListener {
 public:
-	AC_MarkerRegionListener() : SNM_MarkerRegionListener() {}
-	void NotifyMarkerRegionUpdate(int _updateFlags) { AutoColorMarkerRegion(false, _updateFlags); }
+    AC_MarkerRegionListener() : SNM_MarkerRegionListener() {}
+    void NotifyMarkerRegionUpdate(int _updateFlags) { AutoColorMarkerRegion(false, _updateFlags); }
 };
 
 AC_MarkerRegionListener g_mkrRgnListener;
 
-// Optimized/custom version of RegisterToMarkerRegionUpdates()
-// (to avoid useless polling behind the scene)
+// Вспомогательные функции для подсчета слов
+int CountWords(const char* str) {
+    if (!str || !str[0]) return 0;
+    int count = 0;
+    bool inWord = false;
+    for (const char* p = str; *p; ++p) {
+        if (*p == ' ') {
+            inWord = false;
+        } else if (!inWord) {
+            inWord = true;
+            count++;
+        }
+    }
+    return count;
+}
+
+int CountMatchingWords(const char* trackName, const char* ruleFilter) {
+    if (!trackName || !trackName[0] || !ruleFilter || !ruleFilter[0]) return 0;
+    
+    char trackLower[256];
+    char ruleLower[256];
+    strncpy(trackLower, trackName, 255);
+    strncpy(ruleLower, ruleFilter, 255);
+    trackLower[255] = '\0';
+    ruleLower[255] = '\0';
+    
+    for (char* p = trackLower; *p; ++p) *p = tolower(*p);
+    for (char* p = ruleLower; *p; ++p) *p = tolower(*p);
+    
+    char ruleWords[256];
+    strncpy(ruleWords, ruleLower, 255);
+    ruleWords[255] = '\0';
+    
+    char* tokens[64];
+    int tokenCount = 0;
+    char* token = strtok(ruleWords, " ");
+    while (token && tokenCount < 64) {
+        if (strlen(token) > 0)
+            tokens[tokenCount++] = token;
+        token = strtok(NULL, " ");
+    }
+    
+    int matches = 0;
+    for (int i = 0; i < tokenCount; i++) {
+        if (strstr(trackLower, tokens[i]) != NULL) {
+            matches++;
+        }
+    }
+    
+    return matches;
+}
+
 bool ACRegisterUnregisterToMarkerRegionUpdates()
 {
-	if (g_bACMEnabled || g_bACREnabled)
-		for (int i = 0; i < g_pACItems.GetSize(); i++)
-			if (SWS_RuleItem* rule = (SWS_RuleItem*)g_pACItems.Get(i))
-				if ((g_bACMEnabled && rule->m_type == AC_MARKER) || (g_bACREnabled && rule->m_type == AC_REGION)) {
-					RegisterToMarkerRegionUpdates(&g_mkrRgnListener);
-					return true; // do not use the above returned value
-				}
-	UnregisterToMarkerRegionUpdates(&g_mkrRgnListener);
-	return false; // do not use the above returned value
+    if (g_bACMEnabled || g_bACREnabled)
+        for (int i = 0; i < g_pACItems.GetSize(); i++)
+            if (SWS_RuleItem* rule = (SWS_RuleItem*)g_pACItems.Get(i))
+                if ((g_bACMEnabled && rule->m_type == AC_MARKER) || (g_bACREnabled && rule->m_type == AC_REGION)) {
+                    RegisterToMarkerRegionUpdates(&g_mkrRgnListener);
+                    return true;
+                }
+    UnregisterToMarkerRegionUpdates(&g_mkrRgnListener);
+    return false;
 }
 
 // Prototypes
 void AutoColorSaveState();
-
 
 SWS_AutoColorView::SWS_AutoColorView(HWND hwndList, HWND hwndEdit)
 :SWS_ListView(hwndList, hwndEdit, COL_COUNT, g_cols, "AutoColorViewState", false, "sws_DLG_115")
@@ -127,1138 +200,1172 @@ SWS_AutoColorView::SWS_AutoColorView(HWND hwndList, HWND hwndEdit)
 
 void SWS_AutoColorView::GetItemText(SWS_ListItem* item, int iCol, char* str, int iStrMax)
 {
-	if (str)
-		*str = '\0';
+    if (str)
+        *str = '\0';
 
-	SWS_RuleItem* pItem = (SWS_RuleItem*)item;
-	if (!pItem)
-		return;
+    SWS_RuleItem* pItem = (SWS_RuleItem*)item;
+    if (!pItem)
+        return;
 
-	switch (iCol)
-	{
-	case COL_ID:
-		snprintf(str, iStrMax, "%d", g_pACItems.Find(pItem) + 1);
-		break;
-	case COL_TYPE:
-		lstrcpyn(str, __localizeFunc(cTypes[pItem->m_type],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
-		break;
-	case COL_FILTER:
-		{
-			// internal str? => localize for display
-			for (int i=0; i<NUM_FILTERTYPES; i++)
-				if (!strcmp(pItem->m_str_filter.Get(), cFilterTypes[i])) {
-					lstrcpyn(str, __localizeFunc(pItem->m_str_filter.Get(),"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
-					return;
-				}
-			// user defined?
-			lstrcpyn(str, pItem->m_str_filter.Get(), iStrMax);
-		}
-		break;
-	case COL_COLOR:
-		if (pItem->m_color<0 && (-pItem->m_color-1) < __ARRAY_SIZE(cColorTypes))
-			lstrcpyn(str, __localizeFunc(cColorTypes[-pItem->m_color-1],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
-		else
-			snprintf(str, iStrMax, "0x%06x", pItem->m_color);
-		break;
-	case COL_ICON:
-		if (pItem->m_type == AC_TRACK)
-			lstrcpyn(str, pItem->m_icon.Get(), iStrMax);
-		break;
-		case COL_TCP_LAYOUT:
-			if (pItem->m_type == AC_TRACK)
-				lstrcpyn(str, pItem->m_layout[0].Get(), iStrMax);
-			break;
-		case COL_MCP_LAYOUT:
-			if (pItem->m_type == AC_TRACK)
-				lstrcpyn(str, pItem->m_layout[1].Get(), iStrMax);
-			break;
-	}
+    switch (iCol)
+    {
+    case COL_TYPE:
+        lstrcpyn(str, __localizeFunc(cTypes[pItem->m_type],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
+        break;
+    case COL_FILTER:
+        {
+            for (int i=0; i<NUM_FILTERTYPES; i++)
+                if (!strcmp(pItem->m_str_filter.Get(), cFilterTypes[i])) {
+                    lstrcpyn(str, __localizeFunc(pItem->m_str_filter.Get(),"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
+                    return;
+                }
+            lstrcpyn(str, pItem->m_str_filter.Get(), iStrMax);
+        }
+        break;
+    case COL_COLOR:
+        if (pItem->m_color<0 && (-pItem->m_color-1) < __ARRAY_SIZE(cColorTypes))
+            lstrcpyn(str, __localizeFunc(cColorTypes[-pItem->m_color-1],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
+        else
+            snprintf(str, iStrMax, "0x%06x", pItem->m_color);
+        break;
+    case COL_ICON:
+        if (pItem->m_type == AC_TRACK)
+            lstrcpyn(str, pItem->m_icon.Get(), iStrMax);
+        break;
+    case COL_TCP_LAYOUT:
+        if (pItem->m_type == AC_TRACK)
+            lstrcpyn(str, pItem->m_layout[0].Get(), iStrMax);
+        break;
+    case COL_MCP_LAYOUT:
+        if (pItem->m_type == AC_TRACK)
+            lstrcpyn(str, pItem->m_layout[1].Get(), iStrMax);
+        break;
+    }
 }
 
-//JFB: COL_TYPE must be edited via context menu, not by hand (prevent internal/localized strings mismatch)
 void SWS_AutoColorView::SetItemText(SWS_ListItem* item, int iCol, const char* str)
 {
-	SWS_RuleItem* pItem = (SWS_RuleItem*)item;
-	if (!pItem)
-		return;
+    SWS_RuleItem* pItem = (SWS_RuleItem*)item;
+    if (!pItem)
+        return;
 
-	switch(iCol)
-	{
-			case COL_FILTER:
-				for (int i = 0; i < g_pACItems.GetSize(); i++)
-					if (g_pACItems.Get(i) != pItem)
-						if (g_pACItems.Get(i)->m_type == pItem->m_type && !strcmp(g_pACItems.Get(i)->m_str_filter.Get(), str)){
-							MessageBox(GetParent(m_hwndList), __LOCALIZE("Autocolor entry with that name already exists.","sws_DLG_115"), __LOCALIZE("SWS - Error","sws_DLG_115"), MB_OK);
-							return;
-						}
-				if (strlen(str))
-					pItem->m_str_filter.Set(str);
-				break;
-			case COL_COLOR:
-				pItem->m_color = strtol(str, nullptr, 0) & 0xFFFFFF;
-				break;
-			case COL_TCP_LAYOUT:
-				pItem->m_layout[0].Set(str);
-				break;
-			case COL_MCP_LAYOUT:
-				pItem->m_layout[1].Set(str);
-				break;
-	}
-	g_pACWnd->Update();
+    switch(iCol)
+    {
+        case COL_FILTER:
+            for (int i = 0; i < g_pACItems.GetSize(); i++)
+                if (g_pACItems.Get(i) != pItem)
+                    if (g_pACItems.Get(i)->m_type == pItem->m_type && !strcmp(g_pACItems.Get(i)->m_str_filter.Get(), str)){
+                        MessageBox(GetParent(m_hwndList), __LOCALIZE("Autocolor entry with that name already exists.","sws_DLG_115"), __LOCALIZE("SWS - Error","sws_DLG_115"), MB_OK);
+                        return;
+                    }
+            if (strlen(str))
+                pItem->m_str_filter.Set(str);
+            break;
+        case COL_COLOR:
+            pItem->m_color = strtol(str, nullptr, 0) & 0xFFFFFF;
+            break;
+        case COL_TCP_LAYOUT:
+            pItem->m_layout[0].Set(str);
+            break;
+        case COL_MCP_LAYOUT:
+            pItem->m_layout[1].Set(str);
+            break;
+    }
+    g_pACWnd->Update();
 }
 
 void SWS_AutoColorView::GetItemList(SWS_ListItemList* pList)
 {
-	for (int i = 0; i < g_pACItems.GetSize(); i++)
-		pList->Add((SWS_ListItem*)g_pACItems.Get(i));
+    for (int i = 0; i < g_pACItems.GetSize(); i++)
+        pList->Add((SWS_ListItem*)g_pACItems.Get(i));
 }
 
 void SWS_AutoColorView::OnItemDblClk(SWS_ListItem* item, int iCol)
 {
-	SWS_RuleItem* pItem = (SWS_RuleItem*)item;
-	if (pItem && iCol == COL_ICON)
-		g_pACWnd->OnCommand(LOAD_ICON_MSG, (LPARAM)pItem);
+    SWS_RuleItem* pItem = (SWS_RuleItem*)item;
+    if (pItem && iCol == COL_ICON)
+        g_pACWnd->OnCommand(LOAD_ICON_MSG, (LPARAM)pItem);
 }
 
 void SWS_AutoColorView::OnItemSelChanged(SWS_ListItem* item, int iState)
 {
-	g_pACWnd->Update(false);
+    g_pACWnd->Update(false);
 }
 
 void SWS_AutoColorView::OnBeginDrag(SWS_ListItem* item)
 {
-	if (abs(m_iSortCol) == (COL_ID+1)) //1-based
-		SetCapture(GetParent(m_hwndList));
+    if (abs(m_iSortCol) == (COL_TYPE+1))
+        SetCapture(GetParent(m_hwndList));
 }
 
 void SWS_AutoColorView::OnDrag()
 {
-	POINT p;
-	GetCursorPos(&p);
-	SWS_RuleItem* hitItem = (SWS_RuleItem*)GetHitItem(p.x, p.y, NULL);
-	if (hitItem)
-	{
-		int iNewPriority = g_pACItems.Find(hitItem);
-		int iSelPriority;
+    POINT p;
+    GetCursorPos(&p);
+    SWS_RuleItem* hitItem = (SWS_RuleItem*)GetHitItem(p.x, p.y, NULL);
+    if (hitItem)
+    {
+        int iNewPriority = g_pACItems.Find(hitItem);
+        int iSelPriority;
 
-		WDL_PtrList<SWS_RuleItem> draggedItems;
-		int x = 0;
-		SWS_RuleItem* selItem;
-		while((selItem = (SWS_RuleItem*)EnumSelected(&x)))
-		{
-			iSelPriority = g_pACItems.Find(selItem);
-			if (iNewPriority == iSelPriority)
-				return;
-			draggedItems.Add(selItem);
-		}
+        WDL_PtrList<SWS_RuleItem> draggedItems;
+        int x = 0;
+        SWS_RuleItem* selItem;
+        while((selItem = (SWS_RuleItem*)EnumSelected(&x)))
+        {
+            iSelPriority = g_pACItems.Find(selItem);
+            if (iNewPriority == iSelPriority)
+                return;
+            draggedItems.Add(selItem);
+        }
 
-		// Remove the dragged items and then readd them
-		// Switch order of add based on direction of drag & sort order
-		bool bDir = iNewPriority > iSelPriority;
-		if (m_iSortCol < 0)
-			bDir = !bDir;
-		for (int i = bDir ? 0 : draggedItems.GetSize()-1; bDir ? i < draggedItems.GetSize() : i >= 0; bDir ? i++ : i--)
-		{
-			int index = g_pACItems.Find(draggedItems.Get(i));
-			g_pACItems.Delete(index);
-			g_pACItems.Insert(iNewPriority, draggedItems.Get(i));
-		}
+        bool bDir = iNewPriority > iSelPriority;
+        if (m_iSortCol < 0)
+            bDir = !bDir;
+        for (int i = bDir ? 0 : draggedItems.GetSize()-1; bDir ? i < draggedItems.GetSize() : i >= 0; bDir ? i++ : i--)
+        {
+            int index = g_pACItems.Find(draggedItems.Get(i));
+            g_pACItems.Delete(index);
+            g_pACItems.Insert(iNewPriority, draggedItems.Get(i));
+        }
 
-		g_pACWnd->Update(false);
+        g_pACWnd->Update(false);
 
-		++s_ignore_update;
-		for (int i=0; i < draggedItems.GetSize(); i++)
-			SelectByItem((SWS_ListItem*)draggedItems.Get(i), i==0, i==0);
-		--s_ignore_update;
-	}
+        ++s_ignore_update;
+        for (int i=0; i < draggedItems.GetSize(); i++)
+            SelectByItem((SWS_ListItem*)draggedItems.Get(i), i==0, i==0);
+        --s_ignore_update;
+    }
 }
 
 void SWS_AutoColorView::OnEndDrag()
 {
-	g_pACWnd->Update();
+    g_pACWnd->Update();
 }
 
 SWS_AutoColorWnd::SWS_AutoColorWnd()
 :SWS_DockWnd(IDD_AUTOCOLOR, __LOCALIZE("Auto Color/Icon/Layout","sws_DLG_115"), "SWSAutoColor")
 #ifdef __APPLE__
-	,m_bSettingColor(false)
+    ,m_bSettingColor(false)
 #endif
 {
-	// Must call SWS_DockWnd::Init() to restore parameters and open the window if necessary
-	Init();
+    Init();
 }
 
 void SWS_AutoColorWnd::Update(bool applyrules)
 {
-	if (s_ignore_update) return;
+    if (s_ignore_update) return;
 
-	if (IsValidWindow())
-	{
-		SetDlgItemText(m_hwnd, IDC_APPLY, (g_bACEnabled||g_bACMEnabled||g_bACREnabled||g_bAIEnabled||g_bALEnabled) ? __LOCALIZE("Force","sws_DLG_115") : __LOCALIZE("Apply","sws_DLG_115"));
+    if (IsValidWindow())
+    {
+        SetDlgItemText(m_hwnd, IDC_APPLY, (g_bACEnabled||g_bACMEnabled||g_bACREnabled||g_bAIEnabled||g_bALEnabled) ? __LOCALIZE("Force","sws_DLG_115") : __LOCALIZE("Apply","sws_DLG_115"));
 
-		// Redraw the owner drawn button
 #ifdef _WIN32
-		RedrawWindow(GetDlgItem(m_hwnd, IDC_COLOR), NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
+        RedrawWindow(GetDlgItem(m_hwnd, IDC_COLOR), NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
 #else
-		InvalidateRect(GetDlgItem(m_hwnd, IDC_COLOR), NULL, 0);
+        InvalidateRect(GetDlgItem(m_hwnd, IDC_COLOR), NULL, 0);
 #endif
 
-		if (m_pLists.GetSize())
-			m_pLists.Get(0)->Update();
-	}
+        if (m_pLists.GetSize())
+            m_pLists.Get(0)->Update();
+    }
 
-	if (applyrules)
-	{
-		AutoColorSaveState();
-		AutoColorTrack(false);
-		if (ACRegisterUnregisterToMarkerRegionUpdates())
-			AutoColorMarkerRegion(false);
-  }
+    // Убираем автоматическое применение - только по кнопке Apply!
+    if (applyrules && false)  // Отключаем автоматическое применение
+    {
+        AutoColorSaveState();
+        AutoColorTrack(false);
+        if (ACRegisterUnregisterToMarkerRegionUpdates())
+            AutoColorMarkerRegion(false);
+    }
 }
 
 void SWS_AutoColorWnd::OnInitDlg()
 {
-	m_resize.init_item(IDC_LIST,      0.0, 0.0, 1.0, 1.0);
-	m_resize.init_item(IDC_ADD,       0.0, 1.0, 0.0, 1.0);
-	m_resize.init_item(IDC_REMOVE,    0.0, 1.0, 0.0, 1.0);
-	m_resize.init_item(IDC_COLOR,     0.0, 1.0, 0.0, 1.0);
-	m_resize.init_item(IDC_OPTIONS,   1.0, 1.0, 1.0, 1.0);
-	m_resize.init_item(IDC_APPLY,     1.0, 1.0, 1.0, 1.0);
-	m_pView = new SWS_AutoColorView(GetDlgItem(m_hwnd, IDC_LIST), GetDlgItem(m_hwnd, IDC_EDIT));
-	m_pLists.Add(m_pView);
-	Update();
+    m_resize.init_item(IDC_LIST,      0.0, 0.0, 1.0, 1.0);
+    m_resize.init_item(IDC_ADD,       0.0, 1.0, 0.0, 1.0);
+    m_resize.init_item(IDC_REMOVE,    0.0, 1.0, 0.0, 1.0);
+    m_resize.init_item(IDC_COLOR,     0.0, 1.0, 0.0, 1.0);
+    m_resize.init_item(IDC_OPTIONS,   1.0, 1.0, 1.0, 1.0);
+    m_resize.init_item(IDC_APPLY,     1.0, 1.0, 1.0, 1.0);
+    m_pView = new SWS_AutoColorView(GetDlgItem(m_hwnd, IDC_LIST), GetDlgItem(m_hwnd, IDC_EDIT));
+    m_pLists.Add(m_pView);
+    Update();
 }
 
 void SWS_AutoColorWnd::GetMinSize(int* w, int* h)
 {
-  *w=350; *h=MIN_DOCKWND_HEIGHT;
+    *w=350; *h=MIN_DOCKWND_HEIGHT;
 }
 
-//JFB TODO? handle multi-selection
 void SWS_AutoColorWnd::OnCommand(WPARAM wParam, LPARAM lParam)
 {
-	switch (wParam)
-	{
-		case IDC_APPLY:
-			AutoColorTrack(true);
-			AutoColorMarkerRegion(true);
-			break;
-		case IDC_OPTIONS:
-		{
-			HWND hwnd = GetDlgItem(m_hwnd, IDC_OPTIONS);
-			RECT r;  GetClientRect(hwnd, &r);
-			ClientToScreen(hwnd, (LPPOINT)&r);
-			ClientToScreen(hwnd, ((LPPOINT)&r)+1);
-			SendMessage(m_hwnd, WM_CONTEXTMENU, 0, MAKELPARAM((UINT)(r.left), (UINT)(r.bottom+SNM_1PIXEL_Y)));
-			break;
-		}
-		case IDC_ADD:
-			// default options when we add a new row
-			g_pACItems.Add(new SWS_RuleItem(AC_TRACK, __LOCALIZE("(name)","sws_DLG_115"), -AC_NONE-1, "", "", ""));
-			Update();
-			break;
-		case IDC_REMOVE:
-		{
-			int x = 0;
-			SWS_RuleItem* item;
-			while((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-			{
-				int idx = g_pACItems.Find(item);
-				if (idx >= 0)
-					g_pACItems.Delete(idx);
-			}
-			Update();
-			break;
-		}
-		case IDC_COLOR:
-		{
-			SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-			if (item)
-			{
-				// Display the color picker
+    switch (wParam)
+    {
+        case IDC_APPLY:
+            AutoColorTrack(true);
+            AutoColorMarkerRegion(true);
+            break;
+        case IDC_OPTIONS:
+        {
+            HWND hwnd = GetDlgItem(m_hwnd, IDC_OPTIONS);
+            RECT r;  GetClientRect(hwnd, &r);
+            ClientToScreen(hwnd, (LPPOINT)&r);
+            ClientToScreen(hwnd, ((LPPOINT)&r)+1);
+            SendMessage(m_hwnd, WM_CONTEXTMENU, 0, MAKELPARAM((UINT)(r.left), (UINT)(r.bottom+SNM_1PIXEL_Y)));
+            break;
+        }
+        case IDC_ADD:
+            g_pACItems.Add(new SWS_RuleItem(AC_TRACK, __LOCALIZE("(name)","sws_DLG_115"), -AC_NONE-1, "", "", ""));
+            Update();
+            break;
+        case IDC_REMOVE:
+        {
+            int x = 0;
+            SWS_RuleItem* item;
+            while((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+            {
+                int idx = g_pACItems.Find(item);
+                if (idx >= 0)
+                    g_pACItems.Delete(idx);
+            }
+            Update();
+            break;
+        }
+        case IDC_COLOR:
+        {
+            SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+            if (item)
+            {
 #ifdef _WIN32
-				CHOOSECOLOR cc;
-				memset(&cc, 0, sizeof(CHOOSECOLOR));
-				cc.lStructSize = sizeof(CHOOSECOLOR);
-				cc.hwndOwner = m_hwnd;
-				UpdateCustomColors();
-				cc.lpCustColors = g_custColors;
-				cc.Flags = CC_FULLOPEN | CC_RGBINIT;
-				cc.rgbResult = SWS_ColorToNative(item->m_color);
-				if (ChooseColor(&cc))
-				{
-					cc.rgbResult = SWS_ColorFromNative(cc.rgbResult & 0xFFFFFF); // ANDing for issue 600
-					int x = 0;
-					while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-						item->m_color = cc.rgbResult;
-				}
-				Update();
+                CHOOSECOLOR cc;
+                memset(&cc, 0, sizeof(CHOOSECOLOR));
+                cc.lStructSize = sizeof(CHOOSECOLOR);
+                cc.hwndOwner = m_hwnd;
+                UpdateCustomColors();
+                cc.lpCustColors = g_custColors;
+                cc.Flags = CC_FULLOPEN | CC_RGBINIT;
+                cc.rgbResult = SWS_ColorToNative(item->m_color);
+                if (ChooseColor(&cc))
+                {
+                    cc.rgbResult = SWS_ColorFromNative(cc.rgbResult & 0xFFFFFF);
+                    int x = 0;
+                    while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+                        item->m_color = cc.rgbResult;
+                }
+                Update();
 #elif defined(__APPLE__)
-				m_bSettingColor = true;
-				ShowColorChooser(item->m_color);
-				SetTimer(m_hwnd, 1, 50, NULL);
+                m_bSettingColor = true;
+                ShowColorChooser(item->m_color);
+                SetTimer(m_hwnd, 1, 50, NULL);
 #else
-				UpdateCustomColors();
-
-				COLORREF cc = item->m_color;
-				if (SWELL_ChooseColor(m_hwnd,&cc,16,g_custColors))
-				{
-					cc = SWS_ColorFromNative(cc & 0xFFFFFF);
-					int x = 0;
-					while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-						item->m_color = cc;
-				}
-				Update();
+                UpdateCustomColors();
+                COLORREF cc = item->m_color;
+                if (SWELL_ChooseColor(m_hwnd,&cc,16,g_custColors))
+                {
+                    cc = SWS_ColorFromNative(cc & 0xFFFFFF);
+                    int x = 0;
+                    while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+                        item->m_color = cc;
+                }
+                Update();
 #endif
-			}
-			break;
-		}
-		case PRI_UP_MSG:
-		{
-			int x = 0;
-			SWS_RuleItem* item;
-			while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-			{
-				int iPos = g_pACItems.Find(item);
-				if (iPos <= 0)
-					break;
-				g_pACItems.Delete(iPos, false);
-				g_pACItems.Insert(iPos-1, item);
-			}
-			Update();
-			break;
-		}
-		case PRI_DOWN_MSG:
-		{
-			// Go in reverse order
-			for (int i = m_pLists.Get(0)->GetListItemCount()-1; i >= 0; i--)
-			{
-				if (m_pLists.Get(0)->IsSelected(i))
-				{
-					SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->GetListItem(i);
-					int iPos = g_pACItems.Find(item);
-					if (iPos < 0)
-						break;
-					g_pACItems.Delete(iPos, false);
-					g_pACItems.Insert(iPos+1, item);
-				}
-			}
-			Update();
-			break;
-		}
-		case LOAD_ICON_MSG:
-		{
-			SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-			if (item)
-			{
-				char filename[SNM_MAX_PATH];
-				if (BrowseResourcePath(__LOCALIZE("Load icon","sws_DLG_115"), "Data" WDL_DIRCHAR_STR "track_icons" , "PNG files (*.PNG)\0*.PNG\0ICO files (*.ICO)\0*.ICO\0JPEG files (*.JPG)\0*.JPG\0BMP files (*.BMP)\0*.BMP\0PCX files (*.PCX)\0*.PCX\0",
-					filename, sizeof(filename)))
-				{
-					item->m_icon.Set(filename);
-				}
-			}
-			Update();
-			break;
-		}
-		case CLEAR_ICON_MSG:
-		{
-			SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-			if (item)
-				item->m_icon.Set("");
-			Update();
-			break;
-		}
+            }
+            break;
+        }
+        case PRI_UP_MSG:
+        {
+            int x = 0;
+            SWS_RuleItem* item;
+            while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+            {
+                int iPos = g_pACItems.Find(item);
+                if (iPos <= 0)
+                    break;
+                g_pACItems.Delete(iPos, false);
+                g_pACItems.Insert(iPos-1, item);
+            }
+            Update();
+            break;
+        }
+        case PRI_DOWN_MSG:
+        {
+            for (int i = m_pLists.Get(0)->GetListItemCount()-1; i >= 0; i--)
+            {
+                if (m_pLists.Get(0)->IsSelected(i))
+                {
+                    SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->GetListItem(i);
+                    int iPos = g_pACItems.Find(item);
+                    if (iPos < 0)
+                        break;
+                    g_pACItems.Delete(iPos, false);
+                    g_pACItems.Insert(iPos+1, item);
+                }
+            }
+            Update();
+            break;
+        }
+        case LOAD_ICON_MSG:
+        {
+            SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+            if (item)
+            {
+                char filename[SNM_MAX_PATH];
+                if (BrowseResourcePath(__LOCALIZE("Load icon","sws_DLG_115"), "Data" WDL_DIRCHAR_STR "track_icons" , "PNG files (*.PNG)\0*.PNG\0ICO files (*.ICO)\0*.ICO\0JPEG files (*.JPG)\0*.JPG\0BMP files (*.BMP)\0*.BMP\0PCX files (*.PCX)\0*.PCX\0",
+                    filename, sizeof(filename)))
+                {
+                    item->m_icon.Set(filename);
+                }
+            }
+            Update();
+            break;
+        }
+        case CLEAR_ICON_MSG:
+        {
+            SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+            if (item)
+                item->m_icon.Set("");
+            Update();
+            break;
+        }
 
-		default:
-			if (wParam >= TYPETYPE_MSG && wParam < TYPETYPE_MSG + NUM_TYPETYPES)
-			{
-				SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-				if (item)
-					item->m_type = (int)wParam-TYPETYPE_MSG;
-				Update();
-			}
-			else if (wParam >= FILTERTYPE_MSG && wParam < FILTERTYPE_MSG + NUM_FILTERTYPES)
-			{
-				SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
-				if (item)
-				{
-					int iType = (int)wParam - FILTERTYPE_MSG;
-					for (int i = 0; i < g_pACItems.GetSize(); i++)
-						if (g_pACItems.Get(i) != item)
-							if (g_pACItems.Get(i)->m_type == item->m_type && !strcmp(g_pACItems.Get(i)->m_str_filter.Get(), cFilterTypes[iType])) {
-								MessageBox(m_hwnd, __LOCALIZE("Autocolor entry of that type already exists.","sws_DLG_115"), __LOCALIZE("SWS - Error","sws_DLG_115"), MB_OK);
-								return;
-							}
-					item->m_str_filter.Set(cFilterTypes[wParam-FILTERTYPE_MSG]);
-				}
-				Update();
-			}
-			else if (wParam >= COLORTYPE_MSG && wParam < COLORTYPE_MSG + NUM_COLORTYPES)
-			{
-				int x = 0;
-				SWS_RuleItem* item;
-				while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-					item->m_color = -1 - ((int)wParam - COLORTYPE_MSG);
-				Update();
-			}
-			else if (wParam & LAYOUTTYPE_MSG)
-			{
-				const bool isMCP   = wParam & LAYOUTTYPE_MCP_FLAG;
-				const int layoutId = wParam & (LAYOUTTYPE_MSG - 1);
-				char layoutName[255];
-				if (layoutId == 0)
-					strcpy(layoutName, cHideLayout);
-				else
-					ThemeLayout_GetLayout(isMCP ? "mcp" : "tcp", layoutId, layoutName, sizeof(layoutName));
+        default:
+            if (wParam >= TYPETYPE_MSG && wParam < TYPETYPE_MSG + NUM_TYPETYPES)
+            {
+                SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+                if (item)
+                    item->m_type = (int)wParam-TYPETYPE_MSG;
+                Update();
+            }
+            else if (wParam >= FILTERTYPE_MSG && wParam < FILTERTYPE_MSG + NUM_FILTERTYPES)
+            {
+                SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(NULL);
+                if (item)
+                {
+                    int iType = (int)wParam - FILTERTYPE_MSG;
+                    for (int i = 0; i < g_pACItems.GetSize(); i++)
+                        if (g_pACItems.Get(i) != item)
+                            if (g_pACItems.Get(i)->m_type == item->m_type && !strcmp(g_pACItems.Get(i)->m_str_filter.Get(), cFilterTypes[iType])) {
+                                MessageBox(m_hwnd, __LOCALIZE("Autocolor entry of that type already exists.","sws_DLG_115"), __LOCALIZE("SWS - Error","sws_DLG_115"), MB_OK);
+                                return;
+                            }
+                    item->m_str_filter.Set(cFilterTypes[wParam-FILTERTYPE_MSG]);
+                }
+                Update();
+            }
+            else if (wParam >= COLORTYPE_MSG && wParam < COLORTYPE_MSG + NUM_COLORTYPES)
+            {
+                int x = 0;
+                SWS_RuleItem* item;
+                while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+                    item->m_color = -1 - ((int)wParam - COLORTYPE_MSG);
+                Update();
+            }
+            else if (wParam & LAYOUTTYPE_MSG)
+            {
+                const bool isMCP   = wParam & LAYOUTTYPE_MCP_FLAG;
+                const int layoutId = wParam & (LAYOUTTYPE_MSG - 1);
+                char layoutName[255];
+                if (layoutId == 0)
+                    strcpy(layoutName, cHideLayout);
+                else
+                    ThemeLayout_GetLayout(isMCP ? "mcp" : "tcp", layoutId, layoutName, sizeof(layoutName));
 
-				int x = 0;
-				SWS_RuleItem* item;
-				while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-					item->m_layout[isMCP].Set(layoutName);
-				Update();
-			}
-			else
-				Main_OnCommand((int)wParam, (int)lParam);
-	}
+                int x = 0;
+                SWS_RuleItem* item;
+                while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+                    item->m_layout[isMCP].Set(layoutName);
+                Update();
+            }
+            else
+                Main_OnCommand((int)wParam, (int)lParam);
+    }
 }
 
 #ifdef __APPLE__
 void SWS_AutoColorWnd::OnTimer(WPARAM wParam)
 {
-	COLORREF cr;
-	if (m_bSettingColor && GetChosenColor(&cr))
-	{
-		cr &= 0xFFFFFF;
-		int x = 0;
-		SWS_RuleItem* item;
-		while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-			item->m_color = cr;
+    COLORREF cr;
+    if (m_bSettingColor && GetChosenColor(&cr))
+    {
+        cr &= 0xFFFFFF;
+        int x = 0;
+        SWS_RuleItem* item;
+        while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+            item->m_color = cr;
 
-		KillTimer(m_hwnd, 1);
-		Update();
-	}
+        KillTimer(m_hwnd, 1);
+        Update();
+    }
 }
 
 void SWS_AutoColorWnd::OnDestroy()
 {
-	if (m_bSettingColor)
-	{
-		HideColorChooser();
-		KillTimer(m_hwnd, 1);
-	}
+    if (m_bSettingColor)
+    {
+        HideColorChooser();
+        KillTimer(m_hwnd, 1);
+    }
 }
 #endif
 
 INT_PTR SWS_AutoColorWnd::OnUnhandledMsg(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (uMsg == WM_DRAWITEM)
-	{
-		LPDRAWITEMSTRUCT pDI = (LPDRAWITEMSTRUCT)lParam;
-		if (pDI->CtlID == IDC_COLOR)
-		{
-			// Dialog-box background grey for no selection, or multiple colors in selection
-			// Doesn't account for the "special colors" because they're less than zero and get trapped
-			// out below anyway.
-			int col = -1;
-			int x = 0;
-			SWS_RuleItem* item;
-			while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
-			{
-				if (col < 0)
-					col = SWS_ColorToNative(item->m_color);
-				else if (col != item->m_color)
-				{
-					col = -1;
-					break;
-				}
-			}
+    if (uMsg == WM_DRAWITEM)
+    {
+        LPDRAWITEMSTRUCT pDI = (LPDRAWITEMSTRUCT)lParam;
+        if (pDI->CtlID == IDC_COLOR)
+        {
+            int col = -1;
+            int x = 0;
+            SWS_RuleItem* item;
+            while ((item = (SWS_RuleItem*)m_pLists.Get(0)->EnumSelected(&x)))
+            {
+                if (col < 0)
+                    col = SWS_ColorToNative(item->m_color);
+                else if (col != item->m_color)
+                {
+                    col = -1;
+                    break;
+                }
+            }
 
-			if (col < 0)
-				col = GetSysColor(COLOR_3DHILIGHT);
+            if (col < 0)
+                col = GetSysColor(COLOR_3DHILIGHT);
 
-			HBRUSH hb = CreateSolidBrush(col);
-			FillRect(pDI->hDC, &pDI->rcItem, hb);
-			DeleteObject(hb);
-			return 1;
-		}
-	}
-	return 0;
+            HBRUSH hb = CreateSolidBrush(col);
+            FillRect(pDI->hDC, &pDI->rcItem, hb);
+            DeleteObject(hb);
+            return 1;
+        }
+    }
+    return 0;
 }
 
-// must remain in sync with main menu > extensions > sws options
 void SWS_AutoColorWnd::AddOptionsMenu(HMENU _menu)
 {
-	if (GetMenuItemCount(_menu))
-		AddToMenu(_menu, SWS_SEPARATOR, 0);
-	AddToMenu(_menu, __LOCALIZE("Enable auto track coloring", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_ENABLE"), -1, false, g_bACEnabled ?  MF_CHECKED : MF_UNCHECKED);
-	AddToMenu(_menu, __LOCALIZE("Enable auto marker coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_MKR_ENABLE"), -1, false, g_bACMEnabled ?  MF_CHECKED : MF_UNCHECKED);
-	AddToMenu(_menu, __LOCALIZE("Enable auto region coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_RGN_ENABLE"), -1, false, g_bACREnabled ?  MF_CHECKED : MF_UNCHECKED);
-	AddToMenu(_menu, __LOCALIZE("Enable auto track icon", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOICON_ENABLE"), -1, false, g_bAIEnabled ?  MF_CHECKED : MF_UNCHECKED);
-	AddToMenu(_menu, __LOCALIZE("Enable auto track layout", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOLAYOUT_ENABLE"), -1, false, g_bALEnabled ?  MF_CHECKED : MF_UNCHECKED);
+    if (GetMenuItemCount(_menu))
+        AddToMenu(_menu, SWS_SEPARATOR, 0);
+    AddToMenu(_menu, __LOCALIZE("Enable auto track coloring", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_ENABLE"), -1, false, g_bACEnabled ?  MF_CHECKED : MF_UNCHECKED);
+    AddToMenu(_menu, __LOCALIZE("Enable auto marker coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_MKR_ENABLE"), -1, false, g_bACMEnabled ?  MF_CHECKED : MF_UNCHECKED);
+    AddToMenu(_menu, __LOCALIZE("Enable auto region coloring", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOCOLOR_RGN_ENABLE"), -1, false, g_bACREnabled ?  MF_CHECKED : MF_UNCHECKED);
+    AddToMenu(_menu, __LOCALIZE("Enable auto track icon", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOICON_ENABLE"), -1, false, g_bAIEnabled ?  MF_CHECKED : MF_UNCHECKED);
+    AddToMenu(_menu, __LOCALIZE("Enable auto track layout", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOLAYOUT_ENABLE"), -1, false, g_bALEnabled ?  MF_CHECKED : MF_UNCHECKED);
 }
 
 HMENU SWS_AutoColorWnd::OnContextMenu(int x, int y, bool* wantDefaultItems)
 {
-	HMENU hMenu = CreatePopupMenu();
+    HMENU hMenu = CreatePopupMenu();
 
-	// specific context menu for the button "options"
-	{
-		POINT pt = {x, y + 3*(SNM_1PIXEL_Y*(-1))}; // +/- 3: tiny trick, see OnCommand()
-		RECT r;	GetWindowRect(GetDlgItem(m_hwnd, IDC_OPTIONS), &r);
-		if (PtInRect(&r, pt))
-		{
-			*wantDefaultItems = false;
-			AddOptionsMenu(hMenu);
-			return hMenu;
-		}
-	}
+    {
+        POINT pt = {x, y + 3*(SNM_1PIXEL_Y*(-1))};
+        RECT r; GetWindowRect(GetDlgItem(m_hwnd, IDC_OPTIONS), &r);
+        if (PtInRect(&r, pt))
+        {
+            *wantDefaultItems = false;
+            AddOptionsMenu(hMenu);
+            return hMenu;
+        }
+    }
 
-	// "standard" context menu
-	int iCol;
-	if (SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->GetHitItem(x, y, &iCol))
-	{
-		*wantDefaultItems = false;
+    int iCol;
+    if (SWS_RuleItem* item = (SWS_RuleItem*)m_pLists.Get(0)->GetHitItem(x, y, &iCol))
+    {
+        *wantDefaultItems = false;
 
-		switch (iCol)
-		{
-			case COL_TYPE:
-			{
-				for (int i = 0; i < NUM_TYPETYPES; i++)
-					AddToMenu(hMenu, __localizeFunc(cTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), TYPETYPE_MSG + i);
-				AddToMenu(hMenu, SWS_SEPARATOR, 0);
-				break;
-			}
-			case COL_FILTER:
-			{
-				int numFilters = 0;
-				if (item->m_type == AC_TRACK)
-					numFilters= NUM_FILTERTYPES;
-				else if (item->m_type == AC_MARKER || item->m_type == AC_REGION)
-					numFilters = NUM_RGNFILTERTYPES;
-				if (numFilters)
-				{
-					for (int i=0; i<numFilters; i++)
-						AddToMenu(hMenu, __localizeFunc(cFilterTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), FILTERTYPE_MSG + i);
-					AddToMenu(hMenu, SWS_SEPARATOR, 0);
-				}
-				break;
-			}
-			case COL_COLOR:
-			{
-				AddToMenu(hMenu, __LOCALIZE("Set color...","sws_DLG_115"), IDC_COLOR);
-				AddToMenu(hMenu, SWS_SEPARATOR, 0);
+        switch (iCol)
+        {
+            case COL_TYPE:
+            {
+                for (int i = 0; i < NUM_TYPETYPES; i++)
+                    AddToMenu(hMenu, __localizeFunc(cTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), TYPETYPE_MSG + i);
+                AddToMenu(hMenu, SWS_SEPARATOR, 0);
+                break;
+            }
+            case COL_FILTER:
+            {
+                int numFilters = 0;
+                if (item->m_type == AC_TRACK)
+                    numFilters= NUM_FILTERTYPES;
+                else if (item->m_type == AC_MARKER || item->m_type == AC_REGION)
+                    numFilters = NUM_RGNFILTERTYPES;
+                if (numFilters)
+                {
+                    for (int i=0; i<numFilters; i++)
+                        AddToMenu(hMenu, __localizeFunc(cFilterTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), FILTERTYPE_MSG + i);
+                    AddToMenu(hMenu, SWS_SEPARATOR, 0);
+                }
+                break;
+            }
+            case COL_COLOR:
+            {
+                AddToMenu(hMenu, __LOCALIZE("Set color...","sws_DLG_115"), IDC_COLOR);
+                AddToMenu(hMenu, SWS_SEPARATOR, 0);
 
-				if (item->m_type == AC_TRACK)
-				{
-					for (int i = 0; i < NUM_COLORTYPES; i++)
-						AddToMenu(hMenu, __localizeFunc(cColorTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), COLORTYPE_MSG + i);
-				}
-				else if (item->m_type == AC_MARKER || item->m_type == AC_REGION)
-					AddToMenu(hMenu, __localizeFunc(cColorTypes[AC_NONE],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), COLORTYPE_MSG + AC_NONE);
-				AddToMenu(hMenu, SWS_SEPARATOR, 0);
-				break;
-			}
-			case COL_ICON:
-			{
-				AddToMenu(hMenu, __LOCALIZE("Load icon...","sws_DLG_115"), LOAD_ICON_MSG, -1, false, item->m_type == AC_TRACK ? MF_ENABLED : MF_GRAYED);
-				AddToMenu(hMenu, __LOCALIZE("Clear icon","sws_DLG_115"), CLEAR_ICON_MSG, -1, false, item->m_type == AC_TRACK ? MF_ENABLED : MF_GRAYED);
-				AddToMenu(hMenu, SWS_SEPARATOR, 0);
-				break;
-			}
-			case COL_TCP_LAYOUT:
-			case COL_MCP_LAYOUT:
-				AddToMenu(hMenu, __LOCALIZE("(Double-click to edit layout name)", "sws_DLG_115"), 0, -1, false, MF_GRAYED);
-				const char *section = "tcp";
-				int command = LAYOUTTYPE_MSG;
-				if (iCol == COL_MCP_LAYOUT)
-				{
-					command |= LAYOUTTYPE_MCP_FLAG;
-					section = "mcp";
-				}
-				AddToMenu(hMenu, __localizeFunc(cHideLayout, "sws_DLG_115", 0), command);
-				char layout[255];
-				// starting from 1 to skip "global layout default"
-				for (int i = 1; i < LAYOUTTYPE_MSG && ThemeLayout_GetLayout(section, i, layout, sizeof(layout)); ++i)
-				{
-					if (!layout[0])
-						snprintf(layout, sizeof(layout), "Layout %d", i);
-					AddToMenu(hMenu, layout, command | i);
-				}
+                if (item->m_type == AC_TRACK)
+                {
+                    for (int i = 0; i < NUM_COLORTYPES; i++)
+                        AddToMenu(hMenu, __localizeFunc(cColorTypes[i],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), COLORTYPE_MSG + i);
+                }
+                else if (item->m_type == AC_MARKER || item->m_type == AC_REGION)
+                    AddToMenu(hMenu, __localizeFunc(cColorTypes[AC_NONE],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), COLORTYPE_MSG + AC_NONE);
+                AddToMenu(hMenu, SWS_SEPARATOR, 0);
+                break;
+            }
+            case COL_ICON:
+            {
+                AddToMenu(hMenu, __LOCALIZE("Load icon...","sws_DLG_115"), LOAD_ICON_MSG, -1, false, item->m_type == AC_TRACK ? MF_ENABLED : MF_GRAYED);
+                AddToMenu(hMenu, __LOCALIZE("Clear icon","sws_DLG_115"), CLEAR_ICON_MSG, -1, false, item->m_type == AC_TRACK ? MF_ENABLED : MF_GRAYED);
+                AddToMenu(hMenu, SWS_SEPARATOR, 0);
+                break;
+            }
+            case COL_TCP_LAYOUT:
+            case COL_MCP_LAYOUT:
+                AddToMenu(hMenu, __LOCALIZE("(Double-click to edit layout name)", "sws_DLG_115"), 0, -1, false, MF_GRAYED);
+                const char *section = "tcp";
+                int command = LAYOUTTYPE_MSG;
+                if (iCol == COL_MCP_LAYOUT)
+                {
+                    command |= LAYOUTTYPE_MCP_FLAG;
+                    section = "mcp";
+                }
+                AddToMenu(hMenu, __localizeFunc(cHideLayout, "sws_DLG_115", 0), command);
+                char layout[255];
+                for (int i = 1; i < LAYOUTTYPE_MSG && ThemeLayout_GetLayout(section, i, layout, sizeof(layout)); ++i)
+                {
+                    if (!layout[0])
+                        snprintf(layout, sizeof(layout), "Layout %d", i);
+                    AddToMenu(hMenu, layout, command | i);
+                }
 
-				AddToMenu(hMenu, SWS_SEPARATOR, 0);
-				break;
-		}
-		AddToMenu(hMenu, __LOCALIZE("Up in priority","sws_DLG_115"), PRI_UP_MSG);
-		AddToMenu(hMenu, __LOCALIZE("Down in priority","sws_DLG_115"), PRI_DOWN_MSG);
-	}
-	else
-	{
-		AddToMenu(hMenu, __LOCALIZE("Show color management window","sws_DLG_115"), SWSGetCommandID(ShowColorDialog));
-		AddToMenu(hMenu, SWS_SEPARATOR, 0);
+                AddToMenu(hMenu, SWS_SEPARATOR, 0);
+                break;
+        }
+        AddToMenu(hMenu, __LOCALIZE("Up in priority","sws_DLG_115"), PRI_UP_MSG);
+        AddToMenu(hMenu, __LOCALIZE("Down in priority","sws_DLG_115"), PRI_DOWN_MSG);
+    }
+    else
+    {
+        AddToMenu(hMenu, __LOCALIZE("Show color management window","sws_DLG_115"), SWSGetCommandID(ShowColorDialog));
+        AddToMenu(hMenu, SWS_SEPARATOR, 0);
 
-		HMENU hOptionsSubMenu = CreatePopupMenu();
-		AddSubMenu(hMenu, hOptionsSubMenu, __LOCALIZE("Options", "sws_menu"));
-		AddOptionsMenu(hOptionsSubMenu);
-	}
-	return hMenu;
+        HMENU hOptionsSubMenu = CreatePopupMenu();
+        AddSubMenu(hMenu, hOptionsSubMenu, __LOCALIZE("Options", "sws_menu"));
+        AddOptionsMenu(hOptionsSubMenu);
+    }
+    return hMenu;
 }
 
 int SWS_AutoColorWnd::OnKey(MSG* msg, int iKeyState)
 {
-	if (msg->message == WM_KEYDOWN && msg->wParam == VK_DELETE && !iKeyState)
-	{
-		OnCommand(IDC_REMOVE, 0);
-		return 1;
-	}
-	return 0;
+    if (msg->message == WM_KEYDOWN && msg->wParam == VK_DELETE && !iKeyState)
+    {
+        OnCommand(IDC_REMOVE, 0);
+        return 1;
+    }
+    return 0;
 }
 
 void OpenAutoColor(COMMAND_T*)
 {
-	g_pACWnd->Show(true, true);
+    g_pACWnd->Show(true, true);
 }
 
-void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* rule, bool bDoColors, bool bDoIcons, bool bDoLayout, bool bForce)
+void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, bool bDoColors, bool bDoIcons, bool bDoLayout, bool bForce)
 {
-	if(rule->m_type == AC_TRACK)
-	{
-		if (!bDoColors && !bDoIcons && !bDoLayout) // NF: fix #936
-			return;
+    if (!bDoColors && !bDoIcons && !bDoLayout)
+        return;
 
-		PreventUIRefresh(1);
+    // Собираем все правила для треков
+    WDL_PtrList<SWS_RuleItem> trackRules;
+    for (int i = 0; i < g_pACItems.GetSize(); i++) {
+        SWS_RuleItem* rule = g_pACItems.Get(i);
+        if (rule->m_type == AC_TRACK) {
+            trackRules.Add(rule);
+        }
+    }
 
-		int iCount = 0;
-		WDL_PtrList<MediaTrack> gradientTracks;
+    if (trackRules.GetSize() == 0) {
+        return;
+    }
 
-		if (rule->m_color == -AC_CUSTOM-1)
-			UpdateCustomColors();
+    int iCount = 0;
+    WDL_PtrList<MediaTrack> gradientTracks;
 
-		// Check all tracks for matching strings/properties
-		MediaTrack* temp = NULL;
-		const int numTracks = GetNumTracks();
-		activeRules->reserve(numTracks);
-		for (int i = 0; i <= numTracks; i++)
-		{
-			MediaTrack* tr = i ? GetTrack(nullptr, i - 1) : GetMasterTrack(nullptr);
-			bool bColor = bDoColors;
-			bool bIcon  = bDoIcons;
-			bool bLayout[2] = { bDoLayout, bDoLayout };
+    if (trackRules.Get(0)->m_color == -AC_CUSTOM-1)
+        UpdateCustomColors();
 
-			auto pACTrack = activeRules->find(tr);
+    MediaTrack* temp = NULL;
+    const int numTracks = GetNumTracks();
+    activeRules->reserve(numTracks);
+    
+    // Предварительно разбираем все правила на слова
+    struct ParsedRule {
+        SWS_RuleItem* rule;
+        int wordCount;
+        char words[64][64];
+        bool isSpecial;
+        bool isAny;
+        int specialIndex;
+    };
+    
+    WDL_PtrList<ParsedRule> parsedRules;
+    for (int r = 0; r < trackRules.GetSize(); r++) {
+        SWS_RuleItem* rule = trackRules.Get(r);
+        ParsedRule* pr = new ParsedRule();
+        pr->rule = rule;
+        pr->wordCount = 0;
+        pr->isSpecial = false;
+        pr->isAny = false;
+        pr->specialIndex = -1;
+        
+        // Проверяем специальные правила
+        for (int s = 0; s < NUM_FILTERTYPES; s++) {
+            if (strcmp(rule->m_str_filter.Get(), cFilterTypes[s]) == 0) {
+                pr->isSpecial = true;
+                pr->specialIndex = s;
+                if (s == AC_ANY) pr->isAny = true;
+                break;
+            }
+        }
+        
+        if (!pr->isSpecial) {
+            // Разбиваем на слова
+            char filterLower[256];
+            strncpy(filterLower, rule->m_str_filter.Get(), 255);
+            filterLower[255] = '\0';
+            for (char* p = filterLower; *p; ++p) *p = tolower(*p);
+            
+            char* token = strtok(filterLower, " ");
+            while (token && pr->wordCount < 64) {
+                if (strlen(token) > 0) {
+                    strcpy(pr->words[pr->wordCount], token);
+                    pr->wordCount++;
+                }
+                token = strtok(NULL, " ");
+            }
+        }
+        
+        parsedRules.Add(pr);
+    }
+    
+    for (int i = 0; i <= numTracks; i++) {
+        MediaTrack* tr = i ? GetTrack(nullptr, i - 1) : GetMasterTrack(nullptr);
+        
+        // Получаем имя трека один раз
+        char trackLower[256] = "";
+        if (i) {
+            char* cName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
+            if (cName && cName[0]) {
+                strncpy(trackLower, cName, 255);
+                trackLower[255] = '\0';
+                for (char* p = trackLower; *p; ++p) *p = tolower(*p);
+            }
+        }
+        
+        // Ищем лучшее совпадение
+        SWS_RuleItem* bestRule = NULL;
+        int bestMatchCount = -1;
+        double bestScore = 0;
+        
+        for (int r = 0; r < parsedRules.GetSize(); r++) {
+            ParsedRule* pr = parsedRules.Get(r);
+            SWS_RuleItem* rule = pr->rule;
+            bool bMatch = false;
+            int matchCount = 0;
+            
+            if (i) { // не мастер
+                // Проверяем специальные правила
+                if (pr->isSpecial) {
+                    switch(pr->specialIndex) {
+                        case AC_FOLDER: {
+                            int iType;
+                            GetFolderDepth(tr, &iType, &temp);
+                            if (iType == 1) bMatch = true;
+                            break;
+                        }
+                        case AC_CHILDREN: {
+                            temp = CSurf_TrackFromID(0, false);
+                            if (GetFolderDepth(tr, NULL, &temp) >= 1) bMatch = true;
+                            break;
+                        }
+                        case AC_RECEIVE: {
+                            if (GetSetTrackSendInfo(tr, -1, 0, "P_SRCTRACK", NULL)) bMatch = true;
+                            break;
+                        }
+                        case AC_UNNAMED: {
+                            if (!trackLower[0]) bMatch = true;
+                            break;
+                        }
+                        case AC_REC_ARM: {
+                            int* ra = (int*)GetSetMediaTrackInfo(tr, "I_RECARM", NULL);
+                            if (ra && *ra) bMatch = true;
+                            break;
+                        }
+                        case AC_VCA_MASTER: {
+                            int iVcaMaster = GetSetTrackGroupMembership(tr, "VOLUME_VCA_MASTER", 0, 0);
+                            int iVcaMasterHigh = GetSetTrackGroupMembershipHigh(tr, "VOLUME_VCA_MASTER", 0, 0);
+                            if (iVcaMaster || iVcaMasterHigh) bMatch = true;
+                            break;
+                        }
+                        case AC_AUDIOIN: {
+                            int input = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
+                            if (input >= 0 && !(input & 4096)) bMatch = true;
+                            break;
+                        }
+                        case AC_AUDIOOUT: {
+                            int hwouts = GetTrackNumSends(tr, 1);
+                            if (hwouts) bMatch = true;
+                            break;
+                        }
+                        case AC_INSTRUMENT: {
+                            if (TrackFX_GetInstrument(tr) >= 0) bMatch = true;
+                            break;
+                        }
+                        case AC_MIDIIN: {
+                            int input = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
+                            if (input >= 0 && (input & 4096)) bMatch = true;
+                            break;
+                        }
+                        case AC_MIDIOUT: {
+                            int midihw = *(int*)GetSetMediaTrackInfo(tr, "I_MIDIHWOUT", NULL);
+                            int mididv = midihw >> 5;
+                            if (mididv >= 0) bMatch = true;
+                            break;
+                        }
+                        case AC_ANY: {
+                            bMatch = true;
+                            break;
+                        }
+                    }
+                    
+                    if (bMatch) {
+                        matchCount = 999;
+                    }
+                }
+                else if (trackLower[0]) {
+                    // Многословное совпадение
+                    matchCount = 0;
+                    for (int w = 0; w < pr->wordCount; w++) {
+                        if (strstr(trackLower, pr->words[w]) != NULL) {
+                            matchCount++;
+                        }
+                    }
+                    bMatch = (matchCount > 0);
+                }
+            }
+            else if (pr->specialIndex == AC_MASTER) {
+                bMatch = true;
+                matchCount = 999;
+            }
+            
+            if (bMatch) {
+                double score = pr->wordCount > 0 ? (double)matchCount / pr->wordCount : 0;
+                
+                if (matchCount > bestMatchCount || 
+                    (matchCount == bestMatchCount && score > bestScore)) {
+                    bestMatchCount = matchCount;
+                    bestScore = score;
+                    bestRule = rule;
+                }
+            }
+        }
+        
+        // Применяем лучшее правило
+        if (bestRule) {
+            auto pACTrack = activeRules->find(tr);
+            if (pACTrack == activeRules->end()) {
+                pACTrack = activeRules->insert(tr).first;
+            }
+            
+            bool bColor = bDoColors && !pACTrack->m_bColored && bestRule->m_color != -AC_IGNORE-1;
+            bool bIcon = bDoIcons && !pACTrack->m_bIconed && bestRule->m_icon.Get()[0];
+            bool bLayout[2] = {
+                bDoLayout && !pACTrack->m_bLayouted[0] && bestRule->m_layout[0].Get()[0],
+                bDoLayout && !pACTrack->m_bLayouted[1] && bestRule->m_layout[1].Get()[0]
+            };
+            
+            if (bColor || bIcon || bLayout[0] || bLayout[1]) {
+                // Применяем правило
+                if (bColor) {
+                    int iCurColor = *(int*)GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", NULL);
+                    if (!(iCurColor & 0x1000000)) iCurColor = 0;
+                    int newCol = iCurColor;
 
-			if (pACTrack != activeRules->end())
-			{
-				// If already modified by a different rule, or ignoring the color/icon/layout ignore this track
-				if (pACTrack->m_bColored || rule->m_color == -AC_IGNORE-1)
-					bColor = false;
+                    if (bestRule->m_color == -AC_RANDOM-1) {
+                        if (!(iCurColor & 0x1000000))
+                            newCol = RGB(rand() % 256, rand() % 256, rand() % 256) | 0x1000000;
+                    }
+                    else if (bestRule->m_color == -AC_CUSTOM-1) {
+                        if (!AllBlack())
+                            while(!(newCol = g_custColors[iCount++ % 16]));
+                        newCol |= 0x1000000;
+                    }
+                    else if (bestRule->m_color == -AC_GRADIENT-1)
+                        gradientTracks.Add(tr);
+                    else if (bestRule->m_color == -AC_NONE-1)
+                        newCol = 0;
+                    else if (bestRule->m_color == -AC_PARENT-1) {
+                        MediaTrack* parent = (MediaTrack*)GetSetMediaTrackInfo(tr, "P_PARTRACK", NULL);
+                        if (parent) {
+                            int pcol = *(int*)GetSetMediaTrackInfo(parent, "I_CUSTOMCOLOR", NULL);
+                            if (pcol & 0x1000000)
+                                newCol = pcol;
+                        }
+                    }
+                    else
+                        newCol = SWS_ColorToNative(bestRule->m_color | 0x1000000);
 
-				if (pACTrack->m_bIconed || !rule->m_icon.Get()[0])
-					bIcon = false;
+                    if ((bForce || iCurColor == SWS_ColorToNative(pACTrack->m_col)) && newCol != iCurColor) {
+                        GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", &newCol);
+                    }
+                    pACTrack->m_col = SWS_ColorFromNative(newCol);
+                    pACTrack->m_bColored = true;
+                }
 
-				for (int k=0; k<2; k++)
-					if (pACTrack->m_bLayouted[k] || !rule->m_layout[k].Get()[0])
-						bLayout[k] = false;
-			}
-			else
-				pACTrack = activeRules->insert(tr).first;
+                if (bIcon) {
+                    if (_stricmp(bestRule->m_icon.Get(), pACTrack->m_icon.Get())) {
+                        const char *cur = (const char*)GetSetMediaTrackInfo(tr, "P_ICON", NULL);
+                        cur = GetShortResourcePath("Data" WDL_DIRCHAR_STR "track_icons", cur);
+                        if (cur && _stricmp(cur, bestRule->m_icon.Get())) {
+                            if (bForce || !_stricmp(cur, pACTrack->m_icon.Get())) {
+                                GetSetMediaTrackInfo(tr, "P_ICON", (void*)bestRule->m_icon.Get());
+                            }
+                        }
+                        pACTrack->m_icon.Set(bestRule->m_icon.Get());
+                    }
+                    pACTrack->m_bIconed = true;
+                }
 
-			// Do the track rule matching
-			if (bColor || bIcon || bLayout[0] || bLayout[1])
-			{
-				bool bMatch = false;
+                for (int k=0; k<2; k++) if (bLayout[k]) {
+                    pACTrack->m_bLayouted[k] = true;
+                    if (!_stricmp(bestRule->m_layout[k].Get(), pACTrack->m_layout[k].Get()))
+                        continue;
 
-				if (i) // ignore master for most things
-				{
-					// Check "special" rules first:
-					if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_FOLDER]) == 0)
-					{
-						int iType;
-						GetFolderDepth(tr, &iType, &temp);
-						if (iType == 1)
-							bMatch = true;
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_CHILDREN]) == 0)
-					{
-						temp = CSurf_TrackFromID(0, false); // JFB fix: 'temp' could be out of sync
-						if (GetFolderDepth(tr, NULL, &temp) >= 1)
-							bMatch = true;
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_RECEIVE]) == 0)
-					{
-						if (GetSetTrackSendInfo(tr, -1, 0, "P_SRCTRACK", NULL))
-							bMatch = true;
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_UNNAMED]) == 0)
-					{
-						char* cName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
-						if (!cName || !cName[0])
-							bMatch = true;
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_REC_ARM]) == 0)
-					{
-						int* ra = (int*)GetSetMediaTrackInfo(tr, "I_RECARM", NULL);
-						if (ra && *ra)
-							bMatch = true;
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_VCA_MASTER]) == 0)
-					{
-						int iVcaMaster = GetSetTrackGroupMembership(tr, "VOLUME_VCA_MASTER", 0, 0);
+                    if (_stricmp(bestRule->m_layout[k].Get(), cHideLayout)) {
+                        const bool needUnhide = !_stricmp(pACTrack->m_layout[k].Get(), cHideLayout) && !IsTrackVisible(tr, k ? true : false);
+                        const char *curlayout = (const char*)GetSetMediaTrackInfo(tr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", NULL);
+                        if (curlayout && _stricmp(curlayout, bestRule->m_layout[k].Get())) {
+                            if (bForce || needUnhide || !_stricmp(curlayout, pACTrack->m_layout[k].Get()))
+                                GetSetMediaTrackInfo(tr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", (void*)bestRule->m_layout[k].Get());
+                        }
+                        if (needUnhide) {
+                            GetSetMediaTrackInfo(tr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i1);
+                            TrackList_AdjustWindows(k ? false : true);
+                        }
+                    }
+                    else if (IsTrackVisible(tr, k ? true : false)) {
+                        if (bForce || IsTrackVisible(pACTrack->m_pTr, k ? true : false)) {
+                            GetSetMediaTrackInfo(tr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i0);
+                            TrackList_AdjustWindows(k ? false : true);
+                        }
+                    }
+                    pACTrack->m_layout[k].Set(bestRule->m_layout[k].Get());
+                }
+            }
+        }
+    }
+    
+    // Очищаем временные данные
+    for (int r = 0; r < parsedRules.GetSize(); r++) {
+        delete parsedRules.Get(r);
+    }
+    parsedRules.Empty();
 
-						// check newly added groups 33 - 64
-						int iVcaMasterHigh = GetSetTrackGroupMembershipHigh(tr, "VOLUME_VCA_MASTER", 0, 0);
-
-						if (iVcaMaster || iVcaMasterHigh)
-							bMatch = true;
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_AUDIOIN]) == 0)
-					{
-						int input = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
-						if (input >= 0 && !(input & 4096)) { // !none && !MIDI
-							bMatch = true;
-						}
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_AUDIOOUT]) == 0)
-					{
-						int hwouts = GetTrackNumSends(tr, 1);
-						if (hwouts) {
-							bMatch = true;
-						}
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_INSTRUMENT]) == 0)
-					{
-						if (TrackFX_GetInstrument(tr) >= 0)
-							bMatch = true;
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_MIDIIN]) == 0)
-					{
-						int input = *(int*)GetSetMediaTrackInfo(tr, "I_RECINPUT", NULL);
-						if (input >= 0 && (input & 4096)) { // !none && MIDI
-							bMatch = true;
-						}
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_MIDIOUT]) == 0)
-					{
-						int midihw = *(int*)GetSetMediaTrackInfo(tr, "I_MIDIHWOUT", NULL);
-						int mididv = midihw >> 5;
-						// int midich = midihw & 0xF;
-						if (mididv >= 0) {
-							bMatch = true;
-						}
-					}
-					else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_ANY]) == 0)
-					{
-						bMatch = true;
-					}
-					else // Check for name match
-					{
-						char* cName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
-						if (cName && stristr(cName, rule->m_str_filter.Get()))
-							bMatch = true;
-					}
-				}
-				else if (strcmp(rule->m_str_filter.Get(), cFilterTypes[AC_MASTER]) == 0)
-				{	// Check master rule
-					bMatch = true;
-				}
-
-				if (bMatch)
-				{
-					// Set the color
-					if (bColor)
-					{
-						int iCurColor = *(int*)GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", NULL);
-						if (!(iCurColor & 0x1000000))
-							iCurColor = 0;
-						int newCol = iCurColor;
-
-						if (rule->m_color == -AC_RANDOM-1)
-						{
-							// Only randomize once
-							if (!(iCurColor & 0x1000000))
-								newCol = RGB(rand() % 256, rand() % 256, rand() % 256) | 0x1000000;
-						}
-						else if (rule->m_color == -AC_CUSTOM-1)
-						{
-							if (!AllBlack())
-								while(!(newCol = g_custColors[iCount++ % 16]));
-							newCol |= 0x1000000;
-						}
-						else if (rule->m_color == -AC_GRADIENT-1)
-							gradientTracks.Add(tr);
-						else if (rule->m_color == -AC_NONE-1)
-							newCol = 0;
-						else if (rule->m_color == -AC_PARENT-1)
-						{
-							MediaTrack* parent = (MediaTrack*)GetSetMediaTrackInfo(tr, "P_PARTRACK", NULL);
-							if (parent)
-							{
-								int pcol = *(int*)GetSetMediaTrackInfo(parent, "I_CUSTOMCOLOR", NULL);
-								if (pcol & 0x1000000) // Only color like parent if the parent has color (maybe not?)
-									newCol = pcol;
-							}
-						}
-						else
-							newCol = SWS_ColorToNative(rule->m_color | 0x1000000);
-
-						// Only set the color if the user hasn't changed the color manually (but record it as being changed)
-						if ((bForce || iCurColor == SWS_ColorToNative(pACTrack->m_col)) && newCol != iCurColor)
-						{
-							GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", &newCol);
-						}
-
-						pACTrack->m_col = SWS_ColorFromNative(newCol);
-						pACTrack->m_bColored = true;
-					}
-
-					if (bIcon)
-					{
-						if (_stricmp(rule->m_icon.Get(), pACTrack->m_icon.Get()))
-						{
-							const char *cur = (const char*)GetSetMediaTrackInfo(tr, "P_ICON", NULL); // requires REAPER v5.15pre6+
-							cur = GetShortResourcePath("Data" WDL_DIRCHAR_STR "track_icons", cur);
-							if (cur && _stricmp(cur, rule->m_icon.Get()))
-							{
-								// Only overwrite the icon if there's no icon, or we're forcing, or we set it ourselves earlier
-								if (bForce || !_stricmp(cur, pACTrack->m_icon.Get()))
-								{
-									GetSetMediaTrackInfo(tr, "P_ICON", (void*)rule->m_icon.Get());
-								}
-							}
-							pACTrack->m_icon.Set(rule->m_icon.Get());
-						}
-						pACTrack->m_bIconed = true;
-					}
-
-					// Set the layout
-					for (int k=0; k<2; k++) if (bLayout[k])
-					{
-						pACTrack->m_bLayouted[k] = true;
-						if (!_stricmp(rule->m_layout[k].Get(), pACTrack->m_layout[k].Get()))
-							continue;
-
-						// 'normal' track layout
-						if (_stricmp(rule->m_layout[k].Get(), cHideLayout))
-						{
-							const bool needUnhide = !_stricmp(pACTrack->m_layout[k].Get(), cHideLayout) && !IsTrackVisible(tr, k ? true : false);
-							const char *curlayout = (const char*)GetSetMediaTrackInfo(tr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", NULL);
-							if (curlayout && _stricmp(curlayout, rule->m_layout[k].Get()))
-							{
-								// Only overwrite the layout if there's no layout, or we're forcing, or we set it ourselves earlier
-								if (bForce || needUnhide || !_stricmp(curlayout, pACTrack->m_layout[k].Get()))
-									GetSetMediaTrackInfo(tr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", (void*)rule->m_layout[k].Get());
-							}
-							if (needUnhide)
-							{
-								GetSetMediaTrackInfo(tr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i1); // hide the track
-								TrackList_AdjustWindows(k ? false : true); // t=208275
-							}
-						}
-						// '(hide)' layout
-						// Only hide the track if visible, or we're forcing, or we hid it ourselves earlier
-						else if (IsTrackVisible(tr, k ? true : false))
-						{
-							if (bForce || IsTrackVisible(pACTrack->m_pTr, k ? true : false))
-							{
-								GetSetMediaTrackInfo(tr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i0); // hide the track
-								TrackList_AdjustWindows(k ? false : true); // t=208275
-							}
-						}
-						pACTrack->m_layout[k].Set(rule->m_layout[k].Get());
-					}
-				} // /if (bMatch)
-			} // /Do the track rule matching
-		} // /iterate through all tracks
-
-		// Handle gradients
-		for (int i = 0; i < gradientTracks.GetSize(); i++)
-		{
-			int newCol = g_crGradStart | 0x1000000;
-			if (i && gradientTracks.GetSize() > 1)
-				newCol = CalcGradient(g_crGradStart, g_crGradEnd, (double)i / (gradientTracks.GetSize()-1)) | 0x1000000;
-			auto match = activeRules->find(gradientTracks.Get(i));
-			if (match != activeRules->end())
-				match->m_col = newCol;
-			SetMediaTrackInfo_Value(gradientTracks.Get(i), "I_CUSTOMCOLOR", SWS_ColorToNative(newCol));
-		}
-
-		PreventUIRefresh(-1);
-	}
+    // Handle gradients
+    for (int i = 0; i < gradientTracks.GetSize(); i++) {
+        int newCol = g_crGradStart | 0x1000000;
+        if (i && gradientTracks.GetSize() > 1)
+            newCol = CalcGradient(g_crGradStart, g_crGradEnd, (double)i / (gradientTracks.GetSize()-1)) | 0x1000000;
+        auto match = activeRules->find(gradientTracks.Get(i));
+        if (match != activeRules->end())
+            match->m_col = newCol;
+        SetMediaTrackInfo_Value(gradientTracks.Get(i), "I_CUSTOMCOLOR", SWS_ColorToNative(newCol));
+    }
 }
 
-// Here's the meat and potatoes, apply the colors/icons!
 void AutoColorTrack(bool bForce)
 {
-	static bool bRecurse = false;
-	if (bRecurse || (!g_bACEnabled && !g_bAIEnabled && !g_bALEnabled && !bForce))
-		return;
-	bRecurse = true;
+    // Защита от рекурсии
+    if (g_bApplyingRules) return;
+    
+    // Если не форсируем, проверяем нужно ли обновлять
+    if (!bForce) {
+        // Проверяем изменилось ли количество треков
+        int currentTrackCount = GetNumTracks();
+        if (currentTrackCount == g_iLastTrackCount && !g_bACEnabled && !g_bAIEnabled && !g_bALEnabled) {
+            return;
+        }
+        g_iLastTrackCount = currentTrackCount;
+    }
+    
+    g_bApplyingRules = true;
 
-	auto *activeRules = g_pACTracks.Get();
+    auto *activeRules = g_pACTracks.Get();
 
-	// If forcing, start over with the saved track list
-	if (bForce)
-		activeRules->clear();
+    if (bForce)
+        activeRules->clear();
 
-	// Clear the applied bits and cleanup entries belonging to deleted tracks
-	for (auto it = activeRules->begin(); it != activeRules->end();)
-	{
-		if (!ValidatePtr(it->m_pTr, "MediaTrack*"))
-		{
-			it = activeRules->erase(it);
-			continue;
-		}
+    // Clear the applied bits and cleanup entries belonging to deleted tracks
+    for (auto it = activeRules->begin(); it != activeRules->end();) {
+        if (!ValidatePtr(it->m_pTr, "MediaTrack*")) {
+            it = activeRules->erase(it);
+            continue;
+        }
+        it->m_bColored = false;
+        it->m_bIconed  = false;
+        it->m_bLayouted[0] = false;
+        it->m_bLayouted[1] = false;
+        ++it;
+    }
 
-		it->m_bColored = false;
-		it->m_bIconed  = false;
-		it->m_bLayouted[0] = false;
-		it->m_bLayouted[1] = false;
-		++it;
-	}
+    bool bDoColors  = g_bACEnabled || bForce;
+    bool bDoIcons   = g_bAIEnabled || bForce;
+    bool bDoLayouts = g_bALEnabled || bForce;
 
-	// Apply the rules
-	bool bDoColors  = g_bACEnabled || bForce;
-	bool bDoIcons   = g_bAIEnabled || bForce;
-	bool bDoLayouts = g_bALEnabled || bForce;
+    // Проверяем, нужно ли вообще что-то делать
+    bool hasRules = false;
+    for (int i = 0; i < g_pACItems.GetSize(); i++) {
+        if (g_pACItems.Get(i)->m_type == AC_TRACK) {
+            hasRules = true;
+            break;
+        }
+    }
+    
+    if (hasRules && (bDoColors || bDoIcons || bDoLayouts)) {
+        ApplyColorRuleToTrack(activeRules, bDoColors, bDoIcons, bDoLayouts, bForce);
+    }
 
-	PreventUIRefresh(1);
+    // Remove colors/icons if necessary
+    for (auto pACTrack = activeRules->begin(); pACTrack != activeRules->end(); ++pACTrack)
+    {
+        if (bDoColors && !pACTrack->m_bColored && pACTrack->m_col)
+        {
+            int iCurColor = *(int*)GetSetMediaTrackInfo(pACTrack->m_pTr, "I_CUSTOMCOLOR", NULL);
+            if (!(iCurColor & 0x1000000))
+                iCurColor = 0;
 
-	for (int i = 0; i < g_pACItems.GetSize(); i++)
-		ApplyColorRuleToTrack(activeRules, g_pACItems.Get(i), bDoColors, bDoIcons, bDoLayouts, bForce);
+            if (SWS_ColorToNative(pACTrack->m_col) == iCurColor)
+            {
+                GetSetMediaTrackInfo(pACTrack->m_pTr, "I_CUSTOMCOLOR", &g_i0);
+            }
+            pACTrack->m_col = 0;
+        }
 
-	// Remove colors/icons if necessary
-	for (auto pACTrack = activeRules->begin(); pACTrack != activeRules->end(); ++pACTrack)
-	{
-		if (bDoColors && !pACTrack->m_bColored && pACTrack->m_col)
-		{
-			int iCurColor = *(int*)GetSetMediaTrackInfo(pACTrack->m_pTr, "I_CUSTOMCOLOR", NULL);
-			if (!(iCurColor & 0x1000000))
-				iCurColor = 0;
+        if (bDoIcons && !pACTrack->m_bIconed && pACTrack->m_icon.GetLength())
+        {
+            const char *cur = (const char*)GetSetMediaTrackInfo(pACTrack->m_pTr, "P_ICON", NULL);
+            cur = GetShortResourcePath("Data" WDL_DIRCHAR_STR "track_icons", cur);
+            if (cur && !_stricmp(pACTrack->m_icon.Get(), cur))
+            {
+                GetSetMediaTrackInfo(pACTrack->m_pTr, "P_ICON", (void*)"");
+            }
+            pACTrack->m_icon.Set("");
+        }
 
-			// Only remove color on tracks that we colored ourselves
-			if (SWS_ColorToNative(pACTrack->m_col) == iCurColor)
-			{
-				GetSetMediaTrackInfo(pACTrack->m_pTr, "I_CUSTOMCOLOR", &g_i0);
-			}
-			pACTrack->m_col = 0;
-		}
+        if (bDoLayouts) for (int k=0; k<2; k++) if (!pACTrack->m_bLayouted[k] && pACTrack->m_layout[k].GetLength())
+        {
+            if (_stricmp(pACTrack->m_layout[k].Get(), cHideLayout))
+            {
+                const char *curlayout = (const char*)GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", NULL);
+                if (curlayout && !_stricmp(pACTrack->m_layout[k].Get(), curlayout))
+                    GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", (void*)"");
+            }
+            else if (!IsTrackVisible(pACTrack->m_pTr, k ? true : false))
+            {
+                GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i1);
+                TrackList_AdjustWindows(k ? false : true);
+            }
+            pACTrack->m_layout[k].Set("");
+        }
+    }
 
-		// There's an icon set, but there shouldn't be!
-		if (bDoIcons && !pACTrack->m_bIconed && pACTrack->m_icon.GetLength())
-		{
-			// Only remove the icon on the track if we set it ourselves
-			const char *cur = (const char*)GetSetMediaTrackInfo(pACTrack->m_pTr, "P_ICON", NULL); // requires REAPER v5.15pre6+
-			cur = GetShortResourcePath("Data" WDL_DIRCHAR_STR "track_icons", cur);
-			if (cur && !_stricmp(pACTrack->m_icon.Get(), cur))
-			{
-				GetSetMediaTrackInfo(pACTrack->m_pTr, "P_ICON", (void*)"");
-			}
-			pACTrack->m_icon.Set("");
-		}
-
-		if (bDoLayouts) for (int k=0; k<2; k++) if (!pACTrack->m_bLayouted[k] && pACTrack->m_layout[k].GetLength())
-		{
-			// There's a layout set, but there shouldn't be!
-			// 'normal' track layout
-			if (_stricmp(pACTrack->m_layout[k].Get(), cHideLayout))
-			{
-				// Only remove the layout if we set it ourselves
-				const char *curlayout = (const char*)GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", NULL);
-				if (curlayout && !_stricmp(pACTrack->m_layout[k].Get(), curlayout))
-					GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "P_MCP_LAYOUT" : "P_TCP_LAYOUT", (void*)"");
-			}
-			// '(hide)' layout
-			// Only unhide the track if we hid it ourselves
-			else if (!IsTrackVisible(pACTrack->m_pTr, k ? true : false))
-			{
-				GetSetMediaTrackInfo(pACTrack->m_pTr, k ? "B_SHOWINMIXER" : "B_SHOWINTCP", &g_i1); // show the track
-				TrackList_AdjustWindows(k ? false : true);
-			}
-			pACTrack->m_layout[k].Set("");
-		}
-	}
-
-	if (bForce)
-		Undo_OnStateChangeEx(__LOCALIZE("Apply auto color/icon/layout","sws_undo"), UNDO_STATE_TRACKCFG | UNDO_STATE_MISCCFG, -1);
-	UpdateArrange();
-	PreventUIRefresh(-1);
-
-	bRecurse = false;
+    if (bForce)
+        Undo_OnStateChangeEx(__LOCALIZE("Apply auto color/icon/layout","sws_undo"), UNDO_STATE_TRACKCFG | UNDO_STATE_MISCCFG, -1);
+    
+    UpdateArrange();
+    g_bApplyingRules = false;
 }
 
 void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
 {
-	ColorTheme* ct = SNM_GetColorTheme();
-	if (!_rule || !_flags || !ct)
-		return;
+    ColorTheme* ct = SNM_GetColorTheme();
+    if (!_rule || !_flags || !ct)
+        return;
 
-	double pos, end;
-	int x=0, num, color;
-	bool isRgn;
-	const char* name;
+    double pos, end;
+    int x=0, num, color;
+    bool isRgn;
+    const char* name;
 
-	PreventUIRefresh(1);
-	if(_rule->m_type & _flags)
-	{
-		while ((x = EnumProjectMarkers3(NULL, x, &isRgn, &pos, &end, &name, &num, &color)))
-		{
-			if ((!strcmp(cFilterTypes[AC_RGNANY], _rule->m_str_filter.Get()) ||
-				(!strcmp(cFilterTypes[AC_RGNUNNAMED], _rule->m_str_filter.Get()) && (!name || !*name)) ||
-				(name && stristr(name, _rule->m_str_filter.Get())))
-				&&
-				((_flags&AC_REGION && isRgn && _rule->m_type==AC_REGION) ||
-				(_flags&AC_MARKER && !isRgn && _rule->m_type==AC_MARKER)))
-			{
-				SetProjectMarkerByIndex(NULL, x-1, isRgn, pos, end, num, NULL, _rule->m_color==-AC_NONE-1 ? (isRgn?ct->marker:ct->region) : SWS_ColorToNative(_rule->m_color | 0x1000000));
-			}
-		}
-	}
-	PreventUIRefresh(-1);
+    PreventUIRefresh(1);
+    if(_rule->m_type & _flags)
+    {
+        while ((x = EnumProjectMarkers3(NULL, x, &isRgn, &pos, &end, &name, &num, &color)))
+        {
+            bool bMatch = false;
+            
+            if (!strcmp(cFilterTypes[AC_RGNANY], _rule->m_str_filter.Get()))
+                bMatch = true;
+            else if (!strcmp(cFilterTypes[AC_RGNUNNAMED], _rule->m_str_filter.Get()) && (!name || !*name))
+                bMatch = true;
+            else if (name && name[0])
+            {
+                // Многословное совпадение для маркеров и регионов
+                int matchCount = CountMatchingWords(name, _rule->m_str_filter.Get());
+                bMatch = (matchCount > 0);
+            }
+            
+            if (bMatch && ((_flags&AC_REGION && isRgn && _rule->m_type==AC_REGION) ||
+                           (_flags&AC_MARKER && !isRgn && _rule->m_type==AC_MARKER)))
+            {
+                SetProjectMarkerByIndex(NULL, x-1, isRgn, pos, end, num, NULL, _rule->m_color==-AC_NONE-1 ? (isRgn?ct->marker:ct->region) : SWS_ColorToNative(_rule->m_color | 0x1000000));
+            }
+        }
+    }
+    PreventUIRefresh(-1);
 }
 
 void AutoColorMarkerRegion(bool _force, int _flags)
 {
-	static bool bRecurse = false;
-	if (bRecurse || (!g_bACREnabled && !g_bACMEnabled && !_force))
-		return;
-	bRecurse = true;
+    static bool bRecurse = false;
+    if (bRecurse || (!g_bACREnabled && !g_bACMEnabled && !_force))
+        return;
+    bRecurse = true;
 
-	int newFlags = 0;
-	if (_flags&AC_MARKER && (g_bACMEnabled || _force))
-		newFlags |= AC_MARKER;
-	if (_flags&AC_REGION && (g_bACREnabled || _force))
-		newFlags |= AC_REGION;
+    int newFlags = 0;
+    if (_flags&AC_MARKER && (g_bACMEnabled || _force))
+        newFlags |= AC_MARKER;
+    if (_flags&AC_REGION && (g_bACREnabled || _force))
+        newFlags |= AC_REGION;
 
-	if (newFlags)
-	{
-		PreventUIRefresh(1);
+    if (newFlags)
+    {
+        PreventUIRefresh(1);
 
-		for (int i=g_pACItems.GetSize()-1; i>=0; i--) // reverse to obey priority
-			ApplyColorRuleToMarkerRegion(g_pACItems.Get(i), newFlags);
+        for (int i=g_pACItems.GetSize()-1; i>=0; i--)
+            ApplyColorRuleToMarkerRegion(g_pACItems.Get(i), newFlags);
 
-		PreventUIRefresh(-1);
-	}
+        PreventUIRefresh(-1);
+    }
 
-	if (_force)
-		Undo_OnStateChangeEx(__LOCALIZE("Apply auto marker/region color","sws_undo"), UNDO_STATE_MISCCFG, -1);
-	bRecurse = false;
+    if (_force)
+        Undo_OnStateChangeEx(__LOCALIZE("Apply auto marker/region color","sws_undo"), UNDO_STATE_MISCCFG, -1);
+    bRecurse = false;
 }
 
 void EnableAutoColor(COMMAND_T* ct)
 {
-	switch((int)ct->user)
-	{
-		case 0: g_bACEnabled = !g_bACEnabled; break;
-		case 1: g_bACMEnabled = !g_bACMEnabled; break;
-		case 2: g_bACREnabled = !g_bACREnabled; break;
-	}
-	g_pACWnd->Update();
+    switch((int)ct->user)
+    {
+        case 0: g_bACEnabled = !g_bACEnabled; break;
+        case 1: g_bACMEnabled = !g_bACMEnabled; break;
+        case 2: g_bACREnabled = !g_bACREnabled; break;
+    }
+    g_pACWnd->Update();
 }
 
 void EnableAutoIcon(COMMAND_T*)
 {
-	g_bAIEnabled = !g_bAIEnabled;
-	g_pACWnd->Update();
+    g_bAIEnabled = !g_bAIEnabled;
+    g_pACWnd->Update();
 }
 
 void EnableAutoLayout(COMMAND_T*)
 {
-	g_bALEnabled = !g_bALEnabled;
-	g_pACWnd->Update();
+    g_bALEnabled = !g_bALEnabled;
+    g_pACWnd->Update();
 }
 
 void ApplyAutoColor(COMMAND_T*)
 {
-	AutoColorTrack(true);
-	AutoColorMarkerRegion(true);
+    AutoColorTrack(true);
+    AutoColorMarkerRegion(true);
 }
 
-int IsAutoColorOpen(COMMAND_T*)		{ return g_pACWnd->IsWndVisible(); }
-int IsAutoIconEnabled(COMMAND_T*)	{ return g_bAIEnabled; }
-int IsAutoLayoutEnabled(COMMAND_T*)	{ return g_bALEnabled; }
+int IsAutoColorOpen(COMMAND_T*)        { return g_pACWnd->IsWndVisible(); }
+int IsAutoIconEnabled(COMMAND_T*)    { return g_bAIEnabled; }
+int IsAutoLayoutEnabled(COMMAND_T*)    { return g_bALEnabled; }
 
 int IsAutoColorEnabled(COMMAND_T* ct)
 {
-	switch((int)ct->user) {
-		case 0: return g_bACEnabled;
-		case 1: return g_bACMEnabled;
-		case 2: return g_bACREnabled;
-	}
-	return false;
+    switch((int)ct->user) {
+        case 0: return g_bACEnabled;
+        case 1: return g_bACMEnabled;
+        case 2: return g_bACREnabled;
+    }
+    return false;
  }
 
 static bool ProcessExtensionLine(const char *line, ProjectStateContext *ctx, bool isUndo, struct project_config_extension_t *reg)
 {
-	LineParser lp(false);
-	if (lp.parse(line) || lp.getnumtokens() < 1)
-		return false;
-	if (strcmp(lp.gettoken_str(0), "<SWSAUTOCOLOR") == 0)
-	{
-		char linebuf[4096];
-		while(true)
-		{
-			if (!ctx->GetLine(linebuf,sizeof(linebuf)) && !lp.parse(linebuf))
-			{
-				if (lp.gettoken_str(0)[0] == '>')
-					break;
+    LineParser lp(false);
+    if (lp.parse(line) || lp.getnumtokens() < 1)
+        return false;
+    if (strcmp(lp.gettoken_str(0), "<SWSAUTOCOLOR") == 0)
+    {
+        char linebuf[4096];
+        while(true)
+        {
+            if (!ctx->GetLine(linebuf,sizeof(linebuf)) && !lp.parse(linebuf))
+            {
+                if (lp.gettoken_str(0)[0] == '>')
+                    break;
 
-				GUID g;
-				stringToGuid(lp.gettoken_str(0), &g);
-				MediaTrack* tr = GuidToTrack(&g);
-				// not loading master track cache to always re-apply rules (icon isn't persisted in RPP)
-				if (tr && tr != GetMasterTrack(nullptr))
-				{
-					auto rt = g_pACTracks.Get()->insert(tr).first;
-					rt->m_col = ImportColor(lp.gettoken_int(1));
-					rt->m_icon.Set(lp.gettoken_str(2));
-					rt->m_layout[0].Set(lp.gettoken_str(3));
-					rt->m_layout[1].Set(lp.gettoken_str(4));
-				}
-			}
-			else
-				break;
-		}
-		return true;
-	}
-	return false;
+                GUID g;
+                stringToGuid(lp.gettoken_str(0), &g);
+                MediaTrack* tr = GuidToTrack(&g);
+                if (tr && tr != GetMasterTrack(nullptr))
+                {
+                    auto rt = g_pACTracks.Get()->insert(tr).first;
+                    rt->m_col = ImportColor(lp.gettoken_int(1));
+                    rt->m_icon.Set(lp.gettoken_str(2));
+                    rt->m_layout[0].Set(lp.gettoken_str(3));
+                    rt->m_layout[1].Set(lp.gettoken_str(4));
+                }
+            }
+            else
+                break;
+        }
+        return true;
+    }
+    return false;
 }
 
 static void SaveExtensionConfig(ProjectStateContext *ctx, bool isUndo, struct project_config_extension_t *reg)
 {
-	auto *activeRules = g_pACTracks.Get();
-	activeRules->erase_if([](const SWS_RuleTrack &rt) { return !ValidatePtr(rt.m_pTr, "MediaTrack*"); });
-	if (activeRules->empty())
-		return;
+    auto *activeRules = g_pACTracks.Get();
+    activeRules->erase_if([](const SWS_RuleTrack &rt) { return !ValidatePtr(rt.m_pTr, "MediaTrack*"); });
+    if (activeRules->empty())
+        return;
 
-	// serialize in track project order instead of track address order
-	std::vector<const SWS_RuleTrack *> sortedRules;
-	sortedRules.reserve(activeRules->size());
-	std::transform(activeRules->begin(), activeRules->end(),
-		std::back_inserter(sortedRules), [](const SWS_RuleTrack &rt) { return &rt; }); // std::addressof is C++11
-	std::sort(sortedRules.begin(), sortedRules.end(), [](const SWS_RuleTrack *a, const SWS_RuleTrack *b) {
-		return GetMediaTrackInfo_Value(a->m_pTr, "IP_TRACKNUMBER") < GetMediaTrackInfo_Value(b->m_pTr, "IP_TRACKNUMBER");
-	});
+    std::vector<const SWS_RuleTrack *> sortedRules;
+    sortedRules.reserve(activeRules->size());
+    std::transform(activeRules->begin(), activeRules->end(),
+        std::back_inserter(sortedRules), [](const SWS_RuleTrack &rt) { return &rt; });
+    std::sort(sortedRules.begin(), sortedRules.end(), [](const SWS_RuleTrack *a, const SWS_RuleTrack *b) {
+        return GetMediaTrackInfo_Value(a->m_pTr, "IP_TRACKNUMBER") < GetMediaTrackInfo_Value(b->m_pTr, "IP_TRACKNUMBER");
+    });
 
-	ctx->AddLine("<SWSAUTOCOLOR");
-	for (const SWS_RuleTrack *rt : sortedRules)
-	{
+    ctx->AddLine("<SWSAUTOCOLOR");
+    for (const SWS_RuleTrack *rt : sortedRules)
+    {
+        char str[256];
+        GUID g = GUID_NULL;
+        if (CSurf_TrackToID(rt->m_pTr, false))
+            g = *(GUID*)GetSetMediaTrackInfo(rt->m_pTr, "GUID", NULL);
+        guidToString(&g, str);
+        ctx->AddLine("%s %d \"%s\" \"%s\" \"%s\"", str, ExportColor(rt->m_col), rt->m_icon.Get(), rt->m_layout[0].Get(), rt->m_layout[1].Get());
 
-		char str[256];
-		GUID g = GUID_NULL;
-		if (CSurf_TrackToID(rt->m_pTr, false))
-			g = *(GUID*)GetSetMediaTrackInfo(rt->m_pTr, "GUID", NULL);
-		guidToString(&g, str);
-		ctx->AddLine("%s %d \"%s\" \"%s\" \"%s\"", str, ExportColor(rt->m_col), rt->m_icon.Get(), rt->m_layout[0].Get(), rt->m_layout[1].Get());
-
-		++rt;
-	}
-	ctx->AddLine(">");
+        ++rt;
+    }
+    ctx->AddLine(">");
 }
 
 static void BeginLoadProjectState(bool isUndo, struct project_config_extension_t *reg)
 {
-	g_pACTracks.Cleanup();
-	g_pACTracks.Get()->clear();
+    g_pACTracks.Cleanup();
+    g_pACTracks.Get()->clear();
 }
 
 static project_config_extension_t g_projectconfig = { ProcessExtensionLine, SaveExtensionConfig, BeginLoadProjectState, NULL };
@@ -1266,115 +1373,113 @@ static project_config_extension_t g_projectconfig = { ProcessExtensionLine, Save
 //!WANT_LOCALIZE_1ST_STRING_BEGIN:sws_actions
 static COMMAND_T g_commandTable[] =
 {
-	{ { DEFACCEL, "SWS: Open auto color/icon/layout window" },				"SWSAUTOCOLOR_OPEN",		OpenAutoColor,		"SWS Auto color/icon/layout",			0, IsAutoColorOpen },
-	{ { DEFACCEL, "SWS: Toggle auto track coloring enable" },		"SWSAUTOCOLOR_ENABLE",		EnableAutoColor,	"Enable auto track coloring",	0, IsAutoColorEnabled },
-	{ { DEFACCEL, "SWS/S&M: Toggle auto marker coloring enable" },	"S&MAUTOCOLOR_MKR_ENABLE",	EnableAutoColor,	"Enable auto marker coloring",	1, IsAutoColorEnabled },
-	{ { DEFACCEL, "SWS/S&M: Toggle auto region coloring enable" },	"S&MAUTOCOLOR_RGN_ENABLE",	EnableAutoColor,	"Enable auto region coloring",	2, IsAutoColorEnabled },
-	{ { DEFACCEL, "SWS/S&M: Toggle auto track icon enable" },		"S&MAUTOICON_ENABLE",		EnableAutoIcon,		"Enable auto icon",				0, IsAutoIconEnabled },
-	{ { DEFACCEL, "SWS/S&M: Toggle auto track layout enable" },		"S&MAUTOLAYOUT_ENABLE",		EnableAutoLayout,		"Enable auto layout",				0, IsAutoLayoutEnabled },
-	{ { DEFACCEL, "SWS: Apply auto coloring" },						"SWSAUTOCOLOR_APPLY",		ApplyAutoColor,	},
-	{ {}, LAST_COMMAND, }, // Denote end of table
+    { { DEFACCEL, "SWS: Open auto color/icon/layout window" },                "SWSAUTOCOLOR_OPEN",        OpenAutoColor,        "SWS Auto color/icon/layout",            0, IsAutoColorOpen },
+    { { DEFACCEL, "SWS: Toggle auto track coloring enable" },        "SWSAUTOCOLOR_ENABLE",        EnableAutoColor,    "Enable auto track coloring",    0, IsAutoColorEnabled },
+    { { DEFACCEL, "SWS/S&M: Toggle auto marker coloring enable" },    "S&MAUTOCOLOR_MKR_ENABLE",    EnableAutoColor,    "Enable auto marker coloring",    1, IsAutoColorEnabled },
+    { { DEFACCEL, "SWS/S&M: Toggle auto region coloring enable" },    "S&MAUTOCOLOR_RGN_ENABLE",    EnableAutoColor,    "Enable auto region coloring",    2, IsAutoColorEnabled },
+    { { DEFACCEL, "SWS/S&M: Toggle auto track icon enable" },        "S&MAUTOICON_ENABLE",        EnableAutoIcon,        "Enable auto icon",                0, IsAutoIconEnabled },
+    { { DEFACCEL, "SWS/S&M: Toggle auto track layout enable" },        "S&MAUTOLAYOUT_ENABLE",        EnableAutoLayout,        "Enable auto layout",                0, IsAutoLayoutEnabled },
+    { { DEFACCEL, "SWS: Apply auto coloring" },                        "SWSAUTOCOLOR_APPLY",        ApplyAutoColor,    },
+    { {}, LAST_COMMAND, },
 };
 //!WANT_LOCALIZE_1ST_STRING_END
 
-
 int AutoColorInit()
 {
-	if (!plugin_register("projectconfig",&g_projectconfig))
-		return 0;
+    if (!plugin_register("projectconfig",&g_projectconfig))
+        return 0;
 
-	SWSRegisterCommands(g_commandTable);
+    SWSRegisterCommands(g_commandTable);
 
-	g_ACIni.SetFormatted(MAX_PATH, "%s%csws-autocoloricon.ini", GetResourcePath(), PATH_SLASH_CHAR);
+    g_ACIni.SetFormatted(MAX_PATH, "%s%csws-autocoloricon.ini", GetResourcePath(), PATH_SLASH_CHAR);
 
-	// "Upgrade" to the new ini file for just the auto color stuff if necessary
-	WDL_String ini(g_ACIni);
-	bool bUpgrade = false;
-	int iCount = GetPrivateProfileInt(SWS_INI, AC_COUNT_KEY, 0, get_ini_file());
-	if (iCount)
-	{
-		bUpgrade = true;
-		ini.Set(get_ini_file());
-	}
-	else
-		iCount = GetPrivateProfileInt(SWS_INI, AC_COUNT_KEY, 0, ini.Get());
+    WDL_String ini(g_ACIni);
+    bool bUpgrade = false;
+    int iCount = GetPrivateProfileInt(SWS_INI, AC_COUNT_KEY, 0, get_ini_file());
+    if (iCount)
+    {
+        bUpgrade = true;
+        ini.Set(get_ini_file());
+    }
+    else
+        iCount = GetPrivateProfileInt(SWS_INI, AC_COUNT_KEY, 0, ini.Get());
 
-	// Restore state
-	char str[BUFFER_SIZE];
-	g_bACEnabled = GetPrivateProfileInt(SWS_INI, AC_ENABLE_KEY, 0, ini.Get()) ? true : false;
-	g_bACMEnabled = GetPrivateProfileInt(SWS_INI, ACM_ENABLE_KEY, 0, ini.Get()) ? true : false;
-	g_bACREnabled = GetPrivateProfileInt(SWS_INI, ACR_ENABLE_KEY, 0, ini.Get()) ? true : false;
-	g_bAIEnabled = GetPrivateProfileInt(SWS_INI, AI_ENABLE_KEY, 0, ini.Get()) ? true : false;
-	g_bALEnabled = GetPrivateProfileInt(SWS_INI, AL_ENABLE_KEY, 0, ini.Get()) ? true : false;
+    char str[BUFFER_SIZE];
+    g_bACEnabled = GetPrivateProfileInt(SWS_INI, AC_ENABLE_KEY, 0, ini.Get()) ? true : false;
+    g_bACMEnabled = GetPrivateProfileInt(SWS_INI, ACM_ENABLE_KEY, 0, ini.Get()) ? true : false;
+    g_bACREnabled = GetPrivateProfileInt(SWS_INI, ACR_ENABLE_KEY, 0, ini.Get()) ? true : false;
+    g_bAIEnabled = GetPrivateProfileInt(SWS_INI, AI_ENABLE_KEY, 0, ini.Get()) ? true : false;
+    g_bALEnabled = GetPrivateProfileInt(SWS_INI, AL_ENABLE_KEY, 0, ini.Get()) ? true : false;
 
-	char key[32];
-	for (int i = 0; i < iCount; i++)
-	{
-		snprintf(key, 32, AC_ITEM_KEY, i+1);
-		GetPrivateProfileString(SWS_INI, key, "", str, BUFFER_SIZE, ini.Get()); // Read in AutoColor line (stored in str)
-		if (bUpgrade) // Remove old lines
-			WritePrivateProfileString(SWS_INI, key, NULL, get_ini_file());
-		LineParser lp(false);
-		if (!lp.parse(str) && lp.getnumtokens() >= 4)
-			g_pACItems.Add(new SWS_RuleItem(lp.gettoken_int(0), lp.gettoken_str(1), ImportColor(lp.gettoken_int(2)), lp.gettoken_str(3), lp.gettoken_str(4), lp.gettoken_str(5)));
-		else if(!lp.parse(str) && lp.getnumtokens() == 3) //Reformat old format Autocolor line to new format (i.e. region + marker)
-			g_pACItems.Add(new SWS_RuleItem(AC_TRACK, lp.gettoken_str(0), lp.gettoken_int(1), lp.gettoken_str(2), "", ""));
-	}
+    char key[32];
+    for (int i = 0; i < iCount; i++)
+    {
+        snprintf(key, 32, AC_ITEM_KEY, i+1);
+        GetPrivateProfileString(SWS_INI, key, "", str, BUFFER_SIZE, ini.Get());
+        if (bUpgrade)
+            WritePrivateProfileString(SWS_INI, key, NULL, get_ini_file());
+        LineParser lp(false);
+        if (!lp.parse(str) && lp.getnumtokens() >= 4)
+            g_pACItems.Add(new SWS_RuleItem(lp.gettoken_int(0), lp.gettoken_str(1), ImportColor(lp.gettoken_int(2)), lp.gettoken_str(3), lp.gettoken_str(4), lp.gettoken_str(5)));
+        else if(!lp.parse(str) && lp.getnumtokens() == 3)
+            g_pACItems.Add(new SWS_RuleItem(AC_TRACK, lp.gettoken_str(0), lp.gettoken_int(1), lp.gettoken_str(2), "", ""));
+    }
 
-	if (bUpgrade)
-	{	// Remove old stuff
-		WritePrivateProfileString(SWS_INI, AC_ENABLE_KEY, NULL, get_ini_file());
-		WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, NULL, get_ini_file());
-		WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, NULL, get_ini_file());
-		AutoColorSaveState();
-	}
+    if (bUpgrade)
+    {
+        WritePrivateProfileString(SWS_INI, AC_ENABLE_KEY, NULL, get_ini_file());
+        WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, NULL, get_ini_file());
+        WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, NULL, get_ini_file());
+        AutoColorSaveState();
+    }
 
-	ACRegisterUnregisterToMarkerRegionUpdates();
+    ACRegisterUnregisterToMarkerRegionUpdates();
 
-	g_pACWnd = new SWS_AutoColorWnd();
+    g_pACWnd = new SWS_AutoColorWnd();
 
-	return 1;
+    // Применяем правила только один раз при загрузке
+    AutoColorTrack(false);
+
+    return 1;
 }
 
 void AutoColorSaveState()
 {
-	// Save state
-	char str[BUFFER_SIZE];
-	sprintf(str, "%d", g_bACEnabled ? 1 : 0);
-	WritePrivateProfileString(SWS_INI, AC_ENABLE_KEY, str, g_ACIni.Get());
-	sprintf(str, "%d", g_bACMEnabled ? 1 : 0);
-	WritePrivateProfileString(SWS_INI, ACM_ENABLE_KEY, str, g_ACIni.Get());
-	sprintf(str, "%d", g_bACREnabled ? 1 : 0);
-	WritePrivateProfileString(SWS_INI, ACR_ENABLE_KEY, str, g_ACIni.Get());
-	sprintf(str, "%d", g_bAIEnabled ? 1 : 0);
-	WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, str, g_ACIni.Get());
-	sprintf(str, "%d", g_bALEnabled ? 1 : 0);
-	WritePrivateProfileString(SWS_INI, AL_ENABLE_KEY, str, g_ACIni.Get());
-	sprintf(str, "%d", g_pACItems.GetSize());
-	WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, str, g_ACIni.Get());
+    char str[BUFFER_SIZE];
+    sprintf(str, "%d", g_bACEnabled ? 1 : 0);
+    WritePrivateProfileString(SWS_INI, AC_ENABLE_KEY, str, g_ACIni.Get());
+    sprintf(str, "%d", g_bACMEnabled ? 1 : 0);
+    WritePrivateProfileString(SWS_INI, ACM_ENABLE_KEY, str, g_ACIni.Get());
+    sprintf(str, "%d", g_bACREnabled ? 1 : 0);
+    WritePrivateProfileString(SWS_INI, ACR_ENABLE_KEY, str, g_ACIni.Get());
+    sprintf(str, "%d", g_bAIEnabled ? 1 : 0);
+    WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, str, g_ACIni.Get());
+    sprintf(str, "%d", g_bALEnabled ? 1 : 0);
+    WritePrivateProfileString(SWS_INI, AL_ENABLE_KEY, str, g_ACIni.Get());
+    sprintf(str, "%d", g_pACItems.GetSize());
+    WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, str, g_ACIni.Get());
 
-	char key[32];
-	WDL_FastString tmp[4];
-	for (int i = 0; i < g_pACItems.GetSize(); i++)
-	{
-		makeEscapedConfigString(g_pACItems.Get(i)->m_str_filter.Get(), &tmp[0]);
-		makeEscapedConfigString(g_pACItems.Get(i)->m_icon.Get(), &tmp[1]);
-		makeEscapedConfigString(g_pACItems.Get(i)->m_layout[0].Get(), &tmp[2]);
-		makeEscapedConfigString(g_pACItems.Get(i)->m_layout[1].Get(), &tmp[3]);
-		snprintf(str, BUFFER_SIZE, "%d %s %d %s %s %s", g_pACItems.Get(i)->m_type, tmp[0].Get(), ExportColor(g_pACItems.Get(i)->m_color), tmp[1].Get(), tmp[2].Get(), tmp[3].Get());
+    char key[32];
+    WDL_FastString tmp[4];
+    for (int i = 0; i < g_pACItems.GetSize(); i++)
+    {
+        makeEscapedConfigString(g_pACItems.Get(i)->m_str_filter.Get(), &tmp[0]);
+        makeEscapedConfigString(g_pACItems.Get(i)->m_icon.Get(), &tmp[1]);
+        makeEscapedConfigString(g_pACItems.Get(i)->m_layout[0].Get(), &tmp[2]);
+        makeEscapedConfigString(g_pACItems.Get(i)->m_layout[1].Get(), &tmp[3]);
+        snprintf(str, BUFFER_SIZE, "%d %s %d %s %s %s", g_pACItems.Get(i)->m_type, tmp[0].Get(), ExportColor(g_pACItems.Get(i)->m_color), tmp[1].Get(), tmp[2].Get(), tmp[3].Get());
 
-		snprintf(key, 32, AC_ITEM_KEY, i+1);
-		WritePrivateProfileString(SWS_INI, key, str, g_ACIni.Get());
-	}
-	// Erase the n+1 entry
-	snprintf(key, 32, AC_ITEM_KEY, g_pACItems.GetSize() + 1);
-	WritePrivateProfileString(SWS_INI, key, NULL, g_ACIni.Get());
+        snprintf(key, 32, AC_ITEM_KEY, i+1);
+        WritePrivateProfileString(SWS_INI, key, str, g_ACIni.Get());
+    }
+    snprintf(key, 32, AC_ITEM_KEY, g_pACItems.GetSize() + 1);
+    WritePrivateProfileString(SWS_INI, key, NULL, g_ACIni.Get());
 }
 
 void AutoColorExit()
 {
-	plugin_register("-projectconfig",&g_projectconfig);
-	UnregisterToMarkerRegionUpdates(&g_mkrRgnListener);
-	AutoColorSaveState();
-	DELETE_NULL(g_pACWnd);
+    plugin_register("-projectconfig",&g_projectconfig);
+    UnregisterToMarkerRegionUpdates(&g_mkrRgnListener);
+    AutoColorSaveState();
+    DELETE_NULL(g_pACWnd);
 }

--- a/Color/Autocolor.cpp
+++ b/Color/Autocolor.cpp
@@ -138,7 +138,7 @@ void SWS_AutoColorView::GetItemText(SWS_ListItem* item, int iCol, char* str, int
 		return;
 
 	switch (iCol)
-	{	
+	{
 	case COL_TYPE:
 		lstrcpyn(str, __localizeFunc(cTypes[pItem->m_type],"sws_DLG_115",LOCALIZE_FLAG_NOCACHE), iStrMax);
 		break;
@@ -737,28 +737,28 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 		MediaTrack* temp = NULL;
 		const int numTracks = GetNumTracks();
 		activeRules->reserve(numTracks);
-		
+
 		for (int i = 0; i <= numTracks; i++)
 		{
-			MediaTrack* tr = i ? GetTrack(nullptr, i - 1) : GetMasterTrack(nullptr);			
-			
+			MediaTrack* tr = i ? GetTrack(nullptr, i - 1) : GetMasterTrack(nullptr);
+
 			struct RuleMatch {
 				SWS_RuleItem* rule;
 				int totalWords;
 				bool isSpecial;
 			};
-			WDL_PtrList<RuleMatch> matches;			
-			
+			WDL_PtrList<RuleMatch> matches;
+
 			for (int r = 0; r < g_pACItems.GetSize(); r++) {
 				SWS_RuleItem* currentRule = g_pACItems.Get(r);
 				if (currentRule->m_type != AC_TRACK) continue;
-				
+
 				bool bMatch = false;
 				bool isSpecial = false;
 				int totalWords = 0;
-				
-				if (i) 
-				{					
+
+				if (i)
+				{
 					if (strcmp(currentRule->m_str_filter.Get(), cFilterTypes[AC_FOLDER]) == 0) {
 						int iType;
 						GetFolderDepth(tr, &iType, &temp);
@@ -846,7 +846,7 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 						char* cName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
 						if (cName && cName[0]) {
 							int wordCount = CountWords(currentRule->m_str_filter.Get());
-							int matchCount = CountMatchingWords(cName, currentRule->m_str_filter.Get());							
+							int matchCount = CountMatchingWords(cName, currentRule->m_str_filter.Get());
 							if (matchCount > 0 && matchCount == wordCount) {
 								bMatch = true;
 								totalWords = wordCount;
@@ -858,7 +858,7 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 					bMatch = true;
 					isSpecial = true;
 				}
-				
+
 				if (bMatch) {
 					RuleMatch* rm = new RuleMatch();
 					rm->rule = currentRule;
@@ -866,33 +866,33 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 					rm->isSpecial = isSpecial;
 					matches.Add(rm);
 				}
-			}			
-			
+			}
+
 			SWS_RuleItem* bestRule = NULL;
 			int bestTotalWords = -1;
-			
+
 			for (int m = 0; m < matches.GetSize(); m++) {
 				RuleMatch* rm = matches.Get(m);
 				if (rm->totalWords > bestTotalWords) {
 					bestTotalWords = rm->totalWords;
 					bestRule = rm->rule;
 				}
-			}			
-			
+			}
+
 			if (bestRule) {
 				auto pACTrack = activeRules->find(tr);
 				if (pACTrack == activeRules->end()) {
 					pACTrack = activeRules->insert(tr).first;
 				}
-				
+
 				bool bColor = bDoColors && !pACTrack->m_bColored && bestRule->m_color != -AC_IGNORE-1;
 				bool bIcon = bDoIcons && !pACTrack->m_bIconed && bestRule->m_icon.Get()[0];
 				bool bLayout[2] = {
 					bDoLayout && !pACTrack->m_bLayouted[0] && bestRule->m_layout[0].Get()[0],
 					bDoLayout && !pACTrack->m_bLayouted[1] && bestRule->m_layout[1].Get()[0]
 				};
-				
-				if (bColor || bIcon || bLayout[0] || bLayout[1]) {					
+
+				if (bColor || bIcon || bLayout[0] || bLayout[1]) {
 					if (bColor) {
 						int iCurColor = *(int*)GetSetMediaTrackInfo(tr, "I_CUSTOMCOLOR", NULL);
 						if (!(iCurColor & 0x1000000)) iCurColor = 0;
@@ -928,7 +928,7 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 						pACTrack->m_col = SWS_ColorFromNative(newCol);
 						pACTrack->m_bColored = true;
 					}
-					
+
 					if (bIcon) {
 						if (_stricmp(bestRule->m_icon.Get(), pACTrack->m_icon.Get())) {
 							const char *cur = (const char*)GetSetMediaTrackInfo(tr, "P_ICON", NULL);
@@ -942,7 +942,7 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 						}
 						pACTrack->m_bIconed = true;
 					}
-					
+
 					for (int k=0; k<2; k++) if (bLayout[k]) {
 						pACTrack->m_bLayouted[k] = true;
 						if (!_stricmp(bestRule->m_layout[k].Get(), pACTrack->m_layout[k].Get()))
@@ -969,8 +969,8 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 						pACTrack->m_layout[k].Set(bestRule->m_layout[k].Get());
 					}
 				}
-			}			
-			
+			}
+
 			for (int m = 0; m < matches.GetSize(); m++) {
 				delete matches.Get(m);
 			}
@@ -1177,8 +1177,8 @@ void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
 			}
 
 			if (bestRule) {
-				SetProjectMarkerByIndex(NULL, x-1, isRgn, pos, end, num, NULL, 
-					bestRule->m_color==-AC_NONE-1 ? (isRgn?ct->marker:ct->region) : 
+				SetProjectMarkerByIndex(NULL, x-1, isRgn, pos, end, num, NULL,
+					bestRule->m_color==-AC_NONE-1 ? (isRgn?ct->marker:ct->region) :
 					SWS_ColorToNative(bestRule->m_color | 0x1000000));
 			}
 

--- a/Color/Autocolor.cpp
+++ b/Color/Autocolor.cpp
@@ -46,7 +46,7 @@
 #define ACR_ENABLE_KEY "AutoColorRegionEnable"
 #define AI_ENABLE_KEY  "AutoIconEnable"
 #define AL_ENABLE_KEY  "AutoLayoutEnable"
-#define AC_CASE_SENSITIVE_KEY "AutoColorCaseSensitive"
+#define AC_SMART_CASE_KEY "AutoColorSmartCase"
 #define AC_COUNT_KEY   "AutoColorCount"
 #define AC_ITEM_KEY    "AutoColor %d"
 
@@ -89,13 +89,14 @@ static bool g_bACREnabled = false;
 static bool g_bACMEnabled = false;
 static bool g_bAIEnabled = false;
 static bool g_bALEnabled = false;
-static bool g_bACCaseSensitive = false;
+static bool g_bACSmartCase = false;
 static WDL_String g_ACIni;
 static int s_ignore_update;
 
 // Prototypes for helper functions (ADD THIS)
 static int CountWords(const char* str);
-static int CountMatchingWords(const char* trackName, const char* ruleFilter);
+static int CountMatchingWords(const char* trackName, const char* ruleFilter, bool caseSensitive);
+static bool IsLowercaseRule(const char* ruleFilter);
 
 // Register to marker/region updates
 class AC_MarkerRegionListener : public SNM_MarkerRegionListener {
@@ -599,7 +600,7 @@ void SWS_AutoColorWnd::AddOptionsMenu(HMENU _menu)
 	AddToMenu(_menu, __LOCALIZE("Enable auto track icon", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOICON_ENABLE"), -1, false, g_bAIEnabled ?  MF_CHECKED : MF_UNCHECKED);
 	AddToMenu(_menu, __LOCALIZE("Enable auto track layout", "sws_ext_menu"), NamedCommandLookup("_S&MAUTOLAYOUT_ENABLE"), -1, false, g_bALEnabled ?  MF_CHECKED : MF_UNCHECKED);
 	AddToMenu(_menu, SWS_SEPARATOR, 0);
-	AddToMenu(_menu, __LOCALIZE("Case sensitive", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_CASE_SENSITIVE"), -1, false, g_bACCaseSensitive ? MF_CHECKED : MF_UNCHECKED);
+	AddToMenu(_menu, __LOCALIZE("Smart case sensitivity", "sws_ext_menu"), NamedCommandLookup("_SWSAUTOCOLOR_SMART_CASE"), -1, false, g_bACSmartCase ? MF_CHECKED : MF_UNCHECKED);
 }
 
 HMENU SWS_AutoColorWnd::OnContextMenu(int x, int y, bool* wantDefaultItems)
@@ -750,6 +751,8 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 				SWS_RuleItem* rule;
 				int totalWords;
 				bool isSpecial;
+				bool exactCase;
+				bool lowercaseFallback;
 			};
 			WDL_PtrList<RuleMatch> matches;
 
@@ -760,6 +763,8 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 				bool bMatch = false;
 				bool isSpecial = false;
 				int totalWords = 0;
+				bool exactCase = false;
+				bool lowercaseFallback = false;
 
 				if (i)
 				{
@@ -850,10 +855,12 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 						char* cName = (char*)GetSetMediaTrackInfo(tr, "P_NAME", NULL);
 						if (cName && cName[0]) {
 							int wordCount = CountWords(currentRule->m_str_filter.Get());
-							int matchCount = CountMatchingWords(cName, currentRule->m_str_filter.Get());
+							int matchCount = CountMatchingWords(cName, currentRule->m_str_filter.Get(), false);
 							if (matchCount > 0 && matchCount == wordCount) {
 								bMatch = true;
 								totalWords = wordCount;
+								exactCase = CountMatchingWords(cName, currentRule->m_str_filter.Get(), true) == wordCount;
+								lowercaseFallback = IsLowercaseRule(currentRule->m_str_filter.Get());
 							}
 						}
 					}
@@ -868,17 +875,26 @@ void ApplyColorRuleToTrack(FlatSet<SWS_RuleTrack> *activeRules, SWS_RuleItem* ru
 					rm->rule = currentRule;
 					rm->totalWords = isSpecial ? 999 : totalWords;
 					rm->isSpecial = isSpecial;
+					rm->exactCase = exactCase;
+					rm->lowercaseFallback = lowercaseFallback;
 					matches.Add(rm);
 				}
 			}
 
 			SWS_RuleItem* bestRule = NULL;
 			int bestTotalWords = -1;
+			bool bestExactCase = false;
+			bool bestLowercaseFallback = false;
 
 			for (int m = 0; m < matches.GetSize(); m++) {
 				RuleMatch* rm = matches.Get(m);
-				if (rm->totalWords > bestTotalWords) {
+				if (rm->totalWords > bestTotalWords ||
+					(g_bACSmartCase && rm->totalWords == bestTotalWords &&
+						(rm->exactCase > bestExactCase ||
+							(rm->exactCase == bestExactCase && rm->lowercaseFallback > bestLowercaseFallback)))) {
 					bestTotalWords = rm->totalWords;
+					bestExactCase = rm->exactCase;
+					bestLowercaseFallback = rm->lowercaseFallback;
 					bestRule = rm->rule;
 				}
 			}
@@ -1125,6 +1141,8 @@ void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
 				SWS_RuleItem* rule;
 				int totalWords;
 				bool isSpecial;
+				bool exactCase;
+				bool lowercaseFallback;
 			};
 			WDL_PtrList<RuleMatch> matches;
 
@@ -1140,6 +1158,8 @@ void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
 				bool bMatch = false;
 				bool isSpecial = false;
 				int totalWords = 0;
+				bool exactCase = false;
+				bool lowercaseFallback = false;
 
 				if (!strcmp(cFilterTypes[AC_RGNANY], currentRule->m_str_filter.Get())) {
 					bMatch = true;
@@ -1151,11 +1171,13 @@ void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
 				}
 				else if (name && name[0]) {
 					int wordCount = CountWords(currentRule->m_str_filter.Get());
-					int matchCount = CountMatchingWords(name, currentRule->m_str_filter.Get());
+					int matchCount = CountMatchingWords(name, currentRule->m_str_filter.Get(), false);
 					// Match only if ALL words are present (100%)
 					if (matchCount > 0 && matchCount == wordCount) {
 						bMatch = true;
 						totalWords = wordCount;
+						exactCase = CountMatchingWords(name, currentRule->m_str_filter.Get(), true) == wordCount;
+						lowercaseFallback = IsLowercaseRule(currentRule->m_str_filter.Get());
 					}
 				}
 
@@ -1164,6 +1186,8 @@ void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
 					rm->rule = currentRule;
 					rm->totalWords = isSpecial ? 999 : totalWords;
 					rm->isSpecial = isSpecial;
+					rm->exactCase = exactCase;
+					rm->lowercaseFallback = lowercaseFallback;
 					matches.Add(rm);
 				}
 			}
@@ -1171,11 +1195,18 @@ void ApplyColorRuleToMarkerRegion(SWS_RuleItem* _rule, int _flags)
 			// Select rule with most words (most specific)
 			SWS_RuleItem* bestRule = NULL;
 			int bestTotalWords = -1;
+			bool bestExactCase = false;
+			bool bestLowercaseFallback = false;
 
 			for (int m = 0; m < matches.GetSize(); m++) {
 				RuleMatch* rm = matches.Get(m);
-				if (rm->totalWords > bestTotalWords) {
+				if (rm->totalWords > bestTotalWords ||
+					(g_bACSmartCase && rm->totalWords == bestTotalWords &&
+						(rm->exactCase > bestExactCase ||
+							(rm->exactCase == bestExactCase && rm->lowercaseFallback > bestLowercaseFallback)))) {
 					bestTotalWords = rm->totalWords;
+					bestExactCase = rm->exactCase;
+					bestLowercaseFallback = rm->lowercaseFallback;
 					bestRule = rm->rule;
 				}
 			}
@@ -1251,9 +1282,9 @@ void EnableAutoLayout(COMMAND_T*)
 	g_pACWnd->Update();
 }
 
-void ToggleAutoColorCaseSensitive(COMMAND_T*)
+void ToggleAutoColorSmartCase(COMMAND_T*)
 {
-	g_bACCaseSensitive = !g_bACCaseSensitive;
+	g_bACSmartCase = !g_bACSmartCase;
 	g_pACWnd->Update();
 }
 
@@ -1266,7 +1297,7 @@ void ApplyAutoColor(COMMAND_T*)
 int IsAutoColorOpen(COMMAND_T*)		{ return g_pACWnd->IsWndVisible(); }
 int IsAutoIconEnabled(COMMAND_T*)	{ return g_bAIEnabled; }
 int IsAutoLayoutEnabled(COMMAND_T*)	{ return g_bALEnabled; }
-int IsAutoColorCaseSensitive(COMMAND_T*) { return g_bACCaseSensitive; }
+int IsAutoColorSmartCase(COMMAND_T*) { return g_bACSmartCase; }
 
 int IsAutoColorEnabled(COMMAND_T* ct)
 {
@@ -1363,7 +1394,7 @@ static COMMAND_T g_commandTable[] =
 	{ { DEFACCEL, "SWS/S&M: Toggle auto region coloring enable" },	"S&MAUTOCOLOR_RGN_ENABLE",	EnableAutoColor,	"Enable auto region coloring",	2, IsAutoColorEnabled },
 	{ { DEFACCEL, "SWS/S&M: Toggle auto track icon enable" },		"S&MAUTOICON_ENABLE",		EnableAutoIcon,		"Enable auto icon",				0, IsAutoIconEnabled },
 	{ { DEFACCEL, "SWS/S&M: Toggle auto track layout enable" },		"S&MAUTOLAYOUT_ENABLE",		EnableAutoLayout,		"Enable auto layout",				0, IsAutoLayoutEnabled },
-	{ { DEFACCEL, "SWS: Toggle case-sensitive auto color matching" }, "SWSAUTOCOLOR_CASE_SENSITIVE", ToggleAutoColorCaseSensitive, "Case sensitive", 0, IsAutoColorCaseSensitive },
+	{ { DEFACCEL, "SWS: Toggle smart case sensitivity for auto color matching" }, "SWSAUTOCOLOR_SMART_CASE", ToggleAutoColorSmartCase, "Smart case sensitivity", 0, IsAutoColorSmartCase },
 	{ { DEFACCEL, "SWS: Apply auto coloring" },						"SWSAUTOCOLOR_APPLY",		ApplyAutoColor,	},
 	{ {}, LAST_COMMAND, }, // Denote end of table
 };
@@ -1389,7 +1420,7 @@ static int CountWords(const char* str)
     return count;
 }
 
-static int CountMatchingWords(const char* trackName, const char* ruleFilter)
+static int CountMatchingWords(const char* trackName, const char* ruleFilter, bool caseSensitive)
 {
     if (!trackName || !trackName[0] || !ruleFilter || !ruleFilter[0]) return 0;
 
@@ -1400,7 +1431,7 @@ static int CountMatchingWords(const char* trackName, const char* ruleFilter)
     trackLower[255] = '\0';
     ruleLower[255] = '\0';
 
-    if (!g_bACCaseSensitive) {
+    if (!caseSensitive) {
         for (char* p = trackLower; *p; ++p) *p = tolower(static_cast<unsigned char>(*p));
         for (char* p = ruleLower; *p; ++p) *p = tolower(static_cast<unsigned char>(*p));
     }
@@ -1430,6 +1461,18 @@ static int CountMatchingWords(const char* trackName, const char* ruleFilter)
     }
 
     return matches;
+}
+
+static bool IsLowercaseRule(const char* ruleFilter)
+{
+    bool hasLetter = false;
+    for (const unsigned char* p = reinterpret_cast<const unsigned char*>(ruleFilter); *p; ++p) {
+        if (isalpha(*p)) {
+            hasLetter = true;
+            if (!islower(*p)) return false;
+        }
+    }
+    return hasLetter;
 }
 
 // ============================================================================
@@ -1464,7 +1507,7 @@ int AutoColorInit()
 	g_bACREnabled = GetPrivateProfileInt(SWS_INI, ACR_ENABLE_KEY, 0, ini.Get()) ? true : false;
 	g_bAIEnabled = GetPrivateProfileInt(SWS_INI, AI_ENABLE_KEY, 0, ini.Get()) ? true : false;
 	g_bALEnabled = GetPrivateProfileInt(SWS_INI, AL_ENABLE_KEY, 0, ini.Get()) ? true : false;
-	g_bACCaseSensitive = GetPrivateProfileInt(SWS_INI, AC_CASE_SENSITIVE_KEY, 0, ini.Get()) ? true : false;
+	g_bACSmartCase = GetPrivateProfileInt(SWS_INI, AC_SMART_CASE_KEY, 0, ini.Get()) ? true : false;
 
 	char key[32];
 	for (int i = 0; i < iCount; i++)
@@ -1509,8 +1552,8 @@ void AutoColorSaveState()
 	WritePrivateProfileString(SWS_INI, AI_ENABLE_KEY, str, g_ACIni.Get());
 	sprintf(str, "%d", g_bALEnabled ? 1 : 0);
 	WritePrivateProfileString(SWS_INI, AL_ENABLE_KEY, str, g_ACIni.Get());
-	sprintf(str, "%d", g_bACCaseSensitive ? 1 : 0);
-	WritePrivateProfileString(SWS_INI, AC_CASE_SENSITIVE_KEY, str, g_ACIni.Get());
+	sprintf(str, "%d", g_bACSmartCase ? 1 : 0);
+	WritePrivateProfileString(SWS_INI, AC_SMART_CASE_KEY, str, g_ACIni.Get());
 	sprintf(str, "%d", g_pACItems.GetSize());
 	WritePrivateProfileString(SWS_INI, AC_COUNT_KEY, str, g_ACIni.Get());
 

--- a/SnM/SnM_FX.cpp
+++ b/SnM/SnM_FX.cpp
@@ -197,14 +197,8 @@ int IsFXOfflineSelTracks(COMMAND_T * _ct)
 	{
 		MediaTrack* tr = SNM_GetSelectedTrack(NULL, 0, true);
 		int fxId = GetTrackFXIdFromCmd(tr, (int)_ct->user);
-		if (tr && fxId >= 0)
-		{
-			char state[2] = "0";
-			SNM_ChunkParserPatcher p(tr);
-			p.SetWantsMinimalState(true);
-			if (p.Parse(SNM_GET_CHUNK_CHAR, 2, "FXCHAIN", "BYPASS", fxId, 2, state) > 0)
-				return !strcmp(state,"1");
-		}
+		if (tr && fxId >= 0 && fxId < TrackFX_GetCount(tr))
+			return TrackFX_GetOffline(tr, fxId);
 	}
 	// several selected tracks: possible mix of different states 
 	// => return a fake toggle state (best effort)
@@ -213,7 +207,7 @@ int IsFXOfflineSelTracks(COMMAND_T * _ct)
 	return false;
 }
 
-// core func (no dedicated API yet => state chunk update)
+// core func
 bool PatchSelTracksFXOnline(const char * _undoMsg, int _mode, int _fxCmdId, const char* _val = NULL, const char* _valExcept = NULL)
 {
 	bool updated = false;
@@ -225,16 +219,42 @@ bool PatchSelTracksFXOnline(const char * _undoMsg, int _mode, int _fxCmdId, cons
 			int fxId = GetTrackFXIdFromCmd(tr, _fxCmdId);
 			if (fxId >= 0)
 			{
-				SNM_ChunkParserPatcher p(tr);
-				bool updt = (p.ParsePatch(_mode, 2, "FXCHAIN", "BYPASS", fxId, 2, (void*)_val, (void*)_valExcept) > 0);
-				updated |= updt;
+				const int fxcnt = TrackFX_GetCount(tr);
+				for (int j=0; j<fxcnt; j++)
+				{
+					bool offline = false;
+					switch(_mode)
+					{
+						case SNM_TOGGLE_CHUNK_INT:
+							if (j != fxId) continue;
+							offline = !TrackFX_GetOffline(tr, j);
+							break;
+						case SNM_TOGGLE_CHUNK_INT_EXCEPT:
+							if (j == fxId) continue;
+							offline = !TrackFX_GetOffline(tr, j);
+							break;
+						case SNM_SET_CHUNK_CHAR:
+							if (j != fxId) continue;
+							offline = !strcmp(_val, "1");
+							break;
+						case SNM_SETALL_CHUNK_CHAR_EXCEPT:
+							offline = !strcmp(j == fxId ? _valExcept : _val, "1");
+							break;
+						default:
+							continue;
+					}
 
-				// close the GUI for buggy plugins (before chunk update)
-				// http://github.com/reaper-oss/sws/issues/317
-				if (updt && g_SNM_SupportBuggyPlug)
-					TrackFX_SetOpen(tr, fxId, false);
-
-			} // => auto commit
+					if (offline != TrackFX_GetOffline(tr, j))
+					{
+						// close the GUI for buggy plugins (before changing the state)
+						// http://github.com/reaper-oss/sws/issues/317
+						if (g_SNM_SupportBuggyPlug)
+							TrackFX_SetOpen(tr, j, false);
+						TrackFX_SetOffline(tr, j, offline);
+						updated = true;
+					}
+				}
+			}
 		}
 	}
 	if (updated)

--- a/sws_extension.cpp
+++ b/sws_extension.cpp
@@ -506,6 +506,7 @@ public:
 		SNM_CSurfRun();
 		ZoomSlice();
 		MiscSlice();
+		BR_CSurf_Run();
 
 		if (m_bChanged)
 		{


### PR DESCRIPTION
## Summary

- use REAPER's native offline-state API for SWS/S&M track FX actions
- preserve the existing toggle, set, and "except N" behavior for all plugin types
- report toggle state through the same native API

## Root cause

These actions determined and updated plugin offline states by parsing and rewriting the serialized FX-chain state. That unnecessarily coupled the actions to the chunk representation instead of using REAPER's dedicated API.

Using `TrackFX_GetOffline` and `TrackFX_SetOffline` makes the actions operate directly on every track FX plugin without depending on its serialized representation.

Fixes #1933

## Validation

- AppVeyor Windows x64 build passed
- manually tested in REAPER and confirmed working
- `git diff --check`
- reviewed all supported action modes against their existing behavior
